### PR TITLE
update to pywb 0.10.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cffi
 gevent
 ndg-httpsclient
-pywb>=0.10.6
+pywb==0.10.8
 uwsgi>=2.0


### PR DESCRIPTION
Moving from 0.10.6 -> 0.10.8 (Minor bug fix over 0.10.7 that broke some sites)

Google groups should work with this.