### PR TITLE
Move scripts and CSS to footer for faster loading

### DIFF
--- a/bin/create_pdf_template.py
+++ b/bin/create_pdf_template.py
@@ -12,6 +12,7 @@ ITEMS_TO_REMOVE = [
     '<script src="viewer.js"></script>',
 ]
 
+
 def _insert(contents, where, pattern, new_content):
     index = contents.index(pattern)
 

--- a/bin/create_pdf_template.py
+++ b/bin/create_pdf_template.py
@@ -5,6 +5,12 @@ from pkg_resources import resource_filename
 SOURCE_FILE = resource_filename("via", "static/vendor/pdfjs-2/web/viewer.html")
 TARGET_FILE = resource_filename("via", "templates/pdf_wrapper.html.jinja2")
 
+# We want control over where these are so we'll remove them
+ITEMS_TO_REMOVE = [
+    '<link rel="stylesheet" href="viewer.css">',
+    '<script src="../build/pdf.js"></script>',
+    '<script src="viewer.js"></script>',
+]
 
 def _insert(contents, where, pattern, new_content):
     index = contents.index(pattern)
@@ -43,6 +49,12 @@ if __name__ == "__main__":
             "\n\n<!--\nTHIS CONTENT IS AUTO GENERATED. DO NOT EDIT!\n"
             "FROM 'bin/create_pdf_template.pdf'\n-->\n",
         )
+
+    for item in ITEMS_TO_REMOVE:
+        if item not in template:
+            raise ValueError(f"Expected to find '{item}'")
+        print(f"Removing: {item}")
+        template = template.replace(item, f"<!-- {item} -->")
 
     with open(TARGET_FILE, "w") as handle:
         handle.write(template)

--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -16,6 +16,9 @@
     </script>
 
     <link rel="icon" href="{{ static_url("via:static/favicon.ico") }}" type="image/x-icon" />
+{% endblock %}
+
+{% block footer %}
     <script src="{{ static_url("via:static/js/pdfjs-init.js") }}"></script>
 
     {# Configure Hypothesis client. #}
@@ -35,4 +38,7 @@
         };
       }
     </script>
+    <link rel="stylesheet" href="viewer.css">
+    <script src="../build/pdf.js"></script>
+    <script src="viewer.js"></script>
 {% endblock %}

--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -10,15 +10,22 @@
       the rest of via, however, we serve it with the PDF.js viewer application.
     -#}
     <link rel="canonical" href="{{ url }}"/>
-    <script>
-    window.PDF_URL = "{{ pdf_url }}";
-    window.CLIENT_EMBED_URL = "{{ client_embed_url }}";
-    </script>
+
+    <link rel="preload" as="fetch" href="{{ pdf_url }}" crossorigin>
+    <link rel="preload" as="worker" href="../build/pdf.worker.js">
+    <link rel="preload" as="script" href="{{ client_embed_url }}">
 
     <link rel="icon" href="{{ static_url("via:static/favicon.ico") }}" type="image/x-icon" />
+
+    <link rel="stylesheet" href="viewer.css">
 {% endblock %}
 
 {% block footer %}
+    <script>
+        window.PDF_URL = "{{ pdf_url }}";
+        window.CLIENT_EMBED_URL = "{{ client_embed_url }}";
+    </script>
+
     <script src="{{ static_url("via:static/js/pdfjs-init.js") }}"></script>
 
     {# Configure Hypothesis client. #}
@@ -38,7 +45,7 @@
         };
       }
     </script>
-    <link rel="stylesheet" href="viewer.css">
+
     <script src="../build/pdf.js"></script>
     <script src="viewer.js"></script>
 {% endblock %}

--- a/via/templates/pdf_wrapper.html.jinja2
+++ b/via/templates/pdf_wrapper.html.jinja2
@@ -35,15 +35,15 @@ See https://github.com/adobe-type-tools/cmap-resources
     <title>PDF.js viewer</title>{% block head %}{% endblock %}
 
 
-    <link rel="stylesheet" href="viewer.css">
+    <!-- <link rel="stylesheet" href="viewer.css"> -->
 
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="../build/pdf.js"></script>
+<!-- <script src="../build/pdf.js"></script> -->
 
 
-    <script src="viewer.js"></script>
+    <!-- <script src="viewer.js"></script> -->
 
   </head>
 


### PR DESCRIPTION
Using pre-load to get assets loading in parallel (including the PDF!) and deferring javascript to the end of the page.

For: https://github.com/hypothesis/via3/issues/44