### PR TITLE
Auto-kill workers if request takes longer than 60 seconds.

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -29,3 +29,15 @@ cheaper-rss-limit-hard = 805306368
 
 env = PYWB_CONFIG_FILE=./config.yaml
 wsgi = via.app
+
+# Automatically kill workers if request takes a long time to complete, eg. due
+# to proxying a resource from an external host which is unresponsive.
+harakiri = 60
+
+# Enable getting stack traces from workers that are stuck or which have been
+# killed by the "harakiri" feature.
+#
+# Tracebacks from auto-killed workers will appear in log output. Tracebacks
+# from still-running workers can be obtained via
+# `uwsgi --conect-and-read <socket path>`.
+py-tracebacker = /tmp/via-traceback-

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -39,5 +39,5 @@ harakiri = 60
 #
 # Tracebacks from auto-killed workers will appear in log output. Tracebacks
 # from still-running workers can be obtained via
-# `uwsgi --conect-and-read <socket path>`.
+# `uwsgi --connect-and-read <socket path>`.
 py-tracebacker = /tmp/via-traceback-


### PR DESCRIPTION
Automatically kill workers using uWSGI's "harakiri" feature [1] if they
take longer than 60 seconds to respond to a request. This fixes an issue
where workers could get stuck if making an HTTP request to an external
host which is unresponsive, eventually making the whole service
unresponsive once all 32 workers get stuck.

This will have the effect of preventing very large or very slow-loading
resources from being proxied through Via.

Also enable the Python Tracebacker [2] facility so that a stack trace
for auto-killed workers is written to uWSGI's log output. In production
this can be obtained from the Docker logs. This log output includes the
URL of the request which is useful for trying to reproduce the issue.

[1] http://uwsgi-docs.readthedocs.io/en/latest/Glossary.html?highlight=harakiri
[2] http://uwsgi-docs.readthedocs.io/en/latest/Tracebacker.html