### PR TITLE
Caching views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # py-proxy
 The python backend for the proxy-server.
+
+## See also
+
+ * [Caching strategy](docs/caching-strategy.md)

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -2,7 +2,7 @@
 
 ## Short `max-age`, long `stale-while-revalidate`
 
-One strategy we are using for caching the python calls is to provide both a
+One strategy we are using for caching the Python calls is to provide both a
 `max-age` and `stale-while-revalidate` value.
 
 Setting a `max-age` informs the consumer to not come back at all during the

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -1,0 +1,77 @@
+# Caching strategy
+
+## Short `max-age`, long `stale-while-revalidate`
+
+One strategy we are using for caching the python calls is to provide both a
+`max-age` and `stale-while-revalidate` value.
+
+Setting a `max-age` informs the consumer to not come back at all during the
+period as the content is known 'good'. Setting a `stale-while-revalidate` as well
+tells the consumer that they can safely use the content in their cache _while_ they check for updates.
+
+### An example user journey
+
+This should result in the following sort of behavior:
+
+ * User requests a resource for the first time
+    * __Result:__ Cache is populated
+ * User requests the same resource very quickly
+    * __Result:__ User does not even make a second request due to `max-age`
+ * User requests the same resource after the `max-age` has expired but before
+   the `stale-while-revalidate` has expired
+   * __Result:__
+     * User is immediately served the old cached content
+     * _Then asynchronously_ the content is checked for validity
+     * The cache updated as necessary
+ * User requests the same resource very quickly after receiving the previous copy is found 'stale'
+   * __Result:__ User is returned the updated content retrieved asynchronously last time
+
+
+This means the user may see a stale version on the second try if the content has changed,
+but can quickly fix this simply checking again.
+
+### How this works to our advantage
+
+In a very crude overview the proxy works by:
+
+ 1. A Python call to determine the type (PDF or not) - Slowish
+ 2. A call through NGINX to serve the content - Fastish
+
+If this call is made repeatedly the flow is:
+
+ 1. Python call #1
+ 2. NGINX call #1 (user journey 1 complete)
+ 3. Python call #2
+ 4. NGINX call #2 (user journey 2 complete)
+ 5. Python call #3
+ 6. NGINX call #3 (user journey 3 complete)
+
+
+Using the `stale-while-revalidate` the sequence from the users point of view becomes
+
+ 1. Python call #1
+ 2. NGINX call #1 (user journey 1 complete)
+ 3. NGINX call #2 (user journey 2 complete _with contents of Python call #1_)
+ 4. Python call #2 (async)
+ 5. NGINX call #3 (user journey 3 complete _with contents of Python call #2_)
+ 6. Python call #3 (async)
+
+With the caveat that the content is always one call out of date, this effectively
+means the Python call is made after the NGINX call.
+
+## Different timeouts on different calls
+
+The different calls have different time-outs as we can rely on some checks to
+effectively invalidate others.
+
+#### `content_type()` view
+
+* `max-age`: PDF: 5m, HTML 60s
+* PDFs should be relatively static, and take a while to update and change
+* HTML could be served from a Wiki or other volatile source
+
+#### `pdf()`  view
+
+* `max-age`: 1d
+* The PDF view only bakes in the URL for a PDF, and is basically unchanging
+* If the underlying content is no longer a PDF, then the `content_type()` timeouts should catch that

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -68,7 +68,7 @@ effectively invalidate others.
 
 * `max-age`: PDF: 5m, HTML 60s
 * PDFs should be relatively static, and take a while to update and change
-* HTML could be served from a Wiki or other volatile source
+* HTML could be served from a wiki or other volatile source
 
 #### `pdf()`  view
 

--- a/py_proxy/views.py
+++ b/py_proxy/views.py
@@ -45,7 +45,11 @@ def favicon(request):
 
 
 @view.view_config(
-    renderer="py_proxy:templates/pdfjs_viewer.html.jinja2", route_name="pdf"
+    renderer="py_proxy:templates/pdfjs_viewer.html.jinja2",
+    route_name="pdf",
+    # We can use a relatively long expiry here, as we only ever hit this after
+    # the content_type call, which has a shorter check
+    http_cache=(86400, {"public": True, "stale_while_revalidate": 86400}),
 )
 def pdf(request):
     """HTML page with client and the PDF embedded."""
@@ -70,22 +74,26 @@ def content_type(request):
     )
 
     with requests.get(url, stream=True, allow_redirects=True) as rsp:
-        if rsp.headers.get("Content-Type") in ("application/x-pdf", "application/pdf",):
+        if rsp.headers.get("Content-Type") in ("application/x-pdf", "application/pdf"):
             return exc.HTTPFound(
                 request.route_url(
-                    "pdf", pdf_url=request.matchdict["url"], _query=request.params
-                )
+                    "pdf", pdf_url=request.matchdict["url"], _query=request.params,
+                ),
+                headers=_caching_headers(max_age=300),
             )
 
     via_url = request.registry.settings["legacy_via_url"]
-    url = _drop_from_url_begining("/", request.path_qs)
-    return exc.HTTPFound(f"{via_url}/{url}")
+    url = request.path_qs.lstrip("/")
+
+    return exc.HTTPFound(f"{via_url}/{url}", headers=_caching_headers(max_age=60))
 
 
-def _drop_from_url_begining(drop_chars, url):
-    """Drop drop_chars from begining of url."""
-    drop_before = len(drop_chars)
-    return url[drop_before:]
+def _caching_headers(max_age, stale_while_revalidate=86400):
+    # I tried using webob.CacheControl for this but it's total rubbish
+    header = (
+        f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
+    )
+    return {"Cache-Control": header}
 
 
 def _generate_url_without_client_query_params(base_url, query_params):

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -1,0 +1,7 @@
+beautifulsoup4
+httpretty
+pytest
+factory-boy
+mock
+webtest
+h-matchers

--- a/tests/unit/py_proxy/views_test.py
+++ b/tests/unit/py_proxy/views_test.py
@@ -3,10 +3,26 @@ from unittest import mock
 import httpretty
 import pytest
 from bs4 import BeautifulSoup
+from h_matchers import Any
 from jinja2 import Environment, FileSystemLoader
 from pkg_resources import resource_filename
+from webtest import TestApp as WebTestApp  # No pytest, this isn't a test class
 
 from py_proxy import views
+from py_proxy.app import app
+
+
+def assert_cache_control(headers, max_age, stale_while_revalidate):
+    # pylint: disable=no-value-for-parameter
+    # Pylint doesn't seem to understand h_matchers here for some reason
+    assert dict(headers) == Any.dict.containing({"Cache-Control": Any.string()})
+
+    header = headers["Cache-Control"]
+    parts = sorted(header.split(", "))
+
+    assert "public" in parts
+    assert f"max-age={max_age}" in parts
+    assert f"stale-while-revalidate={stale_while_revalidate}" in parts
 
 
 class TestIndexRoute:
@@ -187,10 +203,20 @@ class TestPdfRoute:
         self, make_pyramid_request, request_url, expected_h_request_config
     ):
         request = make_pyramid_request(request_url, "http://example.com/foo.pdf")
-
         result = views.pdf(request)
 
         assert result["h_request_config"] == expected_h_request_config
+
+    def test_pdf_adds_caching_headers(self, test_app):
+        response = test_app.get("/pdf/http://example.com/foo.pdf")
+
+        assert_cache_control(
+            response.headers, max_age=86400, stale_while_revalidate=86400
+        )
+
+    @pytest.fixture
+    def test_app(self, pyramid_settings):
+        return WebTestApp(app(None, **pyramid_settings))
 
     @pytest.fixture
     def make_pyramid_request(self, make_pyramid_request):
@@ -288,6 +314,24 @@ class TestContentTypeRoute:
 
         # pylint: disable=no-member
         assert query_param not in httpretty.last_request().path
+
+    @pytest.mark.parametrize(
+        "content_type,max_age", [("application/pdf", 300), ("text/html", 60)],
+    )
+    def test_sets_correct_cache_control(
+        self, content_type, max_age, make_pyramid_request
+    ):
+        request = make_pyramid_request(
+            request_url="/http://example.com",
+            thirdparty_url="http://example.com",
+            content_type=content_type,
+        )
+
+        result = views.content_type(request)
+
+        assert_cache_control(
+            result.headers, max_age=max_age, stale_while_revalidate=86400
+        )
 
     @pytest.fixture
     def make_pyramid_request(self, make_pyramid_request):

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,7 @@ deps =
     dev: -r requirements-dev.in
     tests: coverage
     {tests,docstrings,checkdocstrings,lint}: -r requirements.txt
-    {tests,docstrings,checkdocstrings,lint}: beautifulsoup4
-    {tests,docstrings,checkdocstrings,lint}: httpretty
-    {tests,docstrings,checkdocstrings,lint}: pytest
-    {tests,docstrings,checkdocstrings,lint}: factory-boy
-    {tests,docstrings,checkdocstrings,lint}: mock
+    {tests,docstrings,checkdocstrings,lint}: -r requirements-test.in
     lint: pylint
     lint: pydocstyle
     {format,checkformatting}: black


### PR DESCRIPTION
For https://github.com/hypothesis/py-proxy/issues/30: Implement appropriate caching for the root endpoint

This adds caching timeouts for the pdf and content_type end-points. The values are different depending on context and the rationalle is explained in:

 * https://github.com/hypothesis/py-proxy/blob/caching-views/docs/caching-strategy.md
