### PR TITLE
Increase gunicorn workers to 4 (2*vCPUs)

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=gunicorn -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
+command=gunicorn --workers 4 -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
This is necessary to allow via3 to handle multiple incoming requests at once. The gunicorn [documentation](https://docs.gunicorn.org/en/stable/settings.html#workers) recommends 
 > A positive integer generally in the [2, 4 x $(NUM_CORES)].

One core can handle 2 threads and the [t3.micro](https://aws.amazon.com/ec2/instance-types/t3/) that we are currently using has 2 vCPUs which means it supports 2 threads and is equivalent to 1 core. We can certainly increase this and I suspect we will have to in order to be able to support proxying through sync Python but I figure we can start with this for now.

