### PR TITLE
Fix broken pdf redirects

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
             set $upstream $proxied_uri$is_args$args;
             proxy_ssl_server_name on;
             proxy_pass $upstream;
-            proxy_redirect ~^(.*)$ $original_scheme://$http_host/id_/$1; 
+            proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1; 
 
             # Strip hypothesis cookies and authorization header.
             set $stripped_cookie $http_cookie;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,6 +54,7 @@ http {
 
             # Do not allow the third party server to set cookies.
             add_header 'Set-Cookie' ''; 
+            proxy_hide_header 'Access-Control-Allow-Origin';
             add_header 'Access-Control-Allow-Origin' $access_control_allow_origin; 
         }
 

--- a/py_proxy/views.py
+++ b/py_proxy/views.py
@@ -55,7 +55,11 @@ def content_type(request):
 
     with requests.get(url, stream=True, allow_redirects=True) as rsp:
         if rsp.headers.get("Content-Type") in ("application/x-pdf", "application/pdf",):
-            return exc.HTTPFound(request.route_url("pdf", pdf_url=url))
+            return exc.HTTPFound(
+                request.route_url(
+                    "pdf", pdf_url=request.matchdict["url"], _query=request.params
+                )
+            )
     via_url = request.registry.settings["legacy_via_url"]
     return exc.HTTPFound(f"{via_url}/{url}")
 
@@ -66,12 +70,17 @@ def _drop_from_url_begining(drop_chars, url):
     return url[drop_before:]
 
 
-def includeme(config):
-    """Pyramid config."""
+def add_routes(config):
+    """Add routes to pyramid config."""
     config.add_route("index", "/")
     config.add_route("status", "/_status")
     config.add_route("favicon", "/favicon.ico")
     config.add_route("robots", "/robots.txt")
     config.add_route("pdf", "/pdf/{pdf_url:.*}")
     config.add_route("content_type", "/{url:.*}")
+
+
+def includeme(config):
+    """Pyramid config."""
+    add_routes(config)
     config.scan(__name__)

--- a/tests/unit/py_proxy/conftest.py
+++ b/tests/unit/py_proxy/conftest.py
@@ -1,7 +1,6 @@
 # pylint: disable=no-self-use
 """A place to put fixture functions that are useful application-wide."""
 import functools
-import re
 from unittest import mock
 
 import httpretty
@@ -50,24 +49,7 @@ def httpretty_():
     all with mock responses. This handles requests sent using the standard
     urllib2 library and the third-party httplib2 and requests libraries.
     """
-    httpretty.enable()
-
-    # Tell httpretty which HTTP requests we want it to mock (all of them).
-    for method in (
-        httpretty.GET,
-        httpretty.PUT,
-        httpretty.POST,
-        httpretty.DELETE,
-        httpretty.HEAD,
-        httpretty.PATCH,
-        httpretty.OPTIONS,
-        httpretty.CONNECT,
-    ):
-        httpretty.register_uri(
-            method=method,
-            uri=re.compile(r"http(s?)://.*"),  # Matches all http:// and https:// URLs.
-            body="",
-        )
+    httpretty.enable(allow_net_connect=False)
 
     yield
 

--- a/tests/unit/py_proxy/conftest.py
+++ b/tests/unit/py_proxy/conftest.py
@@ -6,6 +6,7 @@ from unittest import mock
 import httpretty
 import pytest
 from pyramid import testing
+from pyramid.request import Request
 
 from py_proxy.views import add_routes
 
@@ -39,6 +40,16 @@ def pyramid_settings():
         "nginx_server": "http://via3.hypothes.is",
         "legacy_via_url": "http://via.hypothes.is",
     }
+
+
+@pytest.fixture
+def make_pyramid_request(pyramid_config):
+    def _make_pyramid_request(path):
+        pyramid_request = Request.blank(path)
+        pyramid_request.registry = pyramid_config.registry
+        return pyramid_request
+
+    return _make_pyramid_request
 
 
 @pytest.fixture(autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ filterwarnings =
     ; Suppress warnings about an import of `imp` by Pyramid
     ignore:the imp module is deprecated in favour of importlib
 
+xfail_strict=true
+
 [tox]
 envlist = tests
 skipsdist = true


### PR DESCRIPTION
Previously if a pdf url returned a redirect the pdf would not be proxied correctly. This PR fixes a couple issue that were causing this:
1. The pdf url that was being passed from the python app was incomplete (it was missing query params).
1. The Content-Type header request was not following redirects so if the first redirect did not respond with a pdf Content-Type the request would be routed to legacy via.
1. The nginx redirect url replacement was incorrectly replacing the url with the previous /_id/ endpoint instead of the new /proxy/static/ endpoint.
1. The CORS header was being appended to rather than overwritten inside nginx when proxying the third-party pdf which lead to an invalid value in the CORS header when the third-party pdf server also returned a CORS header.