### PR TITLE
Revert "redirect nginx access log "

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,7 +1,6 @@
 daemon off;
 pid /var/lib/hypothesis/nginx.pid;
 error_log /dev/stderr;
-access_log /dev/stdout;
 worker_rlimit_nofile 7192;
 
 events {


### PR DESCRIPTION
Reverts hypothesis/via3#82 because it was crashing NGINX: `nginx: [emerg] "access_log" directive is not allowed here in /etc/nginx/nginx.conf:4`