### PR TITLE
Add log catpure into supervisor

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -17,3 +17,11 @@ stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
+
+[eventlistener:logger]
+command=bin/logger
+buffer_size=100
+events=PROCESS_LOG
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
+


### PR DESCRIPTION
This is part of fixing papertrail logging and a partial fix for https://github.com/hypothesis/py-proxy/issues/10.