### PR TITLE
Run squid in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --update \
     libffi \
     openssl \
     supervisor \
+    squid \
   && rm -rf /var/cache/apk/*
 
 # Create the via user, group, home directory and package directory.
@@ -30,6 +31,11 @@ RUN apk add --update --virtual build-deps \
 COPY conf/collectd.conf /etc/collectd/collectd.conf
 RUN mkdir /etc/collectd/collectd.conf.d \
  && chown via:via /etc/collectd/collectd.conf.d
+
+# Copy squid config
+COPY conf/squid.conf /etc/squid/squid.conf
+RUN mkdir /var/spool/squid \
+ && chown via:via /var/run/squid /var/spool/squid /var/log/squid
 
 # Install app.
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ COPY conf/squid.conf /etc/squid/squid.conf
 RUN mkdir /var/spool/squid \
  && chown via:via /var/run/squid /var/spool/squid /var/log/squid
 
+# Use local squid by default
+ENV HTTP_PROXY http://localhost:3128
+ENV HTTPS_PROXY http://localhost:3128
+
 # Install app.
 COPY . .
 

--- a/conf/squid.conf
+++ b/conf/squid.conf
@@ -1,0 +1,59 @@
+# A pretty default squid with to_localnet defined and blocked.
+
+access_log none
+
+acl localnet src 10.0.0.0/8		# RFC1918 possible internal network
+acl localnet src 172.16.0.0/12		# RFC1918 possible internal network
+acl localnet src 192.168.0.0/16		# RFC1918 possible internal network
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local addresses (including AWS instance metadata URL)
+
+acl to_localnet dst 10.0.0.0/8		# RFC1918 possible internal network
+acl to_localnet dst 172.16.0.0/12	# RFC1918 possible internal network
+acl to_localnet dst 192.168.0.0/16	# RFC1918 possible internal network
+acl to_localnet dst fc00::/7       	# RFC 4193 local private network range
+acl to_localnet dst fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+acl to_localnet dst 169.254.0.0/16	# RFC 3927 link-local addresses (including AWS instance metadata URL)
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+
+http_access allow localhost manager
+http_access deny manager
+
+http_access deny to_localhost
+http_access deny to_localnet
+
+http_access allow localnet
+http_access allow localhost
+
+http_access deny all
+
+http_port 3128
+
+cache deny all
+
+pid_filename /var/run/squid/squid3.pid
+
+maximum_object_size 4 MB
+coredump_dir /var/spool/squid
+
+delay_pools 1
+delay_class 1 2
+delay_access 1 allow localnet
+delay_access 1 deny all
+delay_parameters 1 -1/-1 -1/-1

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -11,6 +11,13 @@ stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
 
+[program:squid]
+command=squid -NYC
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
 [program:collectd]
 command=bin/start-collectd
 startsecs=0


### PR DESCRIPTION
This will allow us to not have an external squid instance running. It
still can be configured with the environment variables, both the
`HTTP_PROXY` and `HTTPS_PROXY` variables should be set to
`http://localhost:3128`.

The easiest way to test:

```
$ make docker
$ docker run -it --rm -p 9080:9080 -e HTTPS_PROXY=http://localhost:3128 -e HTTP_PROXY=http://localhost:3128 hypothesis/via:latest
```
And then in the browser go to http://localhost:9080/http://169.254.169.254/latest/meta-data/
This is the AWS metadata endpoint which we specifically block in the squid config, so you should see an "Access Denied" squid error page.