### PR TITLE
3A - Remove backwards compatibility for old style LMS params

### DIFF
--- a/tests/unit/via/configuration_test.py
+++ b/tests/unit/via/configuration_test.py
@@ -1,4 +1,3 @@
-import pytest
 from h_matchers import Any
 
 from via.configuration import Configuration

--- a/tests/unit/via/configuration_test.py
+++ b/tests/unit/via/configuration_test.py
@@ -44,25 +44,10 @@ class TestConfiguration:
 
         assert client_params == self.CLIENT_DEFAULTS
 
-    @pytest.mark.parametrize(
-        "params,expected",
-        (
-            ({"via.open_sidebar": "foo"}, {"openSidebar": "foo"}),
-            (
-                {"via.request_config_from_frame": "foo"},
-                {"requestConfigFromFrame": {"origin": "foo", "ancestorLevel": 2}},
-            ),
-            (
-                {
-                    "via.request_config_from_frame": "foo",
-                    "via.config_frame_ancestor_level": "3",
-                },
-                {"requestConfigFromFrame": {"origin": "foo", "ancestorLevel": "3"}},
-            ),
-        ),
-    )
-    def test_it_moves_legacy_params_to_client_config(self, params, expected):
-        via_params, client_params = Configuration.extract_from_params(params)
+    def test_it_moves_legacy_open_sidebar_to_client_config(self):
+        via_params, client_params = Configuration.extract_from_params(
+            {"via.open_sidebar": "foo"}
+        )
 
         assert via_params == {}
-        assert client_params == Any.dict.containing(expected)
+        assert client_params == Any.dict.containing({"openSidebar": "foo"})

--- a/via/configuration.py
+++ b/via/configuration.py
@@ -107,12 +107,3 @@ class Configuration:
 
         # This is like to be around for a while
         client_params.setdefault("openSidebar", via_params.pop("open_sidebar", False))
-
-        # This should be removed when LMS is refactored to send things the
-        # new way
-        request_config = via_params.pop("request_config_from_frame", None)
-        if request_config is not None:
-            client_params["requestConfigFromFrame"] = {
-                "origin": request_config,
-                "ancestorLevel": via_params.pop("config_frame_ancestor_level", 2),
-            }


### PR DESCRIPTION
This cannot be merged until LMS is using the new style params in: https://github.com/hypothesis/lms/pull/1679