### PR TITLE
Remove Brolti compression as Cloudflare ignores it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 *.pyc
 *.egg-info/
 py_proxy/static/**/*.gz
-py_proxy/static/**/*.br
 build.tar

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ clean:
 	@find . -type f -name "*.py[co]" -delete
 	@find . -type d -name "__pycache__" -delete
 	@find . -type f -name "*.gz" -delete
-	@find . -type f -name "*.br" -delete
 
 .PHONY: python
 python:

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ deps =
     pip-compile: pip-tools
     update-pdfjs: -e .
     build: whitenoise
-    build: brotli
 whitelist_externals =
     dev: gunicorn
     dev: newrelic-admin


### PR DESCRIPTION
But it will apparently request resources with gzip so that's nice.

Brotli compression can however be enabled at a site level in Cloudflare.