### PR TITLE
Switch to PDF.js v2 by default

### DIFF
--- a/templates/pdfjs_viewer.html
+++ b/templates/pdfjs_viewer.html
@@ -1,5 +1,5 @@
-{% if "pdfjs2" in via_features %}
-{% include "pdfjs2_viewer.html" %}
-{% else %}
+{% if "pdfjs1" in via_features %}
 {% include "pdfjs1_viewer.html" %}
+{% else %}
+{% include "pdfjs2_viewer.html" %}
 {% endif %}


### PR DESCRIPTION
Invert the feature flag so that PDF.js v2 is used by default and
switching back to PDF.js v1 is temporarily possible by adding a
`via.features=pdfjs1` query param to the URL.

Once this change has baked for a few days and we're happy there are no
significant issues, we can remove PDF.js v1 from the codebase.

nb. This change will also affect the LMS app, regardless of the LMS app's "pdfjs2" feature flag.