### PR TITLE
Fix `make docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --update --virtual build-deps \
     libffi-dev \
     linux-headers \
     openssl-dev \
+  && pip install --no-cache-dir -U pip \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
A bug in the recently released pip 19.0.1 has broken `make docker`. Pip 19.0.2 has already been released with a fix but our Docker base image doesn't seem to have 19.0.2 yet. This is a temporary workaround.