### PR TITLE
Add New Relic monitoring

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -6,7 +6,7 @@ logfile_maxbytes=0
 user=root
 
 [program:web]
-command=uwsgi uwsgi.ini
+command=newrelic-admin run-program uwsgi uwsgi.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ uwsgi
 werkzeug
 static
 PyYAML
+newrelic
 
 # this points to the 'fix-empty-srcset' branch in hypothesis/pywb
 # this is a fork of the upstream pywb (v0.11.0) with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ idna==2.8                 # via requests, tldextract
 jinja2==2.10
 markupsafe==1.1.1         # via jinja2
 ndg-httpsclient==0.5.1
+newrelic==5.0.2.126
 pathtools==0.1.2          # via watchdog
 pyasn1==0.4.5             # via ndg-httpsclient
 pycparser==2.19           # via cffi

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ deps =
     dev: -r requirements-dev.in
     ssl: gunicorn
 commands =
-    dev-!ssl: {posargs:uwsgi uwsgi.ini}
-    dev-ssl: {posargs:gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
+    dev-!ssl: {posargs:newrelic-admin run-program uwsgi uwsgi.ini}
+    dev-ssl: {posargs:newrelic-admin run-program gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
     tests: pytest {posargs:tests}
     lint: flake8 via tests
     format: black via tests

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,6 +8,9 @@ if-env = PORT
 http-socket = :$(PORT)
 endif =
 
+# Enable running of background threads from Python for New Relic data collection.
+enable-threads = true
+
 if-env = VIRTUAL_ENV
 virtualenv = $(VIRTUAL_ENV)
 endif =

--- a/via/app.py
+++ b/via/app.py
@@ -3,6 +3,7 @@ from pkg_resources import resource_filename
 import logging
 import os
 
+import newrelic.agent
 import pywb.apps.wayback
 import static
 from werkzeug.exceptions import NotFound
@@ -83,3 +84,4 @@ application = wsgi.DispatcherMiddleware(
         "/h": redirect_strip_matched_path,
     },
 )
+application = newrelic.agent.WSGIApplicationWrapper(application, name="proxy")


### PR DESCRIPTION
This is a fix for https://github.com/hypothesis/product-backlog/issues/1052.

Note we are [disabling the browser agent](https://rpm.newrelic.com/accounts/1385283/browser/271975748/edit#/settings?_k=1b74hd) as it's getting injected into the page that we don't own.

The [server side configuration](https://rpm.newrelic.com/accounts/1385283/applications/271975748/settings-server-side-agent-configuration) has already been setup.

Before this is released to QA and Prod we need to configure the environment variables:
      - NEW_RELIC_LICENSE_KEY
      - NEW_RELIC_APP_NAME=via 
