### PR TITLE
Fix Dockerfile for pip 19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --update --virtual build-deps \
     linux-headers \
     openssl-dev \
   && pip install --no-cache-dir -U pip \
-  && pip install --no-cache-dir -r requirements.txt \
+  && pip install --no-cache-dir --no-use-pep517 -r requirements.txt \
   && apk del build-deps \
   && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
There is a bug in pip 19 that gives an assertion error
when you build the Docker image (see here for mitigation):
https://github.com/pypa/pip/issues/6197
This commit uses the suggested workaround in that issue in order
to get the image to build.