### PR TITLE
Add New Relic and Sentry monitoring

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=gunicorn -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/py_proxy/app.py
+++ b/py_proxy/app.py
@@ -3,6 +3,8 @@ import os
 
 import pyramid.config
 
+from py_proxy.sentry_filters import SENTRY_FILTERS
+
 
 def settings():
     """Return the app's configuration settings as a dict.
@@ -23,6 +25,12 @@ def settings():
     for param in result:
         if result[param] is None:
             raise ValueError(f"Param {param} must be provided.")
+
+    # Configure sentry
+    result.update(
+        {"h_pyramid_sentry.filters": SENTRY_FILTERS,}
+    )
+
     return result
 
 
@@ -32,4 +40,5 @@ def app():
     config.add_static_view(name="static", path="static")
     config.include("pyramid_jinja2")
     config.include("py_proxy.views")
+    config.include("h_pyramid_sentry")
     return config.make_wsgi_app()

--- a/py_proxy/sentry_filters.py
+++ b/py_proxy/sentry_filters.py
@@ -1,0 +1,6 @@
+"""Functions for filtering out events we don't want to report to Sentry.
+
+These are intended to be passed to h_pyramid_sentry.EventFilter.add_filters
+"""
+
+SENTRY_FILTERS = []

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ gunicorn
 pyramid
 pyramid-jinja2
 requests
+newrelic 

--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,4 @@ pyramid
 pyramid-jinja2
 requests
 newrelic 
+h_pyramid_sentry

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2019.9.11        # via requests
+certifi==2019.9.11        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 gunicorn==20.0.4
+h-pyramid-sentry==1.2.0
 hupper==1.9.1             # via pyramid
 idna==2.8                 # via requests
 jinja2==2.10.3            # via pyramid-jinja2
@@ -18,8 +19,9 @@ plaster==1.0              # via plaster-pastedeploy, pyramid
 pyramid-jinja2==2.8
 pyramid==1.10.4
 requests==2.22.0
+sentry-sdk==0.14.0        # via h-pyramid-sentry
 translationstring==1.3    # via pyramid
-urllib3==1.25.7           # via requests
+urllib3==1.25.7           # via requests, sentry-sdk
 venusian==3.0.0           # via pyramid
 webob==1.8.5              # via pyramid
 zope.deprecation==4.4.0   # via pyramid, pyramid-jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ hupper==1.9.1             # via pyramid
 idna==2.8                 # via requests
 jinja2==2.10.3            # via pyramid-jinja2
 markupsafe==1.1.1         # via jinja2, pyramid-jinja2
+newrelic==5.4.1.134
 pastedeploy==2.0.1        # via plaster-pastedeploy
 plaster-pastedeploy==0.7  # via pyramid
 plaster==1.0              # via plaster-pastedeploy, pyramid
@@ -25,4 +26,4 @@ zope.deprecation==4.4.0   # via pyramid, pyramid-jinja2
 zope.interface==4.6.0     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via gunicorn, plaster, pyramid, zope.deprecation, zope.interface
+# setuptools==45.0.0        # via gunicorn, plaster, pyramid, zope.deprecation, zope.interface

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv =
     dev: LEGACY_VIA_URL = {env:LEGACY_VIA_URL:http://localhost:9080}
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:via3}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
+    dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
 passenv =
     HOME
     dev: CHROME_EXTENSION_ID

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,13 @@ setenv =
     dev: NGINX_SERVER={env:NGINX_URL:http://localhost:9083}
     dev: CLIENT_EMBED_URL = {env:CLIENT_EMBED_URL:http://localhost:5000/embed.js}
     dev: LEGACY_VIA_URL = {env:LEGACY_VIA_URL:http://localhost:9080}
+    dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:via3}
+    dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
 passenv =
     HOME
     dev: CHROME_EXTENSION_ID
     dev: SENTRY_DSN
+    dev: NEW_RELIC_LICENSE_KEY
 deps =
     tests: coverage
     {tests,docstrings,checkdocstrings,lint}: beautifulsoup4
@@ -48,8 +51,9 @@ deps =
     pip-compile: pip-tools
 whitelist_externals =
     dev: gunicorn
+    dev: newrelic-admin
 commands =
-    dev: {posargs:gunicorn --timeout 0 -b "0.0.0.0:9082" --reload "py_proxy.app:app()"}
+    dev: {posargs:newrelic-admin run-program gunicorn --timeout 0 -b "0.0.0.0:9082" --reload "py_proxy.app:app()"}
     docker-compose: docker-compose {posargs}
     lint: pydocstyle --explain py_proxy
     lint: pydocstyle --config tests/.pydocstyle --explain tests


### PR DESCRIPTION
Add New Relic and Sentry monitoring into Python Pyramid application.

This is a partial fix for https://github.com/hypothesis/py-proxy/issues/10.