### PR TITLE
Support serving via over SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ target/
 
 # Other
 .pydeps
+
+# TLS cert and private key.
+.tlscert.pem
+.tlskey.pem

--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,9 @@ collections:
             client:
                 no_rewrite_prefixes:
                     - 'http://localhost:5000/' # Hypothesis dev server
+                    - 'https://localhost:5000/' # Hypothesis dev server (using SSL)
                     - 'http://localhost:3001/' # Hypothesis client dev server
+                    - 'https://localhost:3001/' # Hypothesis client dev server (using SSL)
                     - 'https://hypothes.is/'
                     - 'https://qa.hypothes.is/'
                     - 'https://cdn.hypothes.is/'

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,11 +1,24 @@
 [uwsgi]
-# Run with default port if not set
-if-not-env = PORT
-http-socket = :9080
-endif =
 
 if-env = PORT
-http-socket = :$(PORT)
+socket-addr = :$(PORT)
+endif =
+
+if-not-env = PORT
+socket-addr = :9080
+endif =
+
+# Use HTTPS if cert/key files are present, or HTTP otherwise.
+# This follows the same convention as h and the client.
+#
+# If using HTTPS to serve a local client, you will also need to set the H_EMBED_URL
+# env var accordingly.
+if-file = .tlscert.pem
+https = %(socket-addr),.tlscert.pem,.tlskey.pem
+endif =
+
+if-not-file = .tlscert.pem
+http-socket = %(socket-addr)
 endif =
 
 if-env = VIRTUAL_ENV


### PR DESCRIPTION
In certain testing scenarios it is easier to serve Hypothesis components over SSL rather than bypassing HTTPS checks in the browser. Typically the SSL certificate only has to be registered once with the device's certificate store whereas bypassing HTTPS checks has to be done for each browser and site.

h and the client already support serving via SSL by putting a copy (or symlink) of the certificate and private key files in a standard location (.tlscert.key and .tlskey.pem) in the root of the project directory.

This PR makes the same convention work in Via.