### PR TITLE
redirect nginx access log 

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,7 @@
 daemon off;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
+access_log /dev/stdout;
 worker_rlimit_nofile 7192;
 
 events {


### PR DESCRIPTION
to stdout so that it gets written to the Elastic Beanstalk host's logs (which then forward to paper trail)