### PR TITLE
Adding gzip and Brotli compression to the static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .tox
 *.pyc
 *.egg-info/
+py_proxy/static/**/*.gz
+py_proxy/static/**/*.br

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info/
 py_proxy/static/**/*.gz
 py_proxy/static/**/*.br
+build.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./nginx/nginx_envsubst.conf.template /var/lib/hypothesis/nginx_envsubst.conf.template
 COPY . .
 
-RUN make build
-
 USER hypothesis
 
 CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./nginx/nginx_envsubst.conf.template /var/lib/hypothesis/nginx_envsubst.conf.template
 COPY . .
 
+RUN make build
+
 USER hypothesis
 
 CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,11 @@ upgrade-package: python
 	@tox -qe pip-compile -- --upgrade-package $(name)
 
 .PHONY: docker
-docker:
-	@git archive --format=tar.gz HEAD | docker build -t hypothesis/py_proxy:$(DOCKER_TAG) -
+docker: build
+	@git archive --format=tar HEAD > build.tar
+	@tar --update -f build.tar py_proxy/static
+	@gzip -c build.tar | docker build -t hypothesis/py_proxy:$(DOCKER_TAG) -
+	@rm build.tar
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ help:
 	@echo "make help              Show this help message"
 	@echo "make dev               Run the app in the development server"
 	@echo 'make services          Run the services that `make dev` requires'
+	@echo 'make build            Prepare the build files'
 	@echo "make lint              Run the code linter(s) and print any warnings"
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
@@ -21,6 +22,10 @@ help:
 .PHONY: dev
 dev: python
 	@tox -qe dev
+
+.PHONY: build
+build: python
+	@tox -qe build
 
 .PHONY: services
 services: args?=up -d
@@ -75,6 +80,8 @@ docker:
 clean:
 	@find . -type f -name "*.py[co]" -delete
 	@find . -type d -name "__pycache__" -delete
+	@find . -type f -name "*.gz" -delete
+	@find . -type f -name "*.br" -delete
 
 .PHONY: python
 python:

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ deps =
     docker-compose: docker-compose
     pip-compile: pip-tools
     update-pdfjs: -e .
+    build: whitenoise
+    build: brotli
 whitelist_externals =
     dev: gunicorn
     dev: newrelic-admin
@@ -70,3 +72,4 @@ commands =
     pip-compile: pip-compile {posargs}
     update-pdfjs: sh bin/update-pdfjs
     update-pdfjs: python bin/create_pdf_template.py
+    build: python -m whitenoise.compress py_proxy/static


### PR DESCRIPTION
This is for: https://github.com/hypothesis/via3/issues/42

To test this you can:

* Run `make dev`
* Make the following request
```
curl -I --request GET --url http://0.0.0.0:9082/favicon.ico  --header 'accept-encoding: br, gzip'
```
* You should see no "Content-Encoding" in the response
* Run `make build`
* Restart the dev server
* Make the same request, you should now see "Content-Encoding: br"

----

The result is most dramatic on the largest files:

```
curl -I --request GET --url http://0.0.0.0:9082/vendor/pdfjs-2/build/pdf.worker.js --header 'accept-encoding: br, gzip'
```
Content-Length: 233825

```
curl -I --request GET --url http://0.0.0.0:9082/vendor/pdfjs-2/build/pdf.worker.js --header 'accept-encoding: gzip'
```
Content-Length: 308992