### PR TITLE
Remove worker pre-load as this doesn't seem to work either

### DIFF
--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -12,8 +12,6 @@
     <link rel="canonical" href="{{ url }}"/>
 
     <link rel="preload" as="fetch" href="{{ pdf_url }}" crossorigin>
-    <link rel="preload" as="worker" href="../build/pdf.worker.js">
-
     <link rel="icon" href="{{ static_url("via:static/favicon.ico") }}" type="image/x-icon" />
 
     <link rel="stylesheet" href="viewer.css">


### PR DESCRIPTION
Chrome tools:

 * Recommend we pre-load this
 * Don't use it if we load it as "fetch" or "script"
 * Complain if we load it as "worker", "sharedworker" or "serviceworker"
 * Don't appear to like CORS off, with "anonymous" or "use-credentials"

Basically I can't get this to work. This person is having the exact same trouble too:

https://stackoverflow.com/questions/54550504/how-to-preload-web-worker-asset
