### PR TITLE
Fixing the name of the WSGI app creation function

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,14 +5,14 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:nginx]
-command=nginx 
+command=nginx
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=newrelic-admin run-program gunicorn -b 0.0.0.0:9082 py_proxy.app:app() -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn -b 0.0.0.0:9082 py_proxy.app:create_app() -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
This is my mistake. I changed the name from `app()` to `create_app()` but missed the supervisor conf.