### PR TITLE
Add documentation on how to use Via with a local client and service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ deps:
 .PHONY: test
 test:
 	python -m pytest tests
+
+.PHONY: serve
+serve:
+	uwsgi uwsgi.ini

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Some examples:
 [https://via.hypothes.is/http://www.autodidacts.io/openbci-brain-basics-neurons-structure-and-biology/](https://via.hypothes.is/http://www.autodidacts.io/openbci-brain-basics-neurons-structure-and-biology/)
 
 
-### Running Locally with Docker
+### Running Via locally
+
+#### With Docker
 
 Via now includes a Dockerfile to be more easily deployed in Docker.
 
@@ -30,10 +32,32 @@ To run the container afterwards:
 docker run --name via -d -p 9080:9080 hypothesis/via
 ```
 
-This will start a container on the Docker host, mapped to port 9080. 
+This will start a container on the Docker host, mapped to port 9080.
 
 To stop:
 
 ```
 docker stop via
+```
+
+### Without Docker
+
+You can also run Via locally without using Docker:
+
+```py
+make deps
+make serve
+```
+
+When Via is running, you can access it locally at [localhost:9080](http://localhost:9080).
+
+### Using a local Hypothesis service and client
+
+Via serves the client from the URL specified via the `H_EMBED_URL` environment variable. To make Via use a local version of the client, or one served from a domain other than hypothes.is, set this variable before running the service.
+
+In addition, you will also need to make sure that the host the client is being served from is listed under the `no_rewrite_prefixes` key in [config.yaml](config.yaml).
+
+```sh
+export H_EMBED_URL=http://localhost:5000/embed.js
+make serve
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ collections:
             rewrite_rel_canon: false
             client:
                 no_rewrite_prefixes:
+                    - 'http://localhost:5000/' # Hypothesis dev server
                     - 'https://hypothes.is/'
                     - 'https://stage.hypothes.is/'
                     - '/assets/'


### PR DESCRIPTION
 * Add documentation on how to run Via without Docker and using
   the client served by a local dev install.

 * Add `make serve` target and `http://localhost:5000` to
   no_rewrite_prefixes key in config to make it easier to run Via
   with a dev server.