### PR TITLE
Fix query string bugs relating to repeated elements

### DIFF
--- a/tests/unit/via/views/test__query_params.py
+++ b/tests/unit/via/views/test__query_params.py
@@ -1,0 +1,59 @@
+import pytest
+from webob.multidict import MultiDict, NestedMultiDict
+
+from via.views._query_params import QueryParams
+
+
+class TestQueryParams:
+    ORIGINAL_URL = "http://example.com"
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {QueryParams.CONFIG_FROM_FRAME: "test_1"},
+            {
+                QueryParams.CONFIG_FROM_FRAME: "test_1",
+                QueryParams.OPEN_SIDEBAR: "test_2",
+            },
+        ],
+    )
+    def test_build_url_strips_via_params(self, params):
+        params.update({"p1": "v1", "p2": "v2"})
+
+        url = QueryParams.build_url(self.ORIGINAL_URL, params, strip_via_params=True)
+
+        assert url == self.ORIGINAL_URL + "?p1=v1&p2=v2"
+
+    def test_upper_case_params_are_different(self):
+        param = QueryParams.OPEN_SIDEBAR.upper()
+        url = QueryParams.build_url(
+            self.ORIGINAL_URL, {param: "test_1"}, strip_via_params=True
+        )
+
+        assert url == f"http://example.com?{param}=test_1"
+
+    def test_build_url_can_leave_via_params(self):
+        url = QueryParams.build_url(
+            self.ORIGINAL_URL,
+            {"a": "test_1", QueryParams.OPEN_SIDEBAR: "test_2"},
+            strip_via_params=False,
+        )
+
+        assert url == self.ORIGINAL_URL + "?a=test_1&via.open_sidebar=test_2"
+
+    def test_build_url_handles_multi_dicts(self):
+        url = QueryParams.build_url(
+            self.ORIGINAL_URL,
+            NestedMultiDict(
+                MultiDict({"a": "a1", QueryParams.OPEN_SIDEBAR: "v1"}),
+                MultiDict({"a": "a2", QueryParams.OPEN_SIDEBAR: "v2"}),
+            ),
+            strip_via_params=True,
+        )
+
+        assert url == self.ORIGINAL_URL + "?a=a1&a=a2"
+
+    @pytest.mark.parametrize("url", ["", "jddf://example.com", "http://"])
+    def test_build_url_handles_malformed_urls(self, url):
+        QueryParams.build_url(url, {}, strip_via_params=True)

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -3,11 +3,7 @@
 from pyramid import view
 from pyramid.settings import asbool
 
-from via.views._query_params import (
-    CONFIG_FROM_FRAME,
-    OPEN_SIDEBAR,
-    strip_client_query_params,
-)
+from via.views._query_params import QueryParams
 
 
 @view.view_config(
@@ -20,12 +16,14 @@ from via.views._query_params import (
 def view_pdf(request):
     """HTML page with client and the PDF embedded."""
     nginx_server = request.registry.settings["nginx_server"]
-    pdf_url = strip_client_query_params(request.matchdict["pdf_url"], request.params)
+    pdf_url = QueryParams.build_url(
+        request.matchdict["pdf_url"], request.params, strip_via_params=True
+    )
 
     return {
         "pdf_url": f"{nginx_server}/proxy/static/{pdf_url}",
         "client_embed_url": request.registry.settings["client_embed_url"],
-        "h_open_sidebar": asbool(request.params.get(OPEN_SIDEBAR, False)),
-        "h_request_config": request.params.get(CONFIG_FROM_FRAME, None),
+        "h_open_sidebar": asbool(request.params.get(QueryParams.OPEN_SIDEBAR, False)),
+        "h_request_config": request.params.get(QueryParams.CONFIG_FROM_FRAME, None),
         "static_url": request.static_url,
     }


### PR DESCRIPTION
 * Also separate out testing of the component
 * Remove duplicated testing in other places
 * Use the same code more times
   * Rather than inventing a new way at the end of get_content_type()