### PR TITLE
add access log forwarding to stdout 

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,7 +33,7 @@ http {
         include /var/lib/hypothesis/nginx_envsubst.conf;
         listen 9083;
         merge_slashes off;
-
+        access_log /dev/stdout;
         location ~ /proxy/static/(?<proxied_uri>.*) {
             set $upstream $proxied_uri$is_args$args;
             proxy_ssl_server_name on;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,6 +13,7 @@ http {
     sendfile        on;
     keepalive_timeout  65;
     resolver 8.8.8.8 ipv6=off;
+    access_log /dev/stdout;
 
     # The AWS load balancer talks to the server via http so use the scheme the
     # client provided in the originating request via AWS's X-Forwarded-Proto
@@ -33,7 +34,6 @@ http {
         include /var/lib/hypothesis/nginx_envsubst.conf;
         listen 9083;
         merge_slashes off;
-        access_log /dev/stdout;
         location ~ /proxy/static/(?<proxied_uri>.*) {
             set $upstream $proxied_uri$is_args$args;
             proxy_ssl_server_name on;


### PR DESCRIPTION
So that it will be recorded on the docker host and forwarded to papertrail. 