### PR TITLE
Pin Alpine Linux version and install missing collectd plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:2.7-alpine
+FROM python:2.7-alpine3.7
 MAINTAINER Hypothes.is Project and Ilya Kreymer
 
 # Install runtime deps.
 RUN apk add --update \
     git \
     collectd \
+    collectd-disk \
     libffi \
     openssl \
     supervisor \


### PR DESCRIPTION
The python:2.7-alpine image uses the latest major version of Alpine
Linux. When a new version of Alpine is released, changes in package
organization can break Dockerfile builds from one build of Via to the next.

In this case a "silent" update to Alpine broke collectd because the "disk"
plugin was split out into a separate package (see also [1]), causing an infinite
restart of collectd on startup which eventually filled Via's logfile.

This commit pins the Alpine major version to 3.7, which is what we use
for "h" as well. This way we'll still get security updates to 3.7.x
packages but should avoid breaking changes.

[1] https://github.com/hypothesis/h/commit/7e8047db14f6804f8ca952623cf27e9f0ccd6bcc

----

You can test this locally by building the Docker image and running with a dummy `GRAPHITE_HOST` URL:

```
make docker
docker run -e "GRAPHITE_HOST=http://localhost:8000" -p 9080:9080 hypothesis/via:latest
```

On master you'll see a collectd output loop on startup. On this branch you shouldn't, although there will be errors relating to the dummy graphite host URL.