### PR TITLE
Add test coverage for commas in URLs

### DIFF
--- a/tests/unit/via/views/test_route_by_content.py
+++ b/tests/unit/via/views/test_route_by_content.py
@@ -36,19 +36,21 @@ class TestRouteByContent:
 
     def test_we_call_third_parties_correctly(self, call_route_by_content):
         call_route_by_content(
-            target_url="http://example.com/path?a=b", params={"other": "value"}
+            target_url="http://example.com/path%2C?a=b", params={"other": "value"}
         )
 
         # The fact we got this far means we hit the right host as registered
         # with httpretty, so we just need to check the path. Which is just as
         # well, as httpretty doesn't appear to store the full URL
 
-        assert httpretty.last_request.path == "/path?a=b"  # pylint: disable=no-member
+        assert (
+            httpretty.last_request.path == "/path%2C?a=b"  # pylint: disable=no-member
+        )
 
     def test_redirects_to_pdf_view_for_pdfs_have_the_correct_params(
         self, call_route_by_content
     ):
-        url = "http://example.com/path?a=b"
+        url = "http://example.com/path%2C?a=b"
         results = call_route_by_content(
             "application/pdf", url, params={"other": "value"}
         )
@@ -58,14 +60,15 @@ class TestRouteByContent:
     def test_requests_to_legacy_via_are_formatted_correctly(
         self, call_route_by_content
     ):
-        url = "http://example.com/path?a=b"
+        path = "http://example.com/path%2C"
+        url = path + "?a=b"
         results = call_route_by_content("text/html", url, params={"other": "value"})
 
         # This is horrible, but the params just get blended together. It's
         # via's job to separate them on the other side
-        assert results.location == Any.url.with_path(
-            "http://example.com/path"
-        ).with_query({"a": "b", "other": "value"})
+        assert results.location == Any.url.with_path(path).with_query(
+            {"a": "b", "other": "value"}
+        )
 
     @pytest.mark.parametrize(
         "content_type,max_age", [("application/pdf", 300), ("text/html", 60)],

--- a/tests/unit/via/views/test_view_pdf.py
+++ b/tests/unit/via/views/test_view_pdf.py
@@ -21,7 +21,12 @@ class TestViewPDF:
         assert isinstance(response["client_embed_url"], Markup)
 
     @pytest.mark.parametrize(
-        "pdf_url", ["http://example.com/foo.pdf", "http://example.com/foo.pdf?a=1&a=2"]
+        "pdf_url",
+        [
+            "http://example.com/foo.pdf",
+            "http://example.com/foo.pdf?a=1&a=2",
+            "http://example.com/foo%2C.pdf?a=1&a=2",
+        ],
     )
     def test_we_pass_through_the_url_exactly(
         self, call_view_pdf, pdf_url, pyramid_settings


### PR DESCRIPTION
This is explictly to test the case we encountered with Canvas which
is very sensitive to the URL you request as it is matched against
a crypotgraphic hash.