### PR TITLE
Don't bind Gunicorn to port 9082 in prod

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=newrelic-admin run-program gunicorn -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
:9082 is only used in development, not in production. In production
NGINX proxies to Gunicorn on unix:/tmp/gunicorn-web.sock, so there's no
need for Gunicorn to also bind to :9082 in production.