### PR TITLE
Temporarily bump pywb to a development branch with Safari and Edge fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 cffi
 gevent
 ndg-httpsclient
-pywb==0.10.9.1
 uwsgi>=2.0
 werkzeug>=0.10.4,<0.11.0
 static>=1.1.1,<1.2.0
+
+# this points to a development branch
+# of pywb with fixes for Safari and Microsoft Edge.
+# This should be replaced with 'pywb==0.11' when that
+# is released
+-e git://github.com/ikreymer/pywb.git@04104f04d3c13c05c696bf7a925a71abf759add0#egg=pywb


### PR DESCRIPTION
Until pywb 0.11 is released, bump the pywb dependency
to the 'clide-side-tests' development branch of pywb
which includes fixes to Wombat JS for Safari and Edge
and integration tests for Wombat.

See https://github.com/ikreymer/pywb/tree/client-side-tests

Fixes #25
Fixes #36
Fixes #39
Fixes #44
Fixes #48
Fixes #55
Fixes #59
Fixes #60