### PR TITLE
Support running Via over SSL in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ help:
 dev:
 	tox -q -e py27-dev
 
+.PHONY: dev-ssl
+dev-ssl:
+	tox -q -e py27-dev-ssl
+
 .PHONY: test
 test:
 	tox -q -e py27-tests

--- a/README.md
+++ b/README.md
@@ -62,3 +62,20 @@ In addition, you will also need to make sure that the host the client is being s
 export H_EMBED_URL=http://localhost:5000/embed.js
 make dev
 ```
+
+### Serving Via over SSL in development
+
+To serve Via over SSL locally, you will need to:
+
+1. Create SSL certificates for localhost (you can reuse these for other Hypothesis
+   services). See https://hyp.is/5xXOUMiuEeiDy2smINki5w/letsencrypt.org/docs/certificates-for-localhost/
+2. Copy or symlink the certificate and private key as `.tlscert.pem` and
+   `.tlskey.pem` respectively in the root of your checkout of this repository.
+3. Start Via using `make dev-ssl`
+
+Steps (1) and (2) are the same as for setting up SSL support in other Hypothesis
+projects.
+
+Note that this configuration is *not* suitable for production use.
+Hypothesis' production services use SSL termination provided by AWS load
+balancers.

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,8 @@ collections:
                 no_rewrite_prefixes:
                     - 'http://localhost:5000/' # Hypothesis dev server
                     - 'http://localhost:3001/' # Hypothesis client dev server
+                    - 'https://localhost:5000/' # Hypothesis dev server (SSL)
+                    - 'https://localhost:3001/' # Hypothesis client dev server (SSL)
                     - 'https://hypothes.is/'
                     - 'https://qa.hypothes.is/'
                     - 'https://cdn.hypothes.is/'

--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -174,8 +174,8 @@ class TestConfigExtractor(object):
         def get(url, upstream_app=app):
             client = Client(upstream_app, Response)
 
-            # `Client` does not set "REQUEST_URI" as an actual app would, so
-            # set it manually.
+            # `Client` does not set "REQUEST_URI" as this is set by uwsgi in
+            # the actual app. Set it manually here.
             environ = {"REQUEST_URI": url}
 
             return client.get(url, environ_overrides=environ)

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ deps =
     dev: -r requirements-dev.in
     ssl: gunicorn
 commands =
-    ssl: {posargs:gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
-    dev: {posargs:uwsgi uwsgi.ini}
+    dev-!ssl: {posargs:uwsgi uwsgi.ini}
+    dev-ssl: {posargs:gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
     tests: pytest {posargs:tests}
     lint: flake8 via tests
     format: black via tests

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,9 @@ deps =
     lint: flake8
     {format,checkformatting}: black
     dev: -r requirements-dev.in
+    ssl: gunicorn
 commands =
+    ssl: {posargs:gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
     dev: {posargs:uwsgi uwsgi.ini}
     tests: pytest {posargs:tests}
     lint: flake8 via tests

--- a/via/config_extractor.py
+++ b/via/config_extractor.py
@@ -66,7 +66,10 @@ def pop_query_params_with_prefix(environ, prefix):
 
     updated_qs = urlencode(updated_query_items)
     environ["QUERY_STRING"] = updated_qs
-    environ["REQUEST_URI"] = environ["REQUEST_URI"][: -len(orig_qs)] + updated_qs
+
+    if "REQUEST_URI" in environ:
+        # If using uwsgi, update `REQUEST_URI`.
+        environ["REQUEST_URI"] = environ["REQUEST_URI"][: -len(orig_qs)] + updated_qs
 
     return popped_params
 


### PR DESCRIPTION
Follow the convention in our other repositories of supporting running
the server over SSL locally if `.tlscert.pem` and `.tlskey.pem` files
are present.

uwsgi installed from PyPI does not support SSL, so instead add a
separate `make dev-ssl` command which uses gunicorn, which we already
use as the WSGI HTTP server in our other apps. This is easier than
trying to rebuild uwsgi with SSL support.

One small code change was required to support gunicorn, which is not to
rely on `REQUEST_URI` being present in the WSGI environ dict, as this is
uwsgi-specific.