### PR TITLE
Add crossorigin to h prefetch as it is cross-origin in QA/prod

### DIFF
--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -13,7 +13,7 @@
 
     <link rel="preload" as="fetch" href="{{ pdf_url }}" crossorigin>
     <link rel="preload" as="worker" href="../build/pdf.worker.js">
-    <link rel="preload" as="script" href="{{ client_embed_url }}">
+    <link rel="preload" as="script" href="{{ client_embed_url }}" crossorigin>
 
     <link rel="icon" href="{{ static_url("via:static/favicon.ico") }}" type="image/x-icon" />
 


### PR DESCRIPTION
Looks like one of the pre-fetches needs to be cross-origin when not run locally.

For https://github.com/hypothesis/via3/issues/44