### PR TITLE
Configure Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+node {
+    stage 'Build'
+    checkout scm
+
+    // Store the short commit id for use tagging images
+    sh 'git rev-parse --short HEAD > GIT_SHA'
+    gitSha = readFile('GIT_SHA').trim()
+
+    sh "make docker DOCKER_TAG=${gitSha}"
+    img = docker.image "hypothesis/via:${gitSha}"
+
+    // We only push the image to the Docker Hub if we're on master
+    if (env.BRANCH_NAME != 'master') {
+        return
+    }
+    stage 'Push'
+    docker.withRegistry('', 'docker-hub-build') {
+        img.push('auto')
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+DOCKER_TAG = latest
+
 .PHONY: docker
 docker:
-	docker build -t hypothesis/via:latest .
+	docker build -t hypothesis/via:$(DOCKER_TAG) .
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This will configure Jenkins the same way we're using it for h and bouncer. Each deploy will build the docker image and push it under the `auto` tag.