### PR TITLE
1B - Swapping in the via3 configuration extraction mechanism for programatic params

### DIFF
--- a/tests/config_extractor_test.py
+++ b/tests/config_extractor_test.py
@@ -96,51 +96,18 @@ class TestConfigExtractor(object):
             "/example.com?q=foobar&"
             "via.open_sidebar=1&"
             "via.request_config_from_frame=https://lms.hypothes.is&"
-            "via.config_frame_ancestor_level=2"
+            "via.config_frame_ancestor_level=3"
         )
 
         template_params = json.loads(resp.data).get("pywb.template_params")
         assert template_params == {
             "hypothesis_config": {
                 "appType": "via",
-                "openSidebar": True,
+                "openSidebar": "1",
                 "requestConfigFromFrame": {
                     "origin": "https://lms.hypothes.is",
-                    "ancestorLevel": 2,
+                    "ancestorLevel": "3",
                 },
-                "showHighlights": True,
-            }
-        }
-
-    def test_it_does_not_break_when_ancestor_level_is_not_int(self, client_get):
-        resp = client_get(
-            "/example.com?q=foobar&"
-            "via.open_sidebar=1&"
-            "via.request_config_from_frame=https://lms.hypothes.is&"
-            "via.config_frame_ancestor_level=not_an_int"
-        )
-        template_params = json.loads(resp.data).get("pywb.template_params")
-        assert template_params == {
-            "hypothesis_config": {
-                "appType": "via",
-                "openSidebar": True,
-                "requestConfigFromFrame": {"origin": "https://lms.hypothes.is"},
-                "showHighlights": True,
-            }
-        }
-
-    def test_it_does_not_break_when_ancestor_level_is_missing(self, client_get):
-        resp = client_get(
-            "/example.com?q=foobar&"
-            "via.open_sidebar=1&"
-            "via.request_config_from_frame=https://lms.hypothes.is"
-        )
-        template_params = json.loads(resp.data).get("pywb.template_params")
-        assert template_params == {
-            "hypothesis_config": {
-                "appType": "via",
-                "openSidebar": True,
-                "requestConfigFromFrame": {"origin": "https://lms.hypothes.is"},
                 "showHighlights": True,
             }
         }

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from via.configuration import Configuration
+
+
+class TestConfiguration(object):
+    CLIENT_DEFAULTS = {"appType": "via", "showHighlights": True, "openSidebar": False}
+
+    def test_it_ignores_items_not_marked_with_via(self):
+        via_params, client_params = Configuration.extract_from_params({})
+        assert via_params == {}
+        assert client_params == self.CLIENT_DEFAULTS
+
+    def test_it_leaves_unknown_root_elements_for_via(self):
+        via_params, client_params = Configuration.extract_from_params(
+            {"via.key_name": "value"}
+        )
+
+        assert via_params == {"key_name": "value"}
+        assert client_params == self.CLIENT_DEFAULTS
+
+    def test_it_sets_client_defaults(self):
+        _, client_params = Configuration.extract_from_params({})
+
+        assert client_params == self.CLIENT_DEFAULTS
+
+    def test_it_extracts_nested_client_elements(self):
+        _, client_params = Configuration.extract_from_params(
+            {
+                "via.client.requestConfigFromFrame.itemOne": "one",
+                "via.client.requestConfigFromFrame.itemTwo": "two",
+            }
+        )
+
+        assert client_params["requestConfigFromFrame"] == {
+            "itemOne": "one",
+            "itemTwo": "two",
+        }
+
+    def test_it_filters_non_whitelisted_client_params(self):
+        _, client_params = Configuration.extract_from_params(
+            {"via.client.notAThing": "value"}
+        )
+
+        assert client_params == self.CLIENT_DEFAULTS
+
+    @pytest.mark.parametrize(
+        "params,expected",
+        (
+            ({"via.open_sidebar": "foo"}, {"openSidebar": "foo"}),
+            (
+                {"via.request_config_from_frame": "foo"},
+                {"requestConfigFromFrame": {"origin": "foo", "ancestorLevel": 2}},
+            ),
+            (
+                {
+                    "via.request_config_from_frame": "foo",
+                    "via.config_frame_ancestor_level": "3",
+                },
+                {"requestConfigFromFrame": {"origin": "foo", "ancestorLevel": "3"}},
+            ),
+        ),
+    )
+    def test_it_moves_legacy_params_to_client_config(self, params, expected):
+        via_params, client_params = Configuration.extract_from_params(params)
+
+        assert via_params == {}
+
+        for key, value in expected.items():
+            assert client_params[key] == value

--- a/via/configuration.py
+++ b/via/configuration.py
@@ -1,0 +1,121 @@
+"""Tools for reading in configuration."""
+
+# pylint: disable=too-few-public-methods
+
+# NOTE! This is a _very_ mildly rewritten version of the same code in via3
+# If you are fixing a bug here, fix it there first!
+
+
+class Configuration(object):
+    """Extracts configuration from params.
+
+    This class will extract and separate Client and Via configuration from a
+    mapping by interpreting the keys as dot delimited values.
+
+     * After splitting on '.' the parts are interpreted as nested dict keys
+     * Any keys starting with `via.*` will be processed
+     * Any keys starting with `via.client.*` will be separated out
+     * Keys for the client which don't match a whitelist are discarded
+
+    For example:
+
+    {
+        "other": "ignored",
+        "via.option": "value",
+        "via.client.nestOne.nestTwo": "value2"
+    }
+
+    Results in:
+
+     * Via: {"option": "value"}
+     * Client : {"nestOne": {"nextTwo": "value2"}}
+
+    No attempt is made to interpret the values for the client. The client will
+    get what we were given. If this was called from query parameters, that will
+    mean a string.
+    """
+
+    # Certain configuration options include URLs which we will read, write or
+    # direct the user to. This would allow an attacker to craft a URL which
+    # could do that to a user, so we whitelist harmless parameters instead
+    # From: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#config-settings
+    CLIENT_CONFIG_WHITELIST = {
+        # Things we use now
+        "openSidebar",
+        "requestConfigFromFrame",
+        # Things which seem safe
+        "enableExperimentalNewNoteButton",
+        "externalContainerSelector",
+        "focus",
+        "showHighlights",
+        "theme",
+    }
+
+    @classmethod
+    def extract_from_params(cls, params):
+        """Extract Via and H config from query parameters.
+
+        :param params: A mapping of query parameters
+        :return: A tuple of Via, and H config
+        """
+
+        via_params = cls._unflatten(params)
+        client_params = via_params.pop("client", {})
+
+        cls._filter_client_params(client_params)
+        cls._move_legacy_params(via_params, client_params)
+
+        # Set some defaults
+        client_params["appType"] = "via"
+        client_params.setdefault("showHighlights", True)
+
+        return via_params, client_params
+
+    @staticmethod
+    def _unflatten(params):
+        """Convert dot delimited flat data into nested dicts.
+
+        This method will skip any keys which do not start with "via." and will
+        return a data structure rooted after that point. So "via.a.b" will
+        start at "a".
+        """
+
+        data = {}
+
+        for key, value in params.items():
+            parts = key.split(".")
+            if parts[0] != "via":
+                continue
+
+            target = data
+            # Skip the first ('via') and last parts
+            for part in parts[1:-1]:
+                target = target.setdefault(part, {})
+
+            # Finally set the last key to the value
+            target[parts[-1]] = value
+
+        return data
+
+    @classmethod
+    def _filter_client_params(cls, client_params):
+        """Remove keys which are not in the whitelist."""
+
+        for key in set(client_params.keys()) - cls.CLIENT_CONFIG_WHITELIST:
+            client_params.pop(key)
+
+    @staticmethod
+    def _move_legacy_params(via_params, client_params):
+        """Handle legacy params which we can't move for now."""
+
+        # This is like to be around for a while
+        client_params.setdefault("openSidebar", via_params.pop("open_sidebar", False))
+
+        # This should be removed when LMS is refactored to send things the
+        # new way
+        request_config = via_params.pop("request_config_from_frame", None)
+        if request_config is not None:
+            client_params["requestConfigFromFrame"] = {
+                "origin": request_config,
+                "ancestorLevel": via_params.pop("config_frame_ancestor_level", 2),
+            }


### PR DESCRIPTION
This allows anything to be sent to 'via.client.*' and have it relayed onto the client. This is a direct copy paste job from the same code in via3.

This results in a big mess as Via already has one, but it's not worth spending a lot of time untangling this to be perfect if it just gets killed off later.

----

To test run superdev then goto:

### openSidebar

- http://localhost:9080/http://thisisaboring.website/
- http://localhost:9080/http://thisisaboring.website/?via.open_sidebar=
- http://localhost:9080/http://thisisaboring.website/?via.open_sidebar=false  #! This opens it!
- http://localhost:9080/http://thisisaboring.website/?via.open_sidebar=False  #! This opens it!
- http://localhost:9080/http://thisisaboring.website/?via.open_sidebar=0  #! This opens it!
- http://localhost:9080/http://thisisaboring.website/?via.open_sidebar=1
- http://localhost:9080/http://thisisaboring.website/?via.client.openSidebar=1 (_new stylee_)

The variants of False shouldn't cause the sidebar to open, but that's an issue with client cleaning of the value rather than this PR.

### ancestorLevel

For the next tests make sure the dev tools are open, as we are looking for errors to show things are working:

- http://localhost:9080/http://thisisaboring.website/?via.request_config_from_frame=http://www.google.com&via.config_frame_ancestor_level=8
- http://localhost:9080/http://thisisaboring.website/?via.client.requestConfigFromFrame.origin=http://www.google.com&via.client.requestConfigFromFrame.ancestorLevel=8  (_new stylee_)

These should show:

> index.js:337 Failed to start Hypothesis client:  Error: The target parent frame has exceeded the ancestor tree. Try reducing the `requestConfigFromFrame.ancestorLevel` value in the `hypothesisConfig`

### origin

- http://localhost:9080/http://thisisaboring.website/?via.request_config_from_frame=http://www.google.com&via.config_frame_ancestor_level=0
- http://localhost:9080/http://thisisaboring.website/?via.client.requestConfigFromFrame.origin=http://www.google.com&via.client.requestConfigFromFrame.ancestorLevel=0  (_new stylee_)

> postmessage-json-rpc.js:47 Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('http://www.google.com') does not match the recipient window's origin ('http://localhost:5000').
