### PR TITLE
Fix Via in development environments

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ collections:
             client:
                 no_rewrite_prefixes:
                     - 'http://localhost:5000/' # Hypothesis dev server
+                    - 'http://localhost:3001/' # Hypothesis client dev server
                     - 'https://hypothes.is/'
                     - 'https://qa.hypothes.is/'
                     - 'https://cdn.hypothes.is/'


### PR DESCRIPTION
Via is currently broken in development environments _if_ you configure
your dev Via to use your dev h and client. Because the URL the client is
served from (localhost:3001) is missing from Via's no_rewrite_prefixes
Via does rewrite the client's JavaScript code and Wombat.js ends up
changing the JavaScript in a way that causes a same-origin error that
causes booting up the client to fail. (Result from user's point of view:
no sidebar appears.)