### PR TITLE
Improve usability of URL input field

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -85,6 +85,7 @@
         onsubmit="url = document.getElementById('search').value; if (url != '') { document.location.href = '/' + url; } return false;"
         novalidate>
     <input id="search"
+           aria-label="Web or PDF document to annotate"
            autofocus
            class="url-field"
            name="search"

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,8 +81,16 @@
       <g fill="none" fill-rule="evenodd"><path fill="#FFF" fill-rule="nonzero" d="M3.886 3.945H21.03v16.047H3.886z"/><path d="M0 2.005C0 .898.897 0 2.005 0h19.99C23.102 0 24 .897 24 2.005v19.99A2.005 2.005 0 0 1 21.995 24H2.005A2.005 2.005 0 0 1 0 21.995V2.005zM9 24h6l-3 4-3-4zM7.008 4H4v16h3.008v-4.997C7.008 12.005 8.168 12.01 9 12c1 .007 2.019.06 2.019 2.003V20h3.008v-6.891C14.027 10 12 9.003 10 9.003c-1.99 0-2 0-2.992 1.999V4zM19 19.987c1.105 0 2-.893 2-1.994A1.997 1.997 0 0 0 19 16c-1.105 0-2 .892-2 1.993s.895 1.994 2 1.994z" fill="#3F3F3F"/></g>
     </svg>
   </a>
-  <form class="url-form" onsubmit="url = document.getElementById('search').value; if (url != '') { document.location.href = '/' + url; } return false;">
-    <input id="search" class="url-field" name="search" type="text" maxsize="30" placeholder="Paste a link to create or view annotations"/>
+  <form class="url-form"
+        onsubmit="url = document.getElementById('search').value; if (url != '') { document.location.href = '/' + url; } return false;"
+        novalidate>
+    <input id="search"
+           autofocus
+           class="url-field"
+           name="search"
+           placeholder="Paste a link to create or view annotations"
+           type="url"
+           >
     <button type="submit" class="annotate-btn">Go!</button>
   </form>
   </div>


### PR DESCRIPTION
This PR makes small usability improvements for the URL input field on the Via homepage following testing on iOS.
 
- Set the input type to "url" to disable unwanted autocorrect behavior and
   trigger a virtual keyboard layout specialized for entering URLs/URL-like
   strings.

   This required disabling built-in form validation via "novalidate" because the
   input accepts values (eg. domain names with no scheme) which are not accepted
   by the browser's default validation of URL inputs.

 - Autofocus the URL input field when the page loads.

 - Remove "maxsize" attribute, which is not a valid input attribute.