### PR TITLE
Add a resource for accessing the URL which raises if missing or bad

### DIFF
--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -1,0 +1,20 @@
+import pytest
+from pyramid.httpexceptions import HTTPBadRequest
+
+from via.resources import URLRoute
+
+
+class TestURLRoute:
+    def test_it_returns_url(self, make_request):
+        url = "http://example.com"
+        context = URLRoute(make_request(params={"url": url}))
+
+        assert context.url == url
+
+    @pytest.mark.parametrize("params", ({}, {"urk": "foo"}, {"url": ""}))
+    def test_it_raises_HTTPBadRequest_for_bad_urls(self, params, make_request):
+        request = make_request(params=params)
+        context = URLRoute(request)
+
+        with pytest.raises(HTTPBadRequest):
+            context.url  # pylint: disable=pointless-statement

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -1,20 +1,20 @@
 import pytest
 from pyramid.httpexceptions import HTTPBadRequest
 
-from via.resources import URLRoute
+from via.resources import URLResource
 
 
-class TestURLRoute:
+class TestURLResource:
     def test_it_returns_url(self, make_request):
         url = "http://example.com"
-        context = URLRoute(make_request(params={"url": url}))
+        context = URLResource(make_request(params={"url": url}))
 
-        assert context.url == url
+        assert context.url() == url
 
     @pytest.mark.parametrize("params", ({}, {"urk": "foo"}, {"url": ""}))
     def test_it_raises_HTTPBadRequest_for_bad_urls(self, params, make_request):
         request = make_request(params=params)
-        context = URLRoute(request)
+        context = URLResource(request)
 
         with pytest.raises(HTTPBadRequest):
-            context.url  # pylint: disable=pointless-statement
+            context.url()

--- a/tests/unit/via/views/__init___test.py
+++ b/tests/unit/via/views/__init___test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from via import views
+from via.resources import URLRoute
 
 
 class TestIncludeMe:
@@ -11,7 +12,7 @@ class TestIncludeMe:
 
         assert config.add_route.call_args_list == [
             mock.call("get_status", "/_status"),
-            mock.call("view_pdf", "/pdf"),
-            mock.call("route_by_content", "/route"),
+            mock.call("view_pdf", "/pdf", factory=URLRoute),
+            mock.call("route_by_content", "/route", factory=URLRoute),
         ]
         config.scan.assert_called_once_with("via.views")

--- a/tests/unit/via/views/__init___test.py
+++ b/tests/unit/via/views/__init___test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from via import views
-from via.resources import URLRoute
+from via.resources import URLResource
 
 
 class TestIncludeMe:
@@ -12,7 +12,7 @@ class TestIncludeMe:
 
         assert config.add_route.call_args_list == [
             mock.call("get_status", "/_status"),
-            mock.call("view_pdf", "/pdf", factory=URLRoute),
-            mock.call("route_by_content", "/route", factory=URLRoute),
+            mock.call("view_pdf", "/pdf", factory=URLResource),
+            mock.call("route_by_content", "/route", factory=URLResource),
         ]
         config.scan.assert_called_once_with("via.views")

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -3,6 +3,7 @@ from h_matchers import Any
 from mock import sentinel
 
 from tests.unit.conftest import assert_cache_control
+from via.resources import URLRoute
 from via.views.route_by_content import route_by_content
 
 
@@ -108,8 +109,9 @@ class TestRouteByContent:
     @pytest.fixture
     def call_route_by_content(self, make_request):
         def call_route_by_content(target_url="http://example.com", params=None):
-            return route_by_content(
-                make_request(params=dict(params or {}, url=target_url))
-            )
+            request = make_request(params=dict(params or {}, url=target_url))
+            context = URLRoute(request)
+
+            return route_by_content(context, request)
 
         return call_route_by_content

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -3,7 +3,7 @@ from h_matchers import Any
 from mock import sentinel
 
 from tests.unit.conftest import assert_cache_control
-from via.resources import URLRoute
+from via.resources import URLResource
 from via.views.route_by_content import route_by_content
 
 
@@ -110,7 +110,7 @@ class TestRouteByContent:
     def call_route_by_content(self, make_request):
         def call_route_by_content(target_url="http://example.com", params=None):
             request = make_request(params=dict(params or {}, url=target_url))
-            context = URLRoute(request)
+            context = URLResource(request)
 
             return route_by_content(context, request)
 

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -3,6 +3,7 @@ from h_matchers import Any
 from markupsafe import Markup
 
 from tests.unit.conftest import assert_cache_control
+from via.resources import URLRoute
 from via.views.view_pdf import view_pdf
 
 
@@ -91,6 +92,8 @@ class TestHypothesisConfigConstruction:
 @pytest.fixture
 def call_view_pdf(make_request):
     def call_view_pdf(url="http://example.com/name.pdf", params=None):
-        return view_pdf(make_request(params=dict(params or {}, url=url)))
+        request = make_request(params=dict(params or {}, url=url))
+        context = URLRoute(request)
+        return view_pdf(context, request)
 
     return call_view_pdf

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -3,7 +3,7 @@ from h_matchers import Any
 from markupsafe import Markup
 
 from tests.unit.conftest import assert_cache_control
-from via.resources import URLRoute
+from via.resources import URLResource
 from via.views.view_pdf import view_pdf
 
 
@@ -93,7 +93,7 @@ class TestHypothesisConfigConstruction:
 def call_view_pdf(make_request):
     def call_view_pdf(url="http://example.com/name.pdf", params=None):
         request = make_request(params=dict(params or {}, url=url))
-        context = URLRoute(request)
+        context = URLResource(request)
         return view_pdf(context, request)
 
     return call_view_pdf

--- a/via/resources.py
+++ b/via/resources.py
@@ -1,0 +1,27 @@
+"""Context objects for views."""
+from pyramid.httpexceptions import HTTPBadRequest
+
+# pylint: disable=too-few-public-methods
+
+
+class URLRoute:
+    """Methods for routes which accept a 'url'."""
+
+    def __init__(self, request):
+        self._request = request
+
+    @property
+    def url(self):
+        """Get the 'url' parameter.
+
+        :raise HTTPBadRequest: If the url is missing or empty
+        """
+        try:
+            pdf_url = self._request.params["url"]
+        except KeyError as err:
+            raise HTTPBadRequest("Required parameter 'url' missing") from err
+
+        if not pdf_url:
+            raise HTTPBadRequest("Required parameter 'url' is blank")
+
+        return pdf_url

--- a/via/resources.py
+++ b/via/resources.py
@@ -4,24 +4,24 @@ from pyramid.httpexceptions import HTTPBadRequest
 # pylint: disable=too-few-public-methods
 
 
-class URLRoute:
+class URLResource:
     """Methods for routes which accept a 'url'."""
 
     def __init__(self, request):
         self._request = request
 
-    @property
     def url(self):
         """Get the 'url' parameter.
 
+        :return: The URL as a string
         :raise HTTPBadRequest: If the url is missing or empty
         """
         try:
-            pdf_url = self._request.params["url"]
+            url = self._request.params["url"]
         except KeyError as err:
             raise HTTPBadRequest("Required parameter 'url' missing") from err
 
-        if not pdf_url:
+        if not url:
             raise HTTPBadRequest("Required parameter 'url' is blank")
 
-        return pdf_url
+        return url

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -1,12 +1,12 @@
 """The views for the Pyramid app."""
-from via.resources import URLRoute
+from via.resources import URLResource
 
 
 def add_routes(config):
     """Add routes to pyramid config."""
     config.add_route("get_status", "/_status")
-    config.add_route("view_pdf", "/pdf", factory=URLRoute)
-    config.add_route("route_by_content", "/route", factory=URLRoute)
+    config.add_route("view_pdf", "/pdf", factory=URLResource)
+    config.add_route("route_by_content", "/route", factory=URLResource)
 
 
 def includeme(config):

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -1,11 +1,12 @@
 """The views for the Pyramid app."""
+from via.resources import URLRoute
 
 
 def add_routes(config):
     """Add routes to pyramid config."""
     config.add_route("get_status", "/_status")
-    config.add_route("view_pdf", "/pdf")
-    config.add_route("route_by_content", "/route")
+    config.add_route("view_pdf", "/pdf", factory=URLRoute)
+    config.add_route("route_by_content", "/route", factory=URLRoute)
 
 
 def includeme(config):

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -10,11 +10,9 @@ from via.get_url_details import get_url_details
 
 
 @view.view_config(route_name="route_by_content")
-def route_by_content(request):
+def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
-    path_url = request.params["url"]
-
-    mime_type, status_code = get_url_details(path_url)
+    mime_type, status_code = get_url_details(context.url)
 
     # Can PDF mime types get extra info on the end like "encoding=?"
     if mime_type in ("application/x-pdf", "application/pdf"):

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -12,7 +12,7 @@ from via.get_url_details import get_url_details
 @view.view_config(route_name="route_by_content")
 def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
-    mime_type, status_code = get_url_details(context.url)
+    mime_type, status_code = get_url_details(context.url())
 
     # Can PDF mime types get extra info on the end like "encoding=?"
     if mime_type in ("application/x-pdf", "application/pdf"):

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -21,11 +21,14 @@ class _QueryParams:
     # immutable assets when they are deployed
     http_cache=0,
 )
-def view_pdf(request):
+def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""
 
+    nginx_server = request.registry.settings["nginx_server"]
+    pdf_url = f"{nginx_server}/proxy/static/{context.url}"
+
     return {
-        "pdf_url": Markup(_make_pdf_redirect(request)),
+        "pdf_url": Markup(pdf_url),
         "client_embed_url": Markup(request.registry.settings["client_embed_url"]),
         "static_url": request.static_url,
         "hypothesis_config": _hypothesis_config(request),
@@ -44,12 +47,3 @@ def _hypothesis_config(request):
         config["requestConfigFromFrame"] = request_config
 
     return config
-
-
-def _make_pdf_redirect(request):
-    nginx_server = request.registry.settings["nginx_server"]
-    pdf_url = request.params["url"]
-
-    # Our NGINX is capable of carrying the URL through without messing it up,
-    # and using query params is a pain, so we're sticking with this for now
-    return f"{nginx_server}/proxy/static/{pdf_url}"

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -25,7 +25,7 @@ def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""
 
     nginx_server = request.registry.settings["nginx_server"]
-    pdf_url = f"{nginx_server}/proxy/static/{context.url}"
+    pdf_url = f"{nginx_server}/proxy/static/{context.url()}"
 
     return {
         "pdf_url": Markup(pdf_url),


### PR DESCRIPTION
This isn't very fancy error handling, we now raise a Pyramid `HTTPBadRequest` and let the default handling kick in. But it's better than falling on our face and raising errors in monitoring.

We don't actually attempt to make sure the URL is valid, just that it's not empty.
To test run `make dev` then goto:

View PDF:

 * http://localhost:9082/pdf?url=http://pdf995.com/samples/pdf.pdf (200)
 * http://localhost:9082/pdf (400)
 * http://localhost:9082/pdf?ulk=foo (400)
 * http://localhost:9082/pdf?url= (400)

Route by content:

 * http://localhost:9082/route?url=http://pdf995.com/samples/pdf.pdf (302)
 * http://localhost:9082/route (400)
 * http://localhost:9082/route?ulk=foo (400)
 * http://localhost:9082/route?url= (400)