### PR TITLE
Block content from a prefix blacklist

### DIFF
--- a/blocked/prefixes
+++ b/blocked/prefixes
@@ -1,0 +1,2 @@
+/http://nautil.us
+/http://m.nautil.us

--- a/blocked/template.html
+++ b/blocked/template.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Content not available</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet" type="text/css">
+    <style>
+      /**
+       * Eric Meyer's Reset CSS v2.0 (http://meyerweb.com/eric/tools/css/reset/)
+       * http://cssreset.com
+       */
+      html, body, div, span, applet, object, iframe,
+      h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+      a, abbr, acronym, address, big, cite, code,
+      del, dfn, em, img, ins, kbd, q, s, samp,
+      small, strike, strong, sub, sup, tt, var,
+      b, u, i, center,
+      dl, dt, dd, ol, ul, li,
+      fieldset, form, label, legend,
+      table, caption, tbody, tfoot, thead, tr, th, td,
+      article, aside, canvas, details, embed,
+      figure, figcaption, footer, header, hgroup,
+      menu, nav, output, ruby, section, summary,
+      time, mark, audio, video {
+          margin: 0;
+          padding: 0;
+          border: 0;
+          font-size: 100%;
+          font: inherit;
+          vertical-align: baseline;
+      }
+      /* HTML5 display-role reset for older browsers */
+      article, aside, details, figcaption, figure,
+      footer, header, hgroup, menu, nav, section {
+          display: block;
+      }
+      body {
+          line-height: 1;
+      }
+      ol, ul {
+          list-style: none;
+      }
+      blockquote, q {
+          quotes: none;
+      }
+      blockquote:before, blockquote:after,
+      q:before, q:after {
+          content: '';
+          content: none;
+      }
+      table {
+          border-collapse: collapse;
+          border-spacing: 0;
+      }
+
+      /* page style */
+      body {
+          background-color: #ececec;
+          margin: 0 auto;
+          color: #333333;
+          max-width: 960px;
+          font-family: 'Source Sans Pro', sans-serif;
+          -webkit-font-smoothing: antialiased;
+          text-align: center;
+      }
+
+      header {
+          padding: 100px 0 0 0;
+      }
+
+      header, article {
+          text-align: left;
+          margin: 0 auto;
+          max-width: 600px;
+      }
+
+      p, ol {
+          font-size: 20px;
+          line-height: 27px;
+          padding-bottom: 30px;
+          max-width: 600px;
+          margin: 0 auto;
+      }
+
+      strong {
+          font-weight: 700;
+      }
+
+      h1 {
+          font-weight: 700;
+          font-size: 20px;
+          line-height: 27px;
+      }
+
+      p a, li a {
+          border-bottom: 1px solid #DCDCDC;
+          text-decoration: none;
+          color: #333333;
+      }
+
+      ol {
+          list-style-type: decimal;
+          padding-left: 17px;
+      }
+
+      ol li {
+          font-size: 20px;
+          line-height: 27px;
+          padding-bottom: 30px;
+      }
+
+      a:hover {
+          color: #333333;
+      }
+
+      footer {
+          padding: 90px 0;
+      }
+
+      @media (max-width: 800px) {
+          body {padding: 2em 1em;}
+          header {padding: 50px 0; font-size: 36px; line-height: 42px;}
+          h1 {font-size: 48px; line-height: 48px;}
+          p, ol li {font-size: 18px; line-height: 24px;}
+      }
+    </style>
+    <script async src="https://www.google-analytics.com/analytics.js"></script>
+    <script>
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+        ga('create', 'UA-26026798-1', 'auto');
+        ga('send', 'pageview');
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>Content not available</h1>
+    </header>
+    <article>
+      <p>
+        Unfortunately, the publisher of this page has requested that we disallow
+        access to it through this Hypothesis service. That means we can't show
+        you the page you were looking for right away…
+      </p>
+      <p>
+        <strong>To view the annotations on this page:</strong>
+      </p>
+      <ol>
+        <li>
+          Follow the <a href="https://hypothes.is/" target="_blank">instructions
+          on our homepage</a> to install our browser extension.
+        </li>
+        <li>
+          Visit the page directly<span id="page-url"></span> and click on the
+          extension icon to see the annotations.
+        </li>
+      </ol>
+    </article>
+    <footer>
+      <a href="https://hypothes.is/">
+        <img
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAA4CAQAAAARWLNhAAABgUlEQVR42u2Yz0rDQBDGhwpKe6wUSXspepE+gGfv+gCtPaTv4EMIHrx7K0iepILXmQ2btAQECYmXnoSWStUYxNLdNmoKsyCab2677P6WbybZPwAwapCDESbMEZEzasDH9GP2yT+DxikiXX1iLsgBA+ZoRoHR6dMoAJsDQBHOC0ABKAB/APCCUzwX+3I7Kfm78kic4Q3NWAFkw4rcA7xlA9AAMhSWacAEcI8hU34zv1HfAr4WXhsGuCdMADwlF6c0o3txEewogD0WgDikZ+UIcrnsSbbojaNMr7QzzoNWYU8cZXqnAV6TEjfgUe8Ly8wAnJgGzP8PgELqeJZnUYdCAwAKZXXRLqs6ggfQ1mqvzQ7wLHWUZ7EDhnV11LDODhBd7Q/W5a+iKKgt2oOafin7adPP+x3EZPvNdKezMS6uUL8PYPoibvwpwfhjiPHnnDyifub6+sCluIJyDSDjCvBJtlYOABPZAl6JngoQPeDXMhOM7mdmgtf9tUzwu69nYlP33wEjM9swn4BymAAAAABJRU5ErkJggg=="
+          width="24px"
+          height="28px"
+        >
+      </a>
+    </footer>
+    <script>
+        (function () {
+            function _t(text) {
+                return document.createTextNode(text);
+            }
+
+            // If we're running in the right place add a link to the original
+            // page to the #page-url element.
+            if (window.location.hostname !== 'via.hypothes.is') {
+                return;
+            }
+
+            var expand = document.getElementById('page-url');
+            if (!expand) {
+                return;
+            }
+
+            var url = window.location.pathname.slice(1) + window.location.search;
+            var text = url;
+
+            if (text.length > 50) {
+                text = text.slice(0, 50) + '…';
+            }
+
+            var anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.appendChild(_t(text));
+
+            expand.appendChild(_t(' at '));
+            expand.appendChild(anchor);
+        }());
+    </script>
+  </body>
+</html>

--- a/tests/blocker_test.py
+++ b/tests/blocker_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse as Response
+from werkzeug import wsgi
+
+from via.blocker import Blocker
+
+block_examples = pytest.mark.parametrize('path,blocked', [
+    ('/', False),
+    ('/giraf', False),
+    ('/giraffe', True),
+    ('/giraffe/', True),
+    ('/giraffe/neck', True),
+    ('/birds', False),
+    ('/birds/goose', False),
+    ('/birds/duck', True),
+    ('/birds/duck/bill', True),
+])
+
+
+class TestBlocker(object):
+    @block_examples
+    def test_serves_template(self, client, path, blocked):
+        resp = client.get(path)
+        if blocked:
+            assert resp.data == 'your eyes are protected'
+        else:
+            assert resp.data == 'scary upstream content'
+
+    @block_examples
+    def test_sets_status(self, client, path, blocked):
+        resp = client.get(path)
+        if blocked:
+            assert resp.status_code == 451
+        else:
+            assert resp.status_code == 200
+
+    @block_examples
+    def test_sets_mimetype(self, client, path, blocked):
+        resp = client.get(path)
+        if blocked:
+            assert resp.headers['content-type'].startswith('text/html')
+        else:
+            assert resp.headers['content-type'].startswith('text/plain')
+
+    @pytest.fixture
+    def app(self):
+        return Blocker(upstream_app,
+                       prefixes=['/giraffe', '/birds/duck'],
+                       template='your eyes are protected')
+
+    @pytest.fixture
+    def client(self, app):
+        return Client(app, Response)
+
+
+@wsgi.responder
+def upstream_app(environ, start_response):
+    return Response('scary upstream content', mimetype='text/plain')

--- a/via/app.py
+++ b/via/app.py
@@ -9,6 +9,7 @@ from werkzeug.utils import redirect
 from werkzeug.wrappers import Request
 from werkzeug import wsgi
 
+from via.blocker import Blocker
 from via.security import RequestHeaderSanitiser, ResponseHeaderSanitiser
 
 logging.disable(logging.INFO)
@@ -62,7 +63,10 @@ def app(environ, start_response):
     return pywb.apps.wayback.application(environ, start_response)
 
 
-application = wsgi.DispatcherMiddleware(app, {
+application = RequestHeaderSanitiser(app)
+application = ResponseHeaderSanitiser(application)
+application = Blocker(application)
+application = wsgi.DispatcherMiddleware(application, {
     '/favicon.ico': static.Cling('static/favicon.ico'),
     '/robots.txt': static.Cling('static/robots.txt'),
     '/static': static.Cling('static/'),
@@ -70,5 +74,3 @@ application = wsgi.DispatcherMiddleware(app, {
     '/static/__shared/viewer/web/viewer.html': redirect_old_viewer,
     '/h': redirect_strip_matched_path,
 })
-application = RequestHeaderSanitiser(application)
-application = ResponseHeaderSanitiser(application)

--- a/via/blocker.py
+++ b/via/blocker.py
@@ -1,0 +1,38 @@
+from __future__ import unicode_literals
+
+from werkzeug import wsgi
+from werkzeug.wrappers import BaseResponse as Response
+
+
+class Blocker(object):
+
+    """
+    Blocker is a WSGI middleware that returns a static response when a
+    request path matches a list of predefined prefixes.
+    """
+
+    def __init__(self, application, prefixes=None, template=None):
+        self.application = application
+        if prefixes is None:
+            prefixes = _read_prefixes()
+        self._prefixes = tuple(prefixes)
+        if template is None:
+            template = _read_template()
+        self._template = template
+
+    def __call__(self, environ, start_response):
+        if wsgi.get_path_info(environ).startswith(self._prefixes):
+            resp = Response(self._template, status=451, mimetype='text/html')
+            return resp(environ, start_response)
+        return self.application(environ, start_response)
+
+
+def _read_prefixes():
+    with open('blocked/prefixes') as fp:
+        lines = [l.strip() for l in fp.readlines()]
+    return [l for l in lines if l]
+
+
+def _read_template():
+    with open('blocked/template.html') as fp:
+        return fp.read()


### PR DESCRIPTION
We need to be able to omit content from the via proxy if content owners request it. This is currently implemented using some rather dubious nginx rules, and needs to move into this application for the move to Skyliner.

This commit implements a WSGI middleware responsible for serving a static page for blocked content, and adds the blocked content list to the repository in a flat file.

I've also rearranged the middleware stack so that:

- we cannot accidentally block our own static content
- we do not bother doing header sanitisation on our own block page or on static content