### PR TITLE
Add support for Google Drive API looking up mime-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info/
 via/static/**/*.gz
 build.tar
+.devdata.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 
 USER hypothesis
 
-CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf
+CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ help:
 dev: python
 	@tox -qe dev
 
+.PHONY: devdata
+devdata: python
+	@tox -qe dev -- python bin/devdata.py
+
 .PHONY: build
 build: python
 	@tox -qe build

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ installation process:
 
     cd via3
 
+### Setup data required to run the server
+
+You will need certain items (like Google API keys) to run locally properly.
+To do that you can run:
+
+    make devdata
+
 ### Run the services with Docker Compose
 
 Start the services that Via 3 requires (currently just NGINX) using Docker

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -1,0 +1,19 @@
+"""Copy tox environment variables from devdata."""
+
+import os
+from shutil import copy2, rmtree
+from subprocess import check_call
+from tempfile import mkdtemp
+
+temp_dir = mkdtemp()
+target = os.path.abspath("../.devdata.env")
+
+try:
+    check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", temp_dir])
+    copy2(os.path.join(temp_dir, "via/devdata.env"), target)
+
+    print(f"Created {target}")
+
+finally:
+    if os.path.isdir(temp_dir):
+        rmtree(temp_dir)

--- a/conf/nginx/envsubst.conf.template
+++ b/conf/nginx/envsubst.conf.template
@@ -1,1 +1,2 @@
 set $access_control_allow_origin "${ACCESS_CONTROL_ALLOW_ORIGIN}";
+set $google_api_key "${GOOGLE_API_KEY}";

--- a/conf/nginx/via/direct_proxy.conf
+++ b/conf/nginx/via/direct_proxy.conf
@@ -3,10 +3,23 @@ proxy_ssl_server_name on;
 # Replace the default url-decoded $uri with the $request_uri which is as
 # we received it without url-decoding
 rewrite ^ $request_uri;
+
+# Redirect Google Drive requests to the API using our key
+# Some weird things:
+# * A rule that starts with http will _immediately_ issue a proxy_redirect
+# * So we seemingly pointlessly capture (https) and replace it
+# * This way the _result_ starts with https, but the _rule_ doesn't and we can carry on
+# * NGINX will _merge_ queries you add, not replace them unless you put '?' on the end
+rewrite ^/proxy/static/(https)://drive.google.com/uc\?id=(.*)&export=download$ $1://www.googleapis.com/drive/v3/files/$2?key=$google_api_key&alt=media? break;
+
 # Remove our URL part off of the front
-rewrite ^/proxy/static/(.*) $1 break;
+# The ? at the end means we strip off the args part (which we will add back on later)
+# I have no idea why this works to be honest but it seems to
+rewrite ^/proxy/static/(.*)$ $1? break;
+
 # The proxy directly to the resulting URL
-proxy_pass $uri;
+# Add back on the args which we stripped above so we don't get them twice
+proxy_pass $uri$is_args$args;
 
 proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
       - '127.0.0.1:9083:9083'
     environment:
       - ACCESS_CONTROL_ALLOW_ORIGIN=http://localhost:9082
+      - GOOGLE_API_KEY
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./conf/nginx/via:/etc/nginx/via
       - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template
-    command: /bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
+    command: /bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
 

--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+from h_matchers import Any
 from requests import Response
 from requests.exceptions import (
     MissingSchema,
@@ -14,16 +15,13 @@ from via.get_url_details import get_url_details
 
 
 class TestGetURLDetails:
+    GOOGLE_API_KEY = "google_api_key"
+
     @pytest.mark.parametrize(
         "content_type,status_code", (("text/html", 501), ("application/pdf", 200))
     )
     def test_it_calls_get_for_normal_urls(self, requests, content_type, status_code):
-        response = Response()
-        response.raw = BytesIO(b"")
-        response.headers = {"Content-Type": content_type}
-        response.status_code = status_code
-        requests.get.return_value = response
-
+        requests.get.return_value = self._make_response(content_type, status_code)
         url = "http://example.com"
 
         result = get_url_details(url)
@@ -31,14 +29,40 @@ class TestGetURLDetails:
         assert result == (content_type, status_code)
         requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
 
-    def test_it_assumes_pdf_with_a_google_drive_url(self, requests):
-        result = get_url_details(
-            "https://drive.google.com/uc?id=--FILEID--&export=download"
-        )
+    def test_it_assumes_google_documents_are_pdfs_without_an_api_key(
+        self, requests, google_drive_url
+    ):
+        result = get_url_details(google_drive_url)
 
         assert result == ("application/pdf", 200)
-
         requests.get.assert_not_called()
+
+    @pytest.mark.usefixtures("with_api_key")
+    def test_it_calls_google_drive_api_with_api_key(self, requests, google_drive_url):
+        requests.get.return_value = self._make_response(
+            content_type="application/json", body='{"mimeType": "application/pdf"}'
+        )
+
+        get_url_details(google_drive_url)
+
+        requests.get.assert_called_once_with(
+            Any.url.matching(
+                "https://www.googleapis.com/drive/v3/files/--FILEID--"
+            ).with_query({"key": self.GOOGLE_API_KEY})
+        )
+
+    @pytest.mark.usefixtures("with_api_key")
+    def test_it_handles_bad_google_json_responses(self, requests, google_drive_url):
+        requests.get.return_value = self._make_response(
+            content_type="application/json", body="{"
+        )
+
+        with pytest.raises(UpstreamServiceError):
+            get_url_details(google_drive_url)
+
+    @pytest.fixture
+    def google_drive_url(self):
+        return "https://drive.google.com/uc?id=--FILEID--&export=download"
 
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))
     def test_it_raises_BadURL_for_invalid_urls(self, bad_url):
@@ -61,6 +85,21 @@ class TestGetURLDetails:
 
         with pytest.raises(expected_exception):
             get_url_details("http://example.com")
+
+    @staticmethod
+    def _make_response(content_type="application/pdf", status_code=200, body=None):
+        response = Response()
+
+        response.raw = BytesIO(body.encode("utf-8") if body else b"")
+        response.headers = {"Content-Type": content_type}
+        response.status_code = status_code
+
+        return response
+
+    @pytest.fixture
+    def with_api_key(self, patch):
+        api_key = patch("via.get_url_details.GOOGLE_DRIVE_API_KEY")
+        api_key.__str__.return_value = self.GOOGLE_API_KEY
 
     @pytest.fixture
     def requests(self, patch):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ requires =
     tox-pip-extensions
     tox-pyenv
     tox-run-command
+    tox-envfile
 tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
@@ -32,6 +33,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
+    docker-compose: GOOGLE_API_KEY
 deps =
     dev: -r requirements-dev.in
     tests: coverage

--- a/via/get_url_details.py
+++ b/via/get_url_details.py
@@ -1,6 +1,8 @@
 """Retrieve details about a resource at a URL."""
+import os
 import re
 from functools import wraps
+from json import JSONDecodeError
 
 import requests
 from requests import RequestException
@@ -16,6 +18,8 @@ from via.exceptions import (
 GOOGLE_DRIVE_REGEX = re.compile(
     r"^https://drive.google.com/uc\?id=(.*)&export=download$", re.IGNORECASE
 )
+GOOGLE_DRIVE_API_KEY = os.environ.get("GOOGLE_DRIVE_API_KEY")
+GOOGLE_DRIVE_URL = "https://www.googleapis.com/drive/v3/files/"
 
 
 def _handle_errors(inner):
@@ -28,6 +32,9 @@ def _handle_errors(inner):
 
         except REQUESTS_BAD_URL as err:
             raise BadURL(err.args[0]) from None
+
+        except JSONDecodeError as err:
+            raise UpstreamServiceError(err.args[0]) from None
 
         except REQUESTS_UPSTREAM_SERVICE as err:
             raise UpstreamServiceError(err.args[0]) from None
@@ -50,8 +57,17 @@ def get_url_details(url):
     :raise UnhandledException: For all other request based errors
     """
 
-    if GOOGLE_DRIVE_REGEX.match(url):
-        return "application/pdf", 200
+    google_drive = GOOGLE_DRIVE_REGEX.match(url)
+    if google_drive:
+        if not GOOGLE_DRIVE_API_KEY:
+            return "application/pdf", 200
+
+        rsp = requests.get(
+            f"{GOOGLE_DRIVE_URL}{google_drive.group(1)}?key={GOOGLE_DRIVE_API_KEY}"
+        )
+        data = rsp.json()
+
+        return data["mimeType"], rsp.status_code
 
     with requests.get(url, stream=True, allow_redirects=True) as rsp:
         return rsp.headers.get("Content-Type"), rsp.status_code


### PR DESCRIPTION
We're probably not doing this now, but the first half is a good start point for modification as it splits out the get URL function and tests it separately.

This should make it easier to extend and test in isolation from the view that calls it.