### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:2.7
 MAINTAINER Hypothes.is Project and Ilya Kreymer
 
-WORKDIR /src/
-ADD requirements.txt /src/
+# Create the via user, group, home directory and package directory.
+RUN groupadd via \
+  && useradd -d /var/lib/via -m -s /bin/bash -g via via
+WORKDIR /var/lib/via
+
+ADD requirements.txt .
 RUN pip install -r requirements.txt
-COPY . /src/
+COPY . .
 
 EXPOSE 9080
 
+USER via
 CMD ./run-uwsgi.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: docker
+docker:
+	docker build -t hypothesis/via:latest .
+
+.PHONY: clean
+clean:
+	find . -type f -name "*.py[co]" -delete
+	find . -type d -name "__pycache__" -delete


### PR DESCRIPTION
It is now creating a `via` user, in order to not run uwsgi as root, and the home directory (/var/lib/via) is copied from how we do it in h.

There is now also a Makefile with a `docker` task for building the image.

On another note: I wanted to port it to use Alpine Linux (for a smaller image) but it turns out that uwsgi cannot be compiled on musl, the next version (2.0.13) should be able to work with musl.