### PR TITLE
Set gunicorn worker timeout to infinite in dev

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
 whitelist_externals =
     dev: gunicorn
 commands =
-    dev: {posargs:gunicorn -b "0.0.0.0:9082" --reload "py_proxy.app:app()"}
+    dev: {posargs:gunicorn --timeout 0 -b "0.0.0.0:9082" --reload "py_proxy.app:app()"}
     docker-compose: docker-compose {posargs}
     lint: pydocstyle --explain py_proxy
     lint: pydocstyle --config tests/.pydocstyle --explain tests


### PR DESCRIPTION
This is necessary for debug so the gunicorn worker does not timeout in the middle of a pdb session.