### PR TITLE
Encode the path so we reliably pass on encoded values

### DIFF
--- a/via/views/_query_params.py
+++ b/via/views/_query_params.py
@@ -1,6 +1,6 @@
 """Methods and data relating to query parameters."""
 
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, unquote, urlencode, urlparse
 
 from webob.multidict import MultiDict
 
@@ -32,4 +32,11 @@ class QueryParams:
             for key in via_keys:
                 query.pop(key, None)
 
-        return urlparse(url)._replace(query=urlencode(query)).geturl()
+        url = urlparse(url)
+
+        return url._replace(
+            # Ensure the path is quoted regardless of how we received it
+            path=quote(unquote(url.path)),
+            # Encode the new query parameters
+            query=urlencode(query),
+        ).geturl()


### PR DESCRIPTION
Things to test:

Route by content:

* Does it request the URL correctly when checking the type?
* If it's PDF does it redirect correctly?
* If it's not a PDF does it redirect correctly?

View PDF:

 * TBA

As commas and spaces behave differently, we should check that we preserve escaping for both if present.

We believe it is ok to add encoding where it was not before, but not ok to remove it.
