### PR TITLE
Split get_url_details out from the view so it can be tested separately

### DIFF
--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -22,8 +22,8 @@ class TestGetURLDetails:
         url = "http://example.com"
 
         result = get_url_details(url)
+ 
         assert result == (content_type, status_code)
-
         requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
 
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))

--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -22,7 +22,7 @@ class TestGetURLDetails:
         url = "http://example.com"
 
         result = get_url_details(url)
- 
+
         assert result == (content_type, status_code)
         requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
 

--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -1,0 +1,63 @@
+from io import BytesIO
+
+import pytest
+from requests import Response
+from requests.exceptions import (
+    MissingSchema,
+    ProxyError,
+    SSLError,
+    UnrewindableBodyError,
+)
+
+from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
+from via.get_url_details import get_url_details
+
+
+class TestGetURLDetails:
+    @pytest.mark.parametrize(
+        "content_type,status_code", (("text/html", 501), ("application/pdf", 200))
+    )
+    def test_it_calls_get_for_normal_urls(self, requests, content_type, status_code):
+        requests.get.return_value = self._make_response(content_type, status_code)
+        url = "http://example.com"
+
+        result = get_url_details(url)
+        assert result == (content_type, status_code)
+
+        requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
+
+    @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))
+    def test_it_raises_BadURL_for_invalid_urls(self, bad_url):
+        with pytest.raises(BadURL):
+            get_url_details(bad_url)
+
+    @pytest.mark.parametrize(
+        "request_exception,expected_exception",
+        (
+            (MissingSchema, BadURL),
+            (ProxyError, UpstreamServiceError),
+            (SSLError, UpstreamServiceError),
+            (UnrewindableBodyError, UnhandledException),
+        ),
+    )
+    def test_it_catches_requests_exceptions(
+        self, requests, request_exception, expected_exception
+    ):
+        requests.get.side_effect = request_exception("Oh noe")
+
+        with pytest.raises(expected_exception):
+            get_url_details("http://example.com")
+
+    @staticmethod
+    def _make_response(content_type="application/pdf", status_code=200, body=None):
+        response = Response()
+
+        response.raw = BytesIO(body.encode("utf-8") if body else b"")
+        response.headers = {"Content-Type": content_type}
+        response.status_code = status_code
+
+        return response
+
+    @pytest.fixture
+    def requests(self, patch):
+        return patch("via.get_url_details.requests")

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -62,6 +62,7 @@ class TestRouteByContent:
         self, content_type, max_age, call_route_by_content, get_url_details
     ):
         get_url_details.return_value = (content_type, 200)
+ 
         result = call_route_by_content()
 
         assert_cache_control(

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -63,7 +63,7 @@ class TestRouteByContent:
         self, content_type, max_age, call_route_by_content, get_url_details
     ):
         get_url_details.return_value = (content_type, 200)
- 
+
         result = call_route_by_content()
 
         assert_cache_control(

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -20,6 +20,7 @@ class TestRouteByContent:
         self, content_type, location, call_route_by_content, get_url_details
     ):
         get_url_details.return_value = (content_type, 200)
+
         result = call_route_by_content()
 
         assert result.location == location

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -83,6 +83,7 @@ class TestRouteByContent:
         self, status_code, cache, call_route_by_content, get_url_details
     ):
         get_url_details.return_value = (sentinel.content_type, status_code)
+
         result = call_route_by_content()
 
         assert result.headers == Any.iterable.containing({"Cache-Control": cache})

--- a/via/get_url_details.py
+++ b/via/get_url_details.py
@@ -1,0 +1,36 @@
+"""Retrieve details about a resource at a URL."""
+
+import requests
+from requests import RequestException
+
+from via.exceptions import (
+    REQUESTS_BAD_URL,
+    REQUESTS_UPSTREAM_SERVICE,
+    BadURL,
+    UnhandledException,
+    UpstreamServiceError,
+)
+
+
+def get_url_details(url):
+    """Get the content type and status code for a given URL.
+
+    :param url: URL to retrieve
+    :return: 2-tuple of (content type, status code)
+
+    :raise BadURL: When the URL is malformed
+    :raise UpstreamServiceError: If we server gives us errors
+    :raise UnhandledException: For all other request based errors
+    """
+    try:
+        with requests.get(url, stream=True, allow_redirects=True) as rsp:
+            return rsp.headers.get("Content-Type"), rsp.status_code
+
+    except REQUESTS_BAD_URL as err:
+        raise BadURL(err.args[0]) from None
+
+    except REQUESTS_UPSTREAM_SERVICE as err:
+        raise UpstreamServiceError(err.args[0]) from None
+
+    except RequestException as err:
+        raise UnhandledException(err.args[0]) from None


### PR DESCRIPTION
We are going to be making changes to this function now, and it's going to gain a bit more complexity. This will keep view and attendant view tests size down.