### PR TITLE
Assume PDF for Google Drive documents

### DIFF
--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -18,13 +18,27 @@ class TestGetURLDetails:
         "content_type,status_code", (("text/html", 501), ("application/pdf", 200))
     )
     def test_it_calls_get_for_normal_urls(self, requests, content_type, status_code):
-        requests.get.return_value = self._make_response(content_type, status_code)
+        response = Response()
+        response.raw = BytesIO(b"")
+        response.headers = {"Content-Type": content_type}
+        response.status_code = status_code
+        requests.get.return_value = response
+
         url = "http://example.com"
 
         result = get_url_details(url)
 
         assert result == (content_type, status_code)
         requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
+
+    def test_it_assumes_pdf_with_a_google_drive_url(self, requests):
+        result = get_url_details(
+            "https://drive.google.com/uc?id=--FILEID--&export=download"
+        )
+
+        assert result == ("application/pdf", 200)
+
+        requests.get.assert_not_called()
 
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))
     def test_it_raises_BadURL_for_invalid_urls(self, bad_url):
@@ -47,16 +61,6 @@ class TestGetURLDetails:
 
         with pytest.raises(expected_exception):
             get_url_details("http://example.com")
-
-    @staticmethod
-    def _make_response(content_type="application/pdf", status_code=200, body=None):
-        response = Response()
-
-        response.raw = BytesIO(body.encode("utf-8") if body else b"")
-        response.headers = {"Content-Type": content_type}
-        response.status_code = status_code
-
-        return response
 
     @pytest.fixture
     def requests(self, patch):

--- a/via/get_url_details.py
+++ b/via/get_url_details.py
@@ -1,4 +1,5 @@
 """Retrieve details about a resource at a URL."""
+import re
 from functools import wraps
 
 import requests
@@ -10,6 +11,10 @@ from via.exceptions import (
     BadURL,
     UnhandledException,
     UpstreamServiceError,
+)
+
+GOOGLE_DRIVE_REGEX = re.compile(
+    r"^https://drive.google.com/uc\?id=(.*)&export=download$", re.IGNORECASE
 )
 
 
@@ -44,6 +49,9 @@ def get_url_details(url):
     :raise UpstreamServiceError: If we server gives us errors
     :raise UnhandledException: For all other request based errors
     """
+
+    if GOOGLE_DRIVE_REGEX.match(url):
+        return "application/pdf", 200
 
     with requests.get(url, stream=True, allow_redirects=True) as rsp:
         return rsp.headers.get("Content-Type"), rsp.status_code


### PR DESCRIPTION
I'm not sure if this is a feature or a bug, but we are improving the experience for most, at the cost of some:

 * We now assume that all google drive documents are PDFs
 * If we're right this is obviously much faster
 * If we're wrong it will result in an error message in PDF.js

The downside should only effect users who construct URLs for themselves, or use Via 3's root page.