### PR TITLE
Remove ngs-httpclient dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
 cffi
 gevent
-ndg-httpsclient
 uwsgi
 werkzeug
 static

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,24 +9,20 @@ argh==0.26.2              # via watchdog
 certifi==2019.3.9         # via requests
 cffi==1.12.2
 chardet==3.0.4            # via requests
-cryptography==2.8         # via pyopenssl
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests, tldextract
 jinja2==2.10.1
 markupsafe==1.1.1         # via jinja2
-ndg-httpsclient==0.5.1
 newrelic==5.4.0.132
 pathtools==0.1.2          # via watchdog
-pyasn1==0.4.5             # via ndg-httpsclient
 pycparser==2.19           # via cffi
-pyopenssl==19.0.0         # via ndg-httpsclient
 pystache==0.5.4           # via static
 pyyaml==3.13
 redis==3.2.1
 requests-file==1.4.3      # via tldextract
 requests==2.21.0          # via requests-file, tldextract
-six==1.12.0               # via cryptography, pyopenssl, requests-file
+six==1.12.0               # via requests-file
 static==1.1.1
 surt==0.2
 tldextract==2.2.1         # via surt


### PR DESCRIPTION
This dependency was originally added to support sites that require SNI [1]
but the sites mentioned in the issue and the test page at
https://check-tls.akamaized.net seem to work without it.

This dependency in turn resulted in Via having a bunch of outdated
dependencies (eg. cryptography) which appears to be a cause of a startup
crash when running the dev server on the latest version of macOS
(the issue I encountered matched https://stackoverflow.com/questions/58563849/)

If this approach doesn't work and it turns out that ngs-httpclient is
still required, we may have to update its transitive dependencies
instead.

[1] https://github.com/hypothesis/via/issues/8