### PR TITLE
Update zope to fix broken builds with setuptools errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ venusian==3.0.0           # via pyramid
 webob==1.8.6              # via pyramid
 whitenoise==5.0.1         # via -r requirements.in
 zope.deprecation==4.4.0   # via pyramid, pyramid-jinja2
-zope.interface==4.6.0     # via pyramid
+zope.interface==4.7.2     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
From: https://github.com/hypothesis/bouncer/pull/315 This is the result of running:
```
make upgrade-package name=zope.interface
```