### PR TITLE
Disable cache for redirects only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache --virtual build-deps \
   && apk del build-deps
 
 COPY ./conf/supervisord.conf ./conf/supervisord.conf
-COPY ./conf/nginx.conf /etc/nginx/nginx.conf
+COPY ./conf/nginx/* /etc/nginx/
 COPY ./conf/nginx_envsubst.conf.template /var/lib/hypothesis/nginx_envsubst.conf.template
 COPY . .
 

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -34,33 +34,29 @@ http {
         include /var/lib/hypothesis/nginx_envsubst.conf;
         listen 9083;
         merge_slashes off;
+
         location ~ /proxy/static/(?<proxied_uri>.*) {
-            set $upstream $proxied_uri$is_args$args;
-            proxy_ssl_server_name on;
-            proxy_pass $upstream;
-            proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1;
+            proxy_intercept_errors on;
+            error_page 301 302 307 = @handle_redirect;
 
-            # Strip hypothesis cookies and authorization header.
-            set $stripped_cookie $http_cookie;
+            include via/direct_proxy.conf;
 
-            if ($stripped_cookie ~ "(.*)\s*auth=[^;]+;?(.*)") {
-                set $stripped_cookie $1$2;
-            }
-            if ($stripped_cookie ~ "(.*)\s*session=[^;]+;?(.*)") {
-                set $stripped_cookie $1$2;
-            }
-            proxy_set_header Cookie $stripped_cookie;
-            proxy_set_header Authorization "";
+            # Cache for a 1 day, but allow serving from cache while revalidating for a week
+            proxy_hide_header "Cache-Control";
+            add_header "Cache-Control" "public, max-age=86400, stale-while-revalidate=604800";
+
+            add_header "X-Via" "static-proxy, direct";
+        }
+
+        location @handle_redirect {
+            include via/direct_proxy.conf;
 
             # Disable caching to prevent Cloudflare from kicking in where this
             # might be a temporary redirect to an expiring PDF link
             proxy_hide_header "Cache-Control";
             add_header "Cache-Control" "no-cache, no-store, must-revalidate";
 
-            # Do not allow the third party server to set cookies.
-            add_header "Set-Cookie" "";
-            proxy_hide_header "Access-Control-Allow-Origin";
-            add_header "Access-Control-Allow-Origin" $access_control_allow_origin;
+            add_header "X-Via" "static-proxy, redirect";
         }
 
         location / {
@@ -74,6 +70,8 @@ http {
             proxy_set_header X-Forwarded-Server $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Request-Start "t=${msec}";
+
+            add_header "X-Via" "compute";
         }
     }
 }

--- a/conf/nginx/via/direct_proxy.conf
+++ b/conf/nginx/via/direct_proxy.conf
@@ -1,0 +1,21 @@
+set $upstream $proxied_uri$is_args$args;
+proxy_ssl_server_name on;
+proxy_pass $upstream;
+proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1;
+
+# Strip hypothesis cookies and authorization header.
+set $stripped_cookie $http_cookie;
+
+if ($stripped_cookie ~ "(.*)\s*auth=[^;]+;?(.*)") {
+    set $stripped_cookie $1$2;
+}
+if ($stripped_cookie ~ "(.*)\s*session=[^;]+;?(.*)") {
+    set $stripped_cookie $1$2;
+}
+proxy_set_header Cookie $stripped_cookie;
+proxy_set_header Authorization "";
+
+# Do not allow the third party server to set cookies.
+add_header "Set-Cookie" "";
+proxy_hide_header "Access-Control-Allow-Origin";
+add_header "Access-Control-Allow-Origin" $access_control_allow_origin;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     environment:
       - ACCESS_CONTROL_ALLOW_ORIGIN=http://localhost:9082
     volumes:
-      - ./conf/nginx.conf:/etc/nginx/nginx.conf
+      - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./conf/nginx/via:/etc/nginx/via
       - ./conf/nginx_envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template
     command: bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
 


### PR DESCRIPTION
Details in https://github.com/hypothesis/via3/issues/98, but basically our "PDF" URL can in fact be a redirect to a PDF etc. This could refer to a resource that expires, so it's not safe to signal it can be cached.