### PR TITLE
Add config_frame_ancestor_level param to hypothesisConfig

### DIFF
--- a/templates/client_config.js.jinja2
+++ b/templates/client_config.js.jinja2
@@ -1,14 +1,3 @@
 window.hypothesisConfig = function() {
-  return {
-    showHighlights: true,
-    appType: 'via',
-
-    {% if h_request_config %}
-    requestConfigFromFrame: '{{ h_request_config }}',
-    {% endif %}
-
-    {% if h_open_sidebar %}
-    openSidebar: true,
-    {% endif %}
-  };
+  return {{ hypothesis_config | tojson }};
 }


### PR DESCRIPTION
Note: This PR must land first https://github.com/hypothesis/lms/pull/1552

Change requestConfigFromFrame from a string to an object as such:

```
 requestConfigFromFrame: {
  origin: <string>
  ancestorLevel: <number>
},

```
This extra numerical param (ancestorLevel) informs the client which parent frame to send RCP requests to.

![Screen Shot 2020-03-11 at 4 46 01 PM](https://user-images.githubusercontent.com/3939074/76474772-e2990480-63b9-11ea-8b96-c418f1d254c6.png)


Test URL
http://localhost:9080/https://readthedocs.org/projects/python-packaging-user-guide/downloads/pdf/latest/?via.open_sidebar=1&amp;via.request_config_from_frame=http%3A%2F%2Flocalhost%3A8001&amp;via.config_frame_ancestor_level=2

Update:
Changed this around to be built from a single json object to make the template a bit more simple. Note this still does not resolve the XSS injection issue we have and it does not appear we have magic bullet filter we can use in jinja to escape it e.g. `return {{ hypothesis_config | tojson | e }};` breaks the json object. I suspect we'll need to to the escaping in python.
