### PR TITLE
Use same client configuration for PDF and HTML viewers

### DIFF
--- a/static/pdfjs/proxy.js
+++ b/static/pdfjs/proxy.js
@@ -6,7 +6,3 @@ PDFJS.getDocument = function getDocumentWithProxy(src) {
   src.url = '/id_/' + src.url;
   return _getDocument.apply(PDFJS, args);
 }
-/* Address https://github.com/hypothesis/via/issues/18 */
-window.hypothesisConfig = function() {
-    return {showHighlights: true};
-}

--- a/templates/banner.html
+++ b/templates/banner.html
@@ -16,19 +16,7 @@ if (window.location.pathname.indexOf('/if_/') === 0) {
 var embed_script = document.createElement("script");
 embed_script.src = "{{ h_embed_url }}";
 document.head.appendChild(embed_script);
-window.hypothesisConfig = function() {
-    return {
-      showHighlights: true,
-      appType: 'via',
 
-      {% if h_request_config %}
-      requestConfigFromFrame: '{{ h_request_config }}',
-      {% endif %}
-
-      {% if h_open_sidebar %}
-      openSidebar: true,
-      {% endif %}
-    };
-}
+{% include "client_config.js.jinja2" %}
 })();
 </script>

--- a/templates/client_config.js.jinja2
+++ b/templates/client_config.js.jinja2
@@ -1,0 +1,14 @@
+window.hypothesisConfig = function() {
+  return {
+    showHighlights: true,
+    appType: 'via',
+
+    {% if h_request_config %}
+    requestConfigFromFrame: '{{ h_request_config }}',
+    {% endif %}
+
+    {% if h_open_sidebar %}
+    openSidebar: true,
+    {% endif %}
+  };
+}

--- a/templates/pdfjs_viewer.html
+++ b/templates/pdfjs_viewer.html
@@ -51,6 +51,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
     <script src="/static/pdfjs/web/viewer.js"></script>
 
+    <script>{% include "client_config.js.jinja2" %}</script>
     <script src="/static/pdfjs/proxy.js"></script>
     <script src="{{ h_embed_url }}"></script>
   </head>


### PR DESCRIPTION
**Follow up to https://github.com/hypothesis/via/pull/136**

Use the same client configuration for the PDF viewer as the HTML viewer.
    
This enables the "via."-prefixed parameters to work when viewing a PDF through Via.

As a side benefit this also fixes an issue where client usage on PDFs in Via was not tracked correctly in Google Analytics because the `appType` key was not set in the client config.