### PR TITLE
Strip client query params from thirdparty url

### DIFF
--- a/py_proxy/views.py
+++ b/py_proxy/views.py
@@ -1,8 +1,14 @@
 """The views for the Pyramid app."""
+import urllib
+
 import pyramid.httpexceptions as exc
 import requests
 from pyramid import response, view
 from pyramid.settings import asbool
+
+# Client configuration query parameters.
+OPEN_SIDEBAR = "via.open_sidebar"
+CONFIG_FROM_FRAME = "via.request_config_from_frame"
 
 
 @view.view_config(renderer="py_proxy:templates/index.html.jinja2", route_name="index")
@@ -39,20 +45,24 @@ def favicon(request):
 def pdf(request):
     """HTML page with client and the PDF embedded."""
     nginx_server = request.registry.settings["nginx_server"]
-    pdf_url = _drop_from_url_begining("/pdf/", request.path_qs)
+    pdf_url = _generate_url_without_client_query_params(
+        request.matchdict["pdf_url"], request.params
+    )
 
     return {
         "pdf_url": f"{nginx_server}/proxy/static/{pdf_url}",
         "client_embed_url": request.registry.settings["client_embed_url"],
-        "h_open_sidebar": asbool(request.params.get("via.open_sidebar", False)),
-        "h_request_config": request.params.get("via.request_config_from_frame", None),
+        "h_open_sidebar": asbool(request.params.get(OPEN_SIDEBAR, False)),
+        "h_request_config": request.params.get(CONFIG_FROM_FRAME, None),
     }
 
 
 @view.view_config(route_name="content_type")
 def content_type(request):
     """Routes the request according to the Content-Type header."""
-    url = _drop_from_url_begining("/", request.path_qs)
+    url = _generate_url_without_client_query_params(
+        request.matchdict["url"], request.params
+    )
 
     with requests.get(url, stream=True, allow_redirects=True) as rsp:
         if rsp.headers.get("Content-Type") in ("application/x-pdf", "application/pdf",):
@@ -62,6 +72,7 @@ def content_type(request):
                 )
             )
     via_url = request.registry.settings["legacy_via_url"]
+    url = _drop_from_url_begining("/", request.path_qs)
     return exc.HTTPFound(f"{via_url}/{url}")
 
 
@@ -69,6 +80,36 @@ def _drop_from_url_begining(drop_chars, url):
     """Drop drop_chars from begining of url."""
     drop_before = len(drop_chars)
     return url[drop_before:]
+
+
+def _generate_url_without_client_query_params(base_url, query_params):
+    """Return ``base_url`` with non-Via params from ``query_params`` appended.
+
+    Return ``base_url`` with all the non-Via query params from ``query_params``
+    appended to it as a query string. Any params in ``query_params`` that are
+    meant for Via (the ``"via.*`` query params) will be ignored and *not*
+    appended to the returned URL.
+
+    :param base_url: the protocol, domain and path, for example: https://thirdparty.url/foo.pdf
+    :type base_url: str
+
+    :param query_params: the query params to be added to base_url
+    :type query_params: dict
+
+    :return: ``base_url`` with the non-Via query params appended
+    :rtype: str
+    """
+    client_params = [OPEN_SIDEBAR, CONFIG_FROM_FRAME]
+    filtered_params = urllib.parse.urlencode(
+        {
+            param: value
+            for param, value in query_params.items()
+            if param not in client_params
+        }
+    )
+    if filtered_params:
+        return f"{base_url}?{filtered_params}"
+    return base_url
 
 
 def add_routes(config):


### PR DESCRIPTION
Previously the via.* query params used to configure the hypothesis client were not getting removed from requests to the thirdparty server or in the thirdparty url embedded in the page. This is a fix for https://github.com/hypothesis/py-proxy/issues/6.