### PR TITLE
Stop injecting client into child iframes of the proxied page

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -4,6 +4,15 @@
 <!-- Inject Hypothesis -->
 <script>
 (function () {
+
+// Disable injection in iframes in the top-level page that was proxied through
+// Via. These proxied iframes have URLs of the form `${VIA_URL}/if_/${ORIGINAL_URL}`.
+//
+// See https://github.com/hypothesis/client/issues/568.
+if (window.location.pathname.indexOf('/if_/') === 0) {
+  return;
+}
+
 var embed_script = document.createElement("script");
 embed_script.src = "{{ h_embed_url }}";
 document.head.appendChild(embed_script);


### PR DESCRIPTION
Via used to only inject the client into the top-level window
in a tab because the client didn't handle being loaded into multiple
frames in the same tab well. 26f54033bcaea0a2b4d320b23d7aed9ccf085cf6
removed this check to enable the LTI web app to include an iframe
displaying a page proxied through Via.

It is still the case however that the client has problems on sites that
have large numbers of iframes which in turn all have the client loaded
into them (see https://github.com/hypothesis/client/issues/568).

This commit reintroduces the check but only for child iframes of the
proxied page, not the top-most proxied page itself if that is contained
inside an iframe.

I did look into whether Via can be configured not to rewrite iframe src attributes but that doesn't appear to be configurable independently of other things in the version of pywb we are using.

Fixes https://github.com/hypothesis/client/issues/568