### PR TITLE
Avoid injecting client into iframes - second attempt

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -3,13 +3,55 @@
 
 <!-- Inject Hypothesis -->
 <script>
+
+/**
+  * Return `true` if this frame has no ancestors or its nearest ancestor was
+  * not served through Via.
+  *
+  * The implementation relies on all documents proxied through Via sharing the
+  * same origin.
+  */
+function isTopViaFrame() {
+  if (window === window.top) {
+    // Trivial case - This is the top-most frame in the tab so it must be the
+    // top Via frame.
+    return true;
+  }
+
+  try {
+    // Get a reference to the parent frame. Via's "wombat.js" frontend code
+    // monkey-patches `window.parent` in certain cases, in which case
+    // `window.__WB_orig_parent` is the _real_ parent frame.
+    var parent = window.__WB_orig_parent || window.parent;
+
+    // Try to access the parent frame's location. This will trigger an
+    // exception if the frame comes from a different, non-Via origin.
+    //
+    // This test assumes that all documents proxied through Via are served from
+    // the same origin. If a future change to Via means that is no longer the
+    // case, this function will need to be implemented differently.
+    parent.location.href;
+
+    // If the access succeeded, the parent frame was proxied through Via and so
+    // this is not the top Via frame.
+    return false;
+  } catch (err) {
+    // If the access failed, the parent frame was not proxied through Via and
+    // so this is the top Via frame.
+    return true;
+  }
+}
+
 (function () {
 
-// Disable injection in iframes in the top-level page that was proxied through
-// Via. These proxied iframes have URLs of the form `${VIA_URL}/if_/${ORIGINAL_URL}`.
-//
-// See https://github.com/hypothesis/client/issues/568.
-if (window.location.pathname.indexOf('/if_/') === 0) {
+if (!isTopViaFrame()) {
+  // Do not inject Hypothesis into iframes in documents proxied through Via.
+  // As well as slowing down the loading of the proxied page even more, this
+  // causes problems with the way that the client "discovers" annotate-able iframes.
+  //
+  // See https://github.com/hypothesis/client/issues/568,
+  // https://github.com/hypothesis/via/issues/119 and
+  // https://github.com/hypothesis/lms/issues/701.
   return;
 }
 


### PR DESCRIPTION
**Summary**: When an HTML document was proxied through Via, the Hypothesis client is supposed to be injected only into the main page and not any iframes that the document contains. Sometimes this logic didn't work. If the client was injected into both the main page and iframes, this caused the page to load even more slowly and in the context of the lms app, could also cause highlights from the "Public" group in the first-party authority to show up, even though the sidebar didn't show the corresponding annotations and was logged in to an LMS user account.

----

**Full details:**

The previous method relied on Via rewriting iframe `src` locations so that
the path started with `/if_/`. However there are some circumstances in
which this does not happen, such as when creating an iframe via
`document.createElement` and setting its `src` using
`iframe.setAttribute("src", "<location>")`. In those cases, the client
would be injected into both the iframe and the top-level Via frame.

This commit replaces that method with a more robust one which instead
relies on the fact that all proxied frames are served from the same
origin, Via's origin, and can therefore access each other's
`window.location`. Frames from different origins (such as the LMS app
embedding a Via iframe) will not be accessible. Therefore we can detect
whether the current frame is the top-most Via frame (as opposed to an
iframe proxied through Via) and only inject the client in that case.

In the context of the LMS app, if the client was injected into a
document proxied through Via as well as iframes in that document proxied
through Via, then multiple instances of the sidebar app would be created
with different client configurations. The main frame would be configured
to fetch client configuration from the LMS app but child iframes would
use the client's default configuration, i.e. it would fetch annotations
and account info from the first-party authority in h, instead of the lms
app's authority. Due to the client's problematic process for
discovering content frames [1] the clients in iframes would end up
connecting to the main frame and fetching annotations for it from the
first-party authority, with the result that annotations from the
"Public" group would end up showing up in the main page even if if the
sidebar in the main page was showing annotations from a third-party
group, such as a group created by the LMS app for the current course.

Fixes https://github.com/hypothesis/via/issues/119 and https://github.com/hypothesis/lms/issues/701

[1] See https://github.com/hypothesis/client/issues/187 and
    https://github.com/hypothesis/client/issues/249

**Testing**

I'm afraid this currently requires manual testing.

Steps to test manually:

1. On master, view https://www.theatlantic.com/magazine/archive/2008/07/is-google-making-us-stupid/306868/ or one of the other problem URLs mentioned in https://github.com/hypothesis/lms/issues/701 through your local Via install. Note that warnings are printed about "multiple Discovery servers" in the console, amongst other errors (ignore those)
2. On this branch, the errors about multiple Discovery servers should not appear, but the main page should still show the Hypothesis client