### PR TITLE
Fix errors caused by missing `Promise.prototype.finally` method in IE 11

### DIFF
--- a/static/scripts/pdfjs-init.js
+++ b/static/scripts/pdfjs-init.js
@@ -57,6 +57,18 @@ document.addEventListener('webviewerloaded', function(event) {
   });
 
   pdfjsInitialized.then(function () {
+    // Prevent PDF.js' `Promise` polyfill, if it was used, from being
+    // overwritten by the one that ships with Hypothesis (both from core-js).
+    //
+    // See https://github.com/hypothesis/via/issues/81#issuecomment-531121534
+    if (typeof Promise === 'function' && typeof PromiseRejectionEvent === 'undefined') {
+      window.PromiseRejectionEvent = function FakePromiseRejectionEvent(type, options) {
+        // core-js doesn't actually use this, it just tests for `typeof PromiseRejectionEvent`
+        console.warn('Tried to construct fake `PromiseRejectionEvent`');
+      };
+    }
+
+    // Load the Hypothesis client.
     var embedScript = document.createElement('script');
     embedScript.src = clientEmbedUrl;
     document.body.appendChild(embedScript);


### PR DESCRIPTION
Hypothesis and PDF.js both ship with the same `Promise` polyfill from
core-js v2.6.9. When that polyfill loads, it defines or overwrites the
`Promise` global unless both `Promise` and `PromiseRejectionEvent` are
already defined. The polyfill defines `Promise` but not
`PromiseRejectionEvent`. In browsers without native `Promise` support
(eg. IE 11) this means that when Hypothesis loads, its polyfill overwrites
the one created by PDF.js earlier.

Hypothesis only polyfills the basic Promise implementation, but PDF.js
polyfills and uses methods that were added later, including `finally`.
As a result, the Hypothesis client broke the PDF.js Promise polyfill
when it loaded.

Fix the issue in the most minimal way I can think of by defining a dummy
`PromiseRejectionEvent`, so that Hypothesis will use, but not overwrite,
the Promise polyfill installed by PDF.js.

----

See https://github.com/hypothesis/via/issues/81#issuecomment-531121534 for steps to simulate the original issue in modern browsers.