### PR TITLE
Disable caching to prevent redirects from being cached

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -52,9 +52,10 @@ http {
             proxy_set_header Cookie $stripped_cookie;
             proxy_set_header Authorization "";
 
-            # Cache for a 1 day, but allow serving from cache while revalidating for a week
+            # Disable caching to prevent Cloudflare from kicking in where this
+            # might be a temporary redirect to an expiring PDF link
             proxy_hide_header "Cache-Control";
-            add_header "Cache-Control" "public, max-age=86400, stale-while-revalidate=604800";
+            add_header "Cache-Control" "no-cache, no-store, must-revalidate";
 
             # Do not allow the third party server to set cookies.
             add_header "Set-Cookie" "";


### PR DESCRIPTION
Details in https://github.com/hypothesis/via3/issues/98

Caching redirects is dangerous, as they can point to temporary resources