### PR TITLE
Disable proxying of most media/font/script assets and client-side rewriting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,5 +37,6 @@ collections:
 
 search_html: index.html
 home_html: index.html
+urlrewriter_class: !!python/name:via.rewriter.UrlRewriter
 
 framed_replay: false

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ collections:
             'application/x-pdf': *pdf_viewer
 
         #frame_insert_html: ./templates/frame_insert.html
-        #head_insert_html: ./templates/head_insert.html
+        head_insert_html: ./templates/head_insert.html
         redir_to_exact: false
 
         #cookie_scope: host

--- a/templates/head_insert.html
+++ b/templates/head_insert.html
@@ -1,0 +1,13 @@
+{#
+This is a replacement for the default HTML that pywb injects at the top of
+proxied pages.
+
+The default `head_insert.html` template adds the "wombat" JavaScript rewriting
+code, which does client-side rewriting of dynamically created elements and XHR
+requests to route them through the proxy.
+
+Hypothesis is trying to avoid that as it slows down the page load considerably
+and adds a lot of other resources.
+#}
+{% include banner_html ignore missing %}
+

--- a/via/rewriter.py
+++ b/via/rewriter.py
@@ -1,9 +1,12 @@
 from __future__ import unicode_literals
 
+from urlparse import urlparse, urljoin
+
 import cgi
 import jinja2
 
 from pywb.webapp.live_rewrite_handler import RewriteHandler
+from pywb.rewrite.url_rewriter import UrlRewriter as BaseUrlRewriter
 from pywb.framework.wbrequestresponse import WbResponse
 
 
@@ -37,6 +40,90 @@ class TemplateRewriteHandler(RewriteHandler):
         return super(TemplateRewriteHandler, self)._make_response(
             wbrequest, status_headers, gen, is_rewritten
         )
+
+
+class UrlRewriter(BaseUrlRewriter):
+    """
+    URL rewriter invoked by pywb to rewrite references to URLs in proxied pages.
+
+    The base implementation in pywb rewrites all URLs to go through the proxy.
+
+    Every URL that is proxied adds overhead to the Via service and also slows
+    down the page load for the user, as resources are much slower if served
+    through the proxy than a local CDN.
+
+    :param url: The URL string to rewrite. This may be absolute or relative.
+    :param mod: A hint about the context in which the URL is used
+    """
+    def rewrite(self, url, mod=None):
+        # `url` may be absolute or relative. Convert to absolute if necessary.
+        if _is_absolute_url(url):
+            abs_url = url
+        else:
+            abs_url = urljoin(self.wburl.url, url)
+
+        # Don't proxy resources loaded as media files or that appear to be media
+        # files based on their extension.
+        if mod in ["im_", "oe_"] or _has_extension(abs_url, MEDIA_EXTENSIONS):
+            return abs_url
+
+        # Don't proxy iframes.
+        if mod in ["if_"]:
+            return abs_url
+
+        # Don't proxy scripts.
+        if mod in ["js_"] or _has_extension(abs_url, SCRIPT_EXTENSIONS):
+            return abs_url
+
+        # Don't rewrite URLs that refer to other origins.
+        if _url_origin(abs_url) != _url_origin(self.wburl.url):
+            return abs_url
+
+        # Rewrite the URL, which will make it go through the proxy.
+        return super(UrlRewriter, self).rewrite(url, mod)
+
+
+MEDIA_EXTENSIONS = [
+    # Image files
+    b".gif",
+    b".jpg",
+    b".jpeg",
+    b".ico",
+    b".png",
+    b".svg",
+
+    # Video files
+    b".webm",
+
+    # Audio files
+    b".mp3",
+    b".mp4",
+
+    # Fonts
+    b".woff",
+    b".woff2",
+]
+
+SCRIPT_EXTENSIONS = [b".js"]
+
+
+def _has_extension(url, extensions):
+    parsed_url = urlparse(url)
+    for ext in extensions:
+        if parsed_url.path.endswith(ext):
+            return True
+    return False
+
+
+def _url_origin(url):
+    parsed_url = urlparse(url)
+    return parsed_url.netloc
+
+
+def _is_absolute_url(url):
+    return (
+        url.startswith(b"http:") or url.startswith(b"https:") or url.startswith(b"//")
+    )
 
 
 def _lookup_key(val):


### PR DESCRIPTION
This is an experiment to see whether we can get away with disable rewriting of most media/asset URLs (images, videos, audio files, iframes), scripts and XHR requests etc. As a result of these changes, loading a typical news website will generate far fewer requests to the proxy service. This should reduce server-side load for us and also make the page load faster because images etc. can often be fetched from a CDN near the user instead of going through our west coast US-based server.

- The first commit uses a config option to replace Via's default URL rewriter with a replacement which avoids rewriting many URLs
- The second commit replaces the HTML snippet that Via inserts at the top of each proxied page with a simpler one which doesn't load the JavaScript that does lots of DOM API monkey-patching in order to route XHR requests etc. through the proxy