### PR TITLE
Convert open_sidebar w/ asbool instead of int

### DIFF
--- a/py_proxy/views.py
+++ b/py_proxy/views.py
@@ -2,6 +2,7 @@
 import pyramid.httpexceptions as exc
 import requests
 from pyramid import response, view
+from pyramid.settings import asbool
 
 
 @view.view_config(renderer="py_proxy:templates/index.html.jinja2", route_name="index")
@@ -43,7 +44,7 @@ def pdf(request):
     return {
         "pdf_url": f"{nginx_server}/proxy/static/{pdf_url}",
         "client_embed_url": request.registry.settings["client_embed_url"],
-        "h_open_sidebar": int(request.params.get("via.open_sidebar", "0")),
+        "h_open_sidebar": asbool(request.params.get("via.open_sidebar", False)),
         "h_request_config": request.params.get("via.request_config_from_frame", None),
     }
 

--- a/tests/unit/py_proxy/views_test.py
+++ b/tests/unit/py_proxy/views_test.py
@@ -103,7 +103,7 @@ class TestPdfRoute:
             {
                 "pdf_url": "https://via3.hypothes.is/proxy/static/http://thirdparty.url",
                 "client_embed_url": "https://hypothes.is/embed.js",
-                "h_open_sidebar": 1,
+                "h_open_sidebar": True,
                 "h_request_config": "https://lms.hypothes.is",
             }
         )
@@ -157,9 +157,10 @@ class TestPdfRoute:
     @pytest.mark.parametrize(
         "request_url,expected_h_open_sidebar",
         [
-            ("/pdf/https://thirdparty.url/foo.pdf?via.open_sidebar=1", 1),
-            ("/pdf/https://thirdparty.url/foo.pdf?via.open_sidebar=0", 0),
-            ("/pdf/https://thirdparty.url/foo.pdf", 0),
+            ("/pdf/https://thirdparty.url/foo.pdf?via.open_sidebar=1", True),
+            ("/pdf/https://thirdparty.url/foo.pdf?via.open_sidebar=foo", False),
+            ("/pdf/https://thirdparty.url/foo.pdf?via.open_sidebar=0", False),
+            ("/pdf/https://thirdparty.url/foo.pdf", False),
         ],
     )
     def test_pdf_passes_open_sidebar_query_parameter_to_renderer(


### PR DESCRIPTION
asbool is a safer way of converting via.open_sidebar to a True/False value than using an int cast. Although the value does generally come from another Hypothesis owned tool, there's nothing stopping a user from misconfiguring a call and causing failures by providing some invalid string value like via.open_sidebar=foo. 