### PR TITLE
Revert "only inject client into top-level window"

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -4,11 +4,6 @@
 <!-- Inject Hypothesis -->
 <script>
 (function () {
-// Only run injection for top-level window!
-if (window != window.top) {
-    return;
-}
-
 var embed_script = document.createElement("script");
 embed_script.src = "{{ h_embed_url }}";
 document.head.appendChild(embed_script);


### PR DESCRIPTION
This reverts commit ee9451edfa871fcf27bb58edf53cace088ca75f3.

What ee9451ed does is cause Via to not inject the client into an HTML
page if Via is not the top-level frame. This means that using Via in an
iframe is completely broken. The LTI app
(http://github.com/hypothesis/lti) - both the current one and any future
LTI app - is entirely dependent on using Via in an iframe.

That commit was a fix for this bug
https://github.com/hypothesis/h/issues/2190 that no annotations were
showing in the sidebar when this page
http://blogs.plos.org/scicomm/2015/04/13/hello-world/ was viewed in Via.

Testing locally, after reverting the commit annotations do still show on
that page in Via. So it seems the commit is no longer necessary to work
around the bug.

@judell also reported in mid-2016 that the problem page worked fine
without that commit https://github.com/hypothesis/via/issues/76