### PR TITLE
Moving the pip-compile to tox and it's own env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ checkformatting: python
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py27-dev -- pip-compile --output-file requirements.txt requirements.in
+	tox -q -e py27-pip-compile
 
 .PHONY: clean
 clean:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,2 +1,0 @@
-flake8
-pip-tools

--- a/tox.ini
+++ b/tox.ini
@@ -18,10 +18,10 @@ passenv =
 deps =
     tests: pytest
     {dev,tests}: -r requirements.txt
-    lint: flake8
+    {lint,dev}: flake8
     {format,checkformatting}: black
-    dev: -r requirements-dev.in
     ssl: gunicorn
+    pip-compile: pip-tools
 commands =
     dev-!ssl: {posargs:newrelic-admin run-program uwsgi uwsgi.ini}
     dev-ssl: {posargs:newrelic-admin run-program gunicorn --certfile .tlscert.pem --keyfile .tlskey.pem -b :9080 via.app}
@@ -29,4 +29,5 @@ commands =
     lint: flake8 via tests
     format: black via tests
     checkformatting: black --check via tests
+    pip-compile: pip-compile
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
Also removed the requirements-dev.in as there is only one item (flake8)
in there. At that point it's just misdirection. I noticed other repos
don't necessarily have a requirements-dev.in, so there is precident.