### PR TITLE
Simplify tox commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
         testApp(image: img, runArgs: '-u root -e HTTP_PROXY= -e HTTPS_PROXY= -e SITE_PACKAGES=true') {
             sh 'apk add py2-pip'
             sh 'pip install -q tox>=3.8.0'
-            sh 'cd /var/lib/via && tox -e py27-tests'
+            sh 'cd /var/lib/via && tox'
         }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -16,40 +16,40 @@ help:
 
 .PHONY: dev
 dev: python
-	tox -q -e py27-dev
+	@tox -qe dev
 
 .PHONY: dev-ssl
 dev-ssl: python
-	tox -q -e py27-dev-ssl
+	@tox -qe dev-ssl
 
 .PHONY: test
 test: python
-	tox -q -e py27-tests
+	@tox -q
 
 .PHONY: docker
 docker:
-	docker build -t hypothesis/via:$(DOCKER_TAG) .
+	@docker build -t hypothesis/via:$(DOCKER_TAG) .
 
 .PHONY: lint
 lint: python
-	tox -q -e py27-lint
+	@tox -qe lint
 
 .PHONY: format
 format: python
-	tox -q -e py36-format
+	@tox -qe py36-format
 
 .PHONY: checkformatting
 checkformatting: python
-	tox -q -e py36-checkformatting
+	@tox -qe py36-checkformatting
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py27-pip-compile
+	@tox -qe pip-compile
 
 .PHONY: clean
 clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
+	@find . -type f -name "*.py[co]" -delete
+	@find . -type d -name "__pycache__" -delete
 
 .PHONY: python
 python:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-tests
+envlist = tests
 skipsdist = true
 minversion = 3.8.0
 requires =


### PR DESCRIPTION
1. You can just do `tox -e foo` rather than `tox -e py36-foo`
2. Use `tox -qe` rather than `tox -q -e`
3. Use `@` prefix in Makefile so make doesn't print out each command
   before running it

`tox -qe py36-*` is still used for the `format` and `checkformatting`
envs because these need to run with Python 3.6 (because Black requires
Python 3) whereas everything else in Via runs with Python 2.7 which is
the Via dev env's default.

For more explanation see:

hypothesis/h#5866