### PR TITLE
Support dynamically updated blocklist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ RUN mkdir /var/spool/squid \
 ENV HTTP_PROXY http://localhost:3128
 ENV HTTPS_PROXY http://localhost:3128
 
+ENV BLOCKLIST_PATH /tmp/blocklist.txt
+
 # Install app.
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ ENV HTTP_PROXY http://localhost:3128
 ENV HTTPS_PROXY http://localhost:3128
 
 ENV BLOCKLIST_PATH /tmp/blocklist.txt
+COPY --chown=via via/default-blocklist.txt /tmp/blocklist.txt
 
 # Install app.
 COPY . .

--- a/bin/fetch-blocklist
+++ b/bin/fetch-blocklist
@@ -13,5 +13,5 @@ if [ -z "${BLOCKLIST_PATH:-}" ]; then
 fi
 
 echo "Fetching blocklist from $BLOCKLIST_URL as $BLOCKLIST_PATH"
-curl --silent $BLOCKLIST_URL > $BLOCKLIST_PATH.new
+curl --silent --max-time 5 $BLOCKLIST_URL > $BLOCKLIST_PATH.new
 mv $BLOCKLIST_PATH.new $BLOCKLIST_PATH

--- a/bin/fetch-blocklist
+++ b/bin/fetch-blocklist
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+if [ -z "${BLOCKLIST_URL:-}" ]; then
+  echo "Skipping blocklist fetch. No BLOCKLIST_URL env var is configured."
+  exit 0
+fi
+
+if [ -z "${BLOCKLIST_PATH:-}" ]; then
+  echo "Skipping blocklist fetch. No BLOCKLIST_PATH env var is configured."
+  exit 0
+fi
+
+echo "Fetching blocklist from $BLOCKLIST_URL as $BLOCKLIST_PATH"
+curl --silent $BLOCKLIST_URL > $BLOCKLIST_PATH.new
+mv $BLOCKLIST_PATH.new $BLOCKLIST_PATH

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -39,6 +39,14 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 user=root
 
+[program:refresh_blocklist]
+command=sh -c "while true; do bin/fetch-blocklist; sleep 60; done"
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+user=via
+
 [eventlistener:logger]
 command=bin/logger
 buffer_size=100

--- a/tests/blocker_test.py
+++ b/tests/blocker_test.py
@@ -11,6 +11,12 @@ from via.blocker import Blocker
 # Simulated response from the proxied website, returned if the content is not blocked.
 UPSTREAM_CONTENT = "the upstream content"
 
+# The MIME type associated with `UPSTREAM_CONTENT`. This should be different
+# than the "text/html" type returned for error pages indicating blocked content,
+# so that tests can verify that the expected `Content-Type` header was returned
+# depending on whether the page was blocked.
+UPSTREAM_MIME_TYPE = "text/plain"
+
 # Tests for blocked and non-blocked responses.
 # These assume the default blocklist (via/default-blocklist.txt).
 block_examples = pytest.mark.parametrize(
@@ -62,7 +68,7 @@ class TestBlocker(object):
         if blocked:
             assert resp.headers["content-type"].startswith("text/html")
         else:
-            assert resp.headers["content-type"].startswith("text/plain")
+            assert resp.headers["content-type"].startswith(UPSTREAM_MIME_TYPE)
 
     def test_it_reads_blocklist_from_file(self, file_open, file_stat):
         blocklist_path = "/tmp/custom_blocklist.txt"
@@ -144,4 +150,4 @@ foo bar baz
 
 @wsgi.responder
 def upstream_app(environ, start_response):
-    return Response(UPSTREAM_CONTENT, mimetype="text/plain")
+    return Response(UPSTREAM_CONTENT, mimetype=UPSTREAM_MIME_TYPE)

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,10 @@ setenv =
     dev: H_EMBED_URL = {env:H_EMBED_URL:http://localhost:5000/embed.js}
 passenv =
     HOME
+    dev: BLOCKLIST_PATH
     {dev,tests}: LOCATION
 deps =
+    tests: mock
     tests: pytest
     {dev,tests}: -r requirements.txt
     {lint,dev}: flake8

--- a/via/app.py
+++ b/via/app.py
@@ -67,9 +67,14 @@ def app(environ, start_response):
     return pywb.apps.wayback.application(environ, start_response)
 
 
+blocker_kwargs = {}
+blocklist_path = os.environ.get("BLOCKLIST_PATH")
+if blocklist_path:
+    blocker_kwargs["blocklist_path"] = blocklist_path
+
 application = RequestHeaderSanitiser(app)
 application = ResponseHeaderSanitiser(application)
-application = Blocker(application)
+application = Blocker(application, **blocker_kwargs)
 application = UserAgentDecorator(application, "Hypothesis-Via")
 application = ConfigExtractor(application)
 application = wsgi.DispatcherMiddleware(

--- a/via/blocker.py
+++ b/via/blocker.py
@@ -7,22 +7,10 @@ from jinja2 import Environment, FileSystemLoader
 from werkzeug import wsgi
 from werkzeug.wrappers import BaseResponse as Response
 
+DEFAULT_BLOCKLIST_PATH = (
+    os.path.dirname(os.path.abspath(__file__)) + "/default-blocklist.txt"
+)
 TEMPLATES_DIR = os.path.dirname(os.path.abspath(__file__)) + "/../templates/"
-DOMAINS = [
-    {"domain": "nautil.us", "template": "disallow_access.html.jinja2", "status": 451},
-    {"domain": "m.nautil.us", "template": "disallow_access.html.jinja2", "status": 451},
-    {
-        "domain": "m.youtube.com",
-        "template": "could_not_process.html.jinja2",
-        "status": 200,
-    },
-    {
-        "domain": "www.youtube.com",
-        "template": "could_not_process.html.jinja2",
-        "status": 200,
-    },
-    {"domain": "vimeo.com", "template": "could_not_process.html.jinja2", "status": 200},
-]
 
 
 class Blocker(object):
@@ -30,16 +18,35 @@ class Blocker(object):
     """
     Blocker is a WSGI middleware that returns a static response when a
     request path matches a list of predefined domains.
+
+    The list of domains and the associated reasons for blocking them are defined
+    in a text file with lines in the form:
+
+    <domain> <reason>
+
+    Where "<reason>" is one of "publisher-blocked" or "blocked". Any lines
+    beginning with '#' are ignored. Any lines not in the above form are ignored.
     """
 
-    def __init__(self, application, domains=None):
+    def __init__(self, application, blocklist_path=DEFAULT_BLOCKLIST_PATH):
         self._application = application
         self._jinja_env = Environment(
             loader=FileSystemLoader(TEMPLATES_DIR), trim_blocks=True
         )
-        self._domains = domains or DOMAINS
+
+        self._blocklist_path = blocklist_path
+
+        # dict of domain to block reason.
+        self._blocked_domains = {}
+
+        # mtime of the blocklist file when it was last parsed.
+        self._blocklist_timestamp = 0
+
+        self._update_blocklist()
 
     def __call__(self, environ, start_response):
+        self._update_blocklist()
+
         url_to_annotate = wsgi.get_path_info(environ)[1:]
         parsed_url = urlparse(url_to_annotate)
 
@@ -48,12 +55,47 @@ class Blocker(object):
             parsed_url = urlparse(url_to_annotate)
 
         hostname_to_annotate = parsed_url.hostname
+        if hostname_to_annotate in self._blocked_domains:
+            reason = self._blocked_domains[hostname_to_annotate]
+            if reason == "publisher-blocked":
+                template_name = "disallow_access.html.jinja2"
+                status = 451
+            else:
+                template_name = "could_not_process.html.jinja2"
+                status = 200
 
-        for _d in self._domains:
-            if hostname_to_annotate and hostname_to_annotate == _d["domain"]:
-                template = self._jinja_env.get_template(_d["template"]).render(
-                    url_to_annotate=url_to_annotate
-                )
-                resp = Response(template, status=_d["status"], mimetype="text/html")
-                return resp(environ, start_response)
+            template = self._jinja_env.get_template(template_name).render(
+                url_to_annotate=url_to_annotate
+            )
+            resp = Response(template, status=status, mimetype="text/html")
+            return resp(environ, start_response)
+
         return self._application(environ, start_response)
+
+    def _update_blocklist(self):
+        blocklist_stinfo = os.stat(self._blocklist_path)
+        if blocklist_stinfo.st_mtime == self._blocklist_timestamp:
+            return
+
+        self._blocked_domains = _parse_blocklist(self._blocklist_path)
+        self._blocklist_timestamp = blocklist_stinfo.st_mtime
+
+
+def _parse_blocklist(path):
+    blocklist_content = open(path).read()
+    blocked_domains = {}
+
+    for line in blocklist_content.split("\n"):
+        line = line.strip()
+
+        if not line or line.startswith("#"):
+            # Empty or comment line.
+            continue
+
+        try:
+            domain, reason = line.split(" ")
+            blocked_domains[domain] = reason
+        except Exception:
+            pass
+
+    return blocked_domains

--- a/via/blocker.py
+++ b/via/blocker.py
@@ -82,20 +82,20 @@ class Blocker(object):
 
 
 def _parse_blocklist(path):
-    blocklist_content = open(path).read()
     blocked_domains = {}
 
-    for line in blocklist_content.split("\n"):
-        line = line.strip()
+    with open(path) as blocklist:
+        for line in blocklist:
+            line = line.strip()
 
-        if not line or line.startswith("#"):
-            # Empty or comment line.
-            continue
+            if not line or line.startswith("#"):
+                # Empty or comment line.
+                continue
 
-        try:
-            domain, reason = line.split(" ")
-            blocked_domains[domain] = reason
-        except Exception:
-            pass
+            try:
+                domain, reason = line.split(" ")
+                blocked_domains[domain] = reason
+            except Exception:
+                pass
 
     return blocked_domains

--- a/via/blocker.py
+++ b/via/blocker.py
@@ -4,12 +4,11 @@ import os
 from urlparse import urlparse
 
 from jinja2 import Environment, FileSystemLoader
+from pkg_resources import resource_filename
 from werkzeug import wsgi
 from werkzeug.wrappers import BaseResponse as Response
 
-DEFAULT_BLOCKLIST_PATH = (
-    os.path.dirname(os.path.abspath(__file__)) + "/default-blocklist.txt"
-)
+DEFAULT_BLOCKLIST_PATH = resource_filename("via", "default-blocklist.txt")
 TEMPLATES_DIR = os.path.dirname(os.path.abspath(__file__)) + "/../templates/"
 
 

--- a/via/default-blocklist.txt
+++ b/via/default-blocklist.txt
@@ -1,0 +1,17 @@
+# The blocklist lists domains that have been blocked for legal or operational
+# reasons.
+#
+# The format of each line is a domain name followed by a reason code. The reason
+# determines what error message and status code are returned.
+#
+# The available reasons are:
+#
+# "publisher-blocked" - The publisher asked us not to allow their site to be proxied
+# "blocked" - Generic reason used for other cases
+
+nautil.us publisher-blocked
+m.nautil.us publisher-blocked
+
+m.youtube.com blocked
+www.youtube.com blocked
+vimeo.com blocked


### PR DESCRIPTION
This PR implements a way for the Via blocklist to be updated without having to re-deploy the app, enabling us to respond quicker in the event that a domain needs to be blocked.

The dynamic blocklist works as follows:

- The Python app has been configured to read the blocklist from a text file specified via the `BLOCKLIST_PATH` env var. There is a default blocklist checked into the tree as `via/default-blocklist.txt` which serves as a reference for the file format. The file is read both on startup and when processing a request if the mtime of the file has changed since the last request. The OS's stat cache should make this check very fast when nothing has changed
- The docker container configures the blocklist path to point to a temporary file fetched from a URL specified via a `BLOCKLIST_URL` env var which is updated by a shell script that runs every 60 seconds.

To test this locally, you can do the following:

1. Check out this branch
2. Run `make docker`
3. Write the following to `custom-blocklist.txt`:
   ```
   elites.io blocked
   ```
4. In a terminal run `python -m SimpleHTTPServer 7001` in the directory where the blocklist is located
5. In another terminal run `make docker` and once the Docker image has been built, run:
   ```
   docker run -e BLOCKLIST_URL=http://$HOST_IP:7001/custom-blocklist.txt -it -p 9080:9080 hypothesis/via:latest
   ```
   Where `$HOST_IP` is the IP of the host machine as accessible from the Docker container. On macOS you can usually get this by running `ipconfig getifaddr en0` (assuming "en0" is your main network adapter). Some variation of that (`ipconfig getifaddr eth1`?) should work on Linux.
6. Try accessing http://0.0.0.0:9080/elites.io. You should see an error message
7. Try modifying the blocklist file, waiting a few seconds for the Docker container to print a "refresh_blocklist ..." message, and then accessing a URL to observe that the modified blocklist has been picked up

