### PR TITLE
Disable logging levels INFO and lower

### DIFF
--- a/via/app.py
+++ b/via/app.py
@@ -1,5 +1,6 @@
 from pkg_resources import resource_filename
 
+import logging
 import pywb.apps.wayback
 import static
 from werkzeug.exceptions import NotFound
@@ -7,6 +8,8 @@ from werkzeug.utils import redirect
 from werkzeug.wrappers import Request
 from werkzeug import wsgi
 
+
+logging.disable(logging.INFO)
 
 # Previously, PDFs were served at paths like
 #


### PR DESCRIPTION
It is not possible to configure the log level of pywb, so we have to set
the log level (WARNING and higher) by using the `logging.disable`
function.

We don't need access logging from via itself, as with the new infrastructure we get the access logs from nginx.