### PR TITLE
Add LMS_MODE config setting to put the client into LMS mode

### DIFF
--- a/static/pdfjs/proxy.js
+++ b/static/pdfjs/proxy.js
@@ -8,5 +8,13 @@ PDFJS.getDocument = function getDocumentWithProxy(src) {
 }
 /* Address https://github.com/hypothesis/via/issues/18 */
 window.hypothesisConfig = function() {
-    return {showHighlights: true};
+  return {
+    showHighlights: true,
+    openSidebar: true,
+    services: [{
+      apiUrl: 'http://localhost:5000/api/',
+      authority: 'lms.hypothes.is',
+      grantToken: 'postMessage'
+    }]
+  };
 }

--- a/templates/banner.html
+++ b/templates/banner.html
@@ -19,7 +19,13 @@ document.head.appendChild(embed_script);
 window.hypothesisConfig = function() {
     return {
       showHighlights: true,
-      appType: 'via'
+      appType: 'via'{% if lms_mode %},
+      openSidebar: true,
+      services: [{
+        apiUrl: 'http://localhost:5000/api/',
+        authority: 'lms.hypothes.is',
+        grantToken: 'postMessage'
+      }]{% endif %}
     };
 }
 })();

--- a/via/app.py
+++ b/via/app.py
@@ -60,6 +60,9 @@ def app(environ, start_response):
 
     template_params = environ.get('pywb.template_params', {})
     template_params['h_embed_url'] = embed_url
+
+    template_params['lms_mode'] = os.environ.get('LMS_MODE', False)
+
     environ['pywb.template_params'] = template_params
 
     return pywb.apps.wayback.application(environ, start_response)


### PR DESCRIPTION
If the environment variable `LMS_MODE` is set then inject the config settings necessary to put the client into "LMS mode". This mostly means injecting a [services config](https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-services) with the special `grantToken` value `"postMessage"`. See the [corresponding client pull request that responds to this special `grantToken` value](https://github.com/hypothesis/client/pull/764).

The final name of the `LMS_MODE` config setting remains to be decided.