### PR TITLE
Support customizing Hypothesis client config on a per-request basis

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -19,7 +19,15 @@ document.head.appendChild(embed_script);
 window.hypothesisConfig = function() {
     return {
       showHighlights: true,
-      appType: 'via'
+      appType: 'via',
+
+      {% if h_request_config %}
+      requestConfigFromFrame: '{{ h_request_config }}',
+      {% endif %}
+
+      {% if h_open_sidebar %}
+      openSidebar: true,
+      {% endif %}
     };
 }
 })();

--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -1,0 +1,86 @@
+from __future__ import unicode_literals
+
+import pytest
+
+import json
+
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse as Response
+from werkzeug import wsgi
+
+from via.config_extractor import ConfigExtractor, pop_query_params_with_prefix
+
+
+class TestPopQueryParamsWithPrefix(object):
+
+    def test_it_ignores_non_matching_params(self, create_environ):
+        environ = create_environ('one=1&two=2&three=3')
+        orig_envion = environ.copy()
+
+        params = pop_query_params_with_prefix(environ, 'aprefix.')
+
+        assert params == {}
+        assert environ == orig_envion
+
+    def test_it_pops_matching_params(self, create_environ):
+        environ = create_environ('one=1&two=2&aprefix.three=3&four=4')
+
+        params = pop_query_params_with_prefix(environ, 'aprefix.')
+
+        expected_environ = create_environ('one=1&two=2&four=4')
+        assert params == {'aprefix.three': '3'}
+        assert environ == expected_environ
+
+    @pytest.fixture
+    def create_environ(self):
+        def create(query_string):
+            return {'QUERY_STRING': query_string,
+                    'REQUEST_URI': 'http://example.com?{}'.format(query_string)}
+        return create
+
+
+class TestConfigExtractor(object):
+    def test_it_sets_template_params_from_matching_query_params(self, client_get):
+        resp = client_get('/example.com?q=foobar&'
+                          'via.open_sidebar=1&'
+                          'via.request_config_from_frame=https://lms.hypothes.is')
+
+        template_params = json.loads(resp.data).get('pywb.template_params')
+        assert template_params == {'h_open_sidebar': True,
+                                   'h_request_config': 'https://lms.hypothes.is'}
+
+    def test_it_passes_non_matching_query_params_to_upstream_app(self, client_get):
+        resp = client_get('/example.com?q=foobar&via.open_sidebar=1')
+
+        upstream_environ = json.loads(resp.data)
+        assert upstream_environ['QUERY_STRING'] == 'q=foobar'
+        assert upstream_environ['REQUEST_URI'] == '/example.com?q=foobar'
+
+    @pytest.fixture
+    def app(self):
+        return ConfigExtractor(upstream_app)
+
+    @pytest.fixture
+    def client_get(self, app):
+        def get(url):
+            client = Client(app, Response)
+
+            # `Client` does not set "REQUEST_URI" as an actual app would, so
+            # set it manually.
+            environ = {'REQUEST_URI': url}
+
+            return client.get(url, environ_overrides=environ)
+        return get
+
+
+@wsgi.responder
+def upstream_app(environ, start_response):
+    class Encoder(json.JSONEncoder):
+        def default(self, o):
+            try:
+                return json.JSONEncoder.default(self, o)
+            except TypeError:
+                # Ignore un-serializable fields.
+                return None
+    body = Encoder().encode(environ)
+    return Response(body)

--- a/via/app.py
+++ b/via/app.py
@@ -2,6 +2,7 @@ from pkg_resources import resource_filename
 
 import logging
 import os
+
 import pywb.apps.wayback
 import static
 from werkzeug.exceptions import NotFound
@@ -10,6 +11,7 @@ from werkzeug.wrappers import Request
 from werkzeug import wsgi
 
 from via.blocker import Blocker
+from via.config_extractor import ConfigExtractor
 from via.security import RequestHeaderSanitiser, ResponseHeaderSanitiser
 from via.useragent import UserAgentDecorator
 
@@ -69,6 +71,7 @@ application = RequestHeaderSanitiser(app)
 application = ResponseHeaderSanitiser(application)
 application = Blocker(application)
 application = UserAgentDecorator(application, 'Hypothesis-Via')
+application = ConfigExtractor(application)
 application = wsgi.DispatcherMiddleware(application, {
     '/favicon.ico': static.Cling('static/favicon.ico'),
     '/robots.txt': static.Cling('static/robots.txt'),

--- a/via/config_extractor.py
+++ b/via/config_extractor.py
@@ -1,0 +1,58 @@
+from __future__ import unicode_literals
+
+from urllib import urlencode
+from urlparse import parse_qsl
+
+
+def pop_query_params_with_prefix(environ, prefix):
+    """
+    Extract and remove query string parameters beginning with ``prefix``.
+
+    :param environ: WSGI environ dict
+    :param prefix: Prefix to match
+    :return: A dict of query param / value pairs
+    """
+    orig_qs = environ['QUERY_STRING']
+    parsed_query_items = parse_qsl(orig_qs, keep_blank_values=True)
+    popped_params = {}
+    updated_query_items = []
+
+    for key, value in parsed_query_items:
+        if key.startswith(prefix):
+            popped_params[key] = value
+        else:
+            updated_query_items.append((key, value))
+
+    updated_qs = urlencode(updated_query_items)
+    environ['QUERY_STRING'] = updated_qs
+    environ['REQUEST_URI'] = environ['REQUEST_URI'][:-len(orig_qs)] + updated_qs
+
+    return popped_params
+
+
+class ConfigExtractor(object):
+    """
+    WSGI middleware which extracts client configuration params from the URL.
+
+    Client configuration is supplied via "via."-prefixed query parameters,
+    which are removed from the URL passed along to the proxy server.
+
+    These parameters are then used to populate the parameters exposed to
+    rendered templates.
+    """
+
+    def __init__(self, application):
+        self._application = application
+
+    def __call__(self, environ, start_response):
+        template_params = environ.get('pywb.template_params', {})
+
+        via_params = pop_query_params_with_prefix(environ, 'via.')
+        if 'via.request_config_from_frame' in via_params:
+            template_params['h_request_config'] = via_params['via.request_config_from_frame']
+        if 'via.open_sidebar' in via_params:
+            template_params['h_open_sidebar'] = True
+
+        environ['pywb.template_params'] = template_params
+
+        return self._application(environ, start_response)


### PR DESCRIPTION
Support customizing aspects of the Hypothesis client configuration for a
given request by setting "via."-prefixed query params. These params are
stripped from the WSGI environment and are not seen by the proxy.

The initial use case is to support setting the "requestConfig" and
"openSidebar" client config properties, which will be needed by our LMS
integration.

In future we could also use this mechanism as a way to set "feature
flags" for requests in order to test out server-side behavior changes.