### PR TITLE
Add proxying Google Drive files from the API not the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info/
 via/static/**/*.gz
 build.tar
+.devdata.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 
 USER hypothesis
 
-CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf
+CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ help:
 dev: python
 	@tox -qe dev
 
+.PHONY: devdata
+devdata: python
+	@tox -qe dev -- python bin/devdata.py
+
 .PHONY: build
 build: python
 	@tox -qe build

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ installation process:
 
     cd via3
 
+### Setup data required to run the server
+
+You will need certain items (like Google API keys) to run locally properly.
+To do that you can run:
+
+    make devdata
+
 ### Run the services with Docker Compose
 
 Start the services that Via 3 requires (currently just NGINX) using Docker

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ installation process:
 
     cd via3
 
-### Setup data required to run the server
+### Create the development data and settings
 
-You will need certain items (like Google API keys) to run locally properly.
-To do that you can run:
+Create the environment variable settings needed to get Via 3 working nicely with other services (e.g. Google Drive):
 
     make devdata
 

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -1,4 +1,4 @@
-"""Copy tox environment variables from devdata."""
+"""Download .devdata.env from github.com:hypothesis/devdata.git."""
 
 import os
 from shutil import copy2, rmtree

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -1,24 +1,28 @@
 """Download .devdata.env from github.com:hypothesis/devdata.git."""
 
 import os
-from shutil import copy2, rmtree
+from shutil import copyfile
 from subprocess import check_call
-from tempfile import mkdtemp
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import via
 
 
 def _get_devdata():
-    temp_dir = mkdtemp()
-    target = os.path.abspath(".devdata.env")
+    # The directory that we'll clone the devdata git repo into.
+    with TemporaryDirectory() as tmp_dir_name:
+        git_dir = os.path.join(tmp_dir_name, "devdata")
 
-    try:
-        check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", temp_dir])
-        copy2(os.path.join(temp_dir, "via/devdata.env"), target)
+        check_call(
+            ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+        )
 
-        print(f"Created {target}")
-
-    finally:
-        if os.path.isdir(temp_dir):
-            rmtree(temp_dir)
+        # Copy devdata env file into place.
+        copyfile(
+            os.path.join(git_dir, "via/devdata.env"),
+            os.path.join(Path(via.__file__).parent.parent, ".devdata.env"),
+        )
 
 
 if __name__ == "__main__":

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -1,0 +1,25 @@
+"""Copy tox environment variables from devdata."""
+
+import os
+from shutil import copy2, rmtree
+from subprocess import check_call
+from tempfile import mkdtemp
+
+
+def _get_devdata():
+    temp_dir = mkdtemp()
+    target = os.path.abspath(".devdata.env")
+
+    try:
+        check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", temp_dir])
+        copy2(os.path.join(temp_dir, "via/devdata.env"), target)
+
+        print(f"Created {target}")
+
+    finally:
+        if os.path.isdir(temp_dir):
+            rmtree(temp_dir)
+
+
+if __name__ == "__main__":
+    _get_devdata()

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -1,10 +1,10 @@
 """Download .devdata.env from github.com:hypothesis/devdata.git."""
 
 import os
+from pathlib import Path
 from shutil import copyfile
 from subprocess import check_call
 from tempfile import TemporaryDirectory
-from pathlib import Path
 
 import via
 
@@ -14,9 +14,7 @@ def _get_devdata():
     with TemporaryDirectory() as tmp_dir_name:
         git_dir = os.path.join(tmp_dir_name, "devdata")
 
-        check_call(
-            ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
-        )
+        check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir])
 
         # Copy devdata env file into place.
         copyfile(

--- a/conf/nginx/envsubst.conf.template
+++ b/conf/nginx/envsubst.conf.template
@@ -1,1 +1,2 @@
 set $access_control_allow_origin "${ACCESS_CONTROL_ALLOW_ORIGIN}";
+set $google_api_key "${GOOGLE_API_KEY}";

--- a/conf/nginx/via/direct_proxy.conf
+++ b/conf/nginx/via/direct_proxy.conf
@@ -3,10 +3,23 @@ proxy_ssl_server_name on;
 # Replace the default url-decoded $uri with the $request_uri which is as
 # we received it without url-decoding
 rewrite ^ $request_uri;
+
+# Redirect Google Drive requests to the API using our key
+# Some weird things:
+# * A rule that starts with http will _immediately_ issue a proxy_redirect
+# * So we seemingly pointlessly capture (https) and replace it
+# * This way the _result_ starts with https, but the _rule_ doesn't and we can carry on
+# * NGINX will _merge_ queries you add, not replace them unless you put '?' on the end
+rewrite ^/proxy/static/(https)://drive.google.com/uc\?id=(.*)&export=download$ $1://www.googleapis.com/drive/v3/files/$2?key=$google_api_key&alt=media? break;
+
 # Remove our URL part off of the front
-rewrite ^/proxy/static/(.*) $1 break;
+# The ? at the end means we strip off the args part (which we will add back on later)
+# I have no idea why this works to be honest but it seems to
+rewrite ^/proxy/static/(.*)$ $1? break;
+
 # The proxy directly to the resulting URL
-proxy_pass $uri;
+# Add back on the args which we stripped above so we don't get them twice
+proxy_pass $uri$is_args$args;
 
 proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
       - '127.0.0.1:9083:9083'
     environment:
       - ACCESS_CONTROL_ALLOW_ORIGIN=http://localhost:9082
+      - GOOGLE_API_KEY
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./conf/nginx/via:/etc/nginx/via
       - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template
-    command: /bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
+    command: /bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ requires =
     tox-pip-extensions
     tox-pyenv
     tox-run-command
+    tox-envfile
 tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
@@ -32,6 +33,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
+    docker-compose: GOOGLE_API_KEY
 deps =
     dev: -r requirements-dev.in
     tests: coverage


### PR DESCRIPTION
This uses a Google API key to serve files from the google drive API, rather than the user facing website.

This has the following good effects:

 * We no longer have a redirect
 * So requests should be a little faster, and get cached more often
 * We will hopefully run into less rate limiting

It has the following less than good effects:

 * We don't have a sensible "Content-Disposition" header any more, so the filename is just hex
 * The service returns JSON errors when things go wrong
 * We don't really know what effects using the API will have

----

How to test:

 * Run "docker stop via3_nginx-proxy_1; docker rm via3_nginx-proxy_1; make services;"
 * Goto: http://localhost:9083/proxy/static/http://httpbin.org/get?a=b
 * You should see the params get through
 * Goto: https://drive.google.com/uc?id=1heF_Yjs_ZZyms4QpdG0P06fTEXWkMdVW&export=download
 * You should see direct download with filename "sample.pdf"
 * Goto: http://localhost:9083/proxy/static/https://drive.google.com/uc?id=1heF_Yjs_ZZyms4QpdG0P06fTEXWkMdVW&export=download
 * You should see a file download with the id

----

This cannot be merged until:

 * [x] There is an API key for QA
 * [x] The `GOOGLE_API_KEY` env var is setup for QA
 * [x] There is an API key for Prod
 * [x] The `GOOGLE_API_KEY` env var is setup for Prod