### PR TITLE
Propagate "via."-prefixed query params upon upstream redirect

### DIFF
--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -98,9 +98,15 @@ class TestConfigExtractor(object):
         assert upstream_environ['QUERY_STRING'] == 'q=foobar'
         assert upstream_environ['REQUEST_URI'] == '/example.com?q=foobar'
 
-    def test_it_propagates_matching_query_params_to_redirect_location(self, client_get):
+    @pytest.mark.parametrize('upstream_status,upstream_location', [
+        ('302 Found', 'https://example.com/moved'),
+        ('301 Moved Permanently', 'https://example.com/moved'),
+    ])
+    def test_it_propagates_matching_query_params_to_redirect_location(
+        self, client_get, upstream_status, upstream_location
+    ):
         def upstream_app(environ, start_response):
-            start_response('302 Found', [('Location', 'https://example.com/moved')])
+            start_response(upstream_status, [('Location', upstream_location)])
             return []
 
         app = ConfigExtractor(upstream_app)

--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -66,8 +66,9 @@ class TestRewriteLocationHeader(object):
             params['via.foo'], params['via.baz']
         )
 
-    def test_it_retains_rest_of_url(self):
-        url = 'https://localhost:5000/a/path?some_query=#some_fragment'
+    def test_it_preserves_rest_of_url_in_location_header(self):
+        query_string = 'empty_param=&non_empty_param=foo&q=one&q=two'
+        url = 'https://localhost:5000/a/path?{}#some_fragment'.format(query_string)
 
         header, value = rewrite_location_header('Location', url, {})
 

--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -122,7 +122,11 @@ class TestConfigExtractor(object):
         # nb. A default "Content-Type" header gets inserted if none is supplied
         # by upstream, so all examples here include one.
         ('200 OK', [DEFAULT_CONTENT_TYPE]),
-        ('200 OK', [DEFAULT_CONTENT_TYPE, ('Location', 'https://dont_touch_me.com/')]),
+
+        # 201 responses include a "Location" header, but browsers don't redirect
+        # to the created resource.
+        ('201 Created', [DEFAULT_CONTENT_TYPE, ('Location', 'https://dont_touch_me.com/')]),
+
         ('400 Bad Request', [DEFAULT_CONTENT_TYPE]),
     ])
     def test_it_returns_response_unmodified_if_upstream_returns_non_3xx_status(

--- a/via/config_extractor.py
+++ b/via/config_extractor.py
@@ -103,7 +103,7 @@ class ConfigExtractor(object):
         # This ensures that client configuration is preserved if the user requests
         # a URL which immediately redirects.
         def start_response_wrapper(status, headers, exc_info=None):
-            code_str, _ = status.split(' ')
+            code_str, _ = status.split(' ', 1)
             code = int(code_str)
 
             if code >= 300 and code < 400:

--- a/via/config_extractor.py
+++ b/via/config_extractor.py
@@ -1,7 +1,44 @@
 from __future__ import unicode_literals
 
+import logging
 from urllib import urlencode
-from urlparse import parse_qsl
+from urlparse import parse_qsl, urlparse, urlunparse
+
+
+def rewrite_location_header(name, value, params):
+    """
+    Rewrite "Location" header to append params to the URL's query string.
+
+    Returns other headers unmodified.
+
+    :param name: HTTP header name
+    :param value: HTTP header value
+    :param params: dict of params to add to the URL's query string
+    :return: Modified (name, value) pair
+    """
+
+    if name.lower() != 'location':
+        return (name, value)
+
+    try:
+        parsed_url = urlparse(value)
+        parsed_query = parse_qsl(parsed_url.query, keep_blank_values=True)
+
+        for k, v in params.items():
+            parsed_query.append((k, v))
+
+        updated_query = urlencode(parsed_query)
+        updated_url = urlunparse((parsed_url.scheme,
+                                  parsed_url.netloc,
+                                  parsed_url.path,
+                                  parsed_url.params,
+                                  updated_query,
+                                  parsed_url.fragment))
+
+        return (name, updated_url)
+    except Exception:
+        logging.warn('Failed to parse "Location" header: {}'.format(value))
+        return (name, value)
 
 
 def pop_query_params_with_prefix(environ, prefix):
@@ -39,6 +76,11 @@ class ConfigExtractor(object):
 
     These parameters are then used to populate the parameters exposed to
     rendered templates.
+
+    This middleware also rewrites redirect responses from the upstream app to
+    preserve "via."-prefixed parameters from the original request. Note that
+    this only works for server-side redirects. Client-side redirects will still
+    "lose" these parameters.
     """
 
     def __init__(self, application):
@@ -55,4 +97,18 @@ class ConfigExtractor(object):
 
         environ['pywb.template_params'] = template_params
 
-        return self._application(environ, start_response)
+        # A wrapper which intercepts redirects and adds any params from `via_params`
+        # to the query string in the URL in the "Location" header.
+        #
+        # This ensures that client configuration is preserved if the user requests
+        # a URL which immediately redirects.
+        def start_response_wrapper(status, headers, exc_info=None):
+            code_str, _ = status.split(' ')
+            code = int(code_str)
+
+            if code >= 300 and code < 400:
+                headers = [rewrite_location_header(k, v, via_params) for k, v in headers]
+
+            return start_response(status, headers, exc_info)
+
+        return self._application(environ, start_response_wrapper)


### PR DESCRIPTION
When a URL is fetched through Via which includes "via."-prefixed query
parameters in order to control client behavior, those client config
changes were lost if the upstream server returned a redirect to a
different location.

Resolve this by intercepting 3xx-responses in the `ConfigExtractor`
middleware and rewriting the "Location" header to append the
"via."-prefixed query params from the original URL.

Fixes https://github.com/hypothesis/via/issues/138