### PR TITLE
Prevent breaking out of quotes for items read from URL

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     tests: coverage
     {tests,docstrings,checkdocstrings,lint}: -r requirements.txt
     {tests,docstrings,checkdocstrings,lint}: -r requirements-test.in
-    lint: pylint
+    lint: pylint<2.5
     lint: pydocstyle
     {format,checkformatting}: black
     {format,checkformatting}: isort

--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -18,8 +18,9 @@
 
 {% block footer %}
     <script>
-        window.PDF_URL = "{{ pdf_url }}";
-        window.CLIENT_EMBED_URL = "{{ client_embed_url }}";
+        {# These values come pre-escaped by the backend #}
+        window.PDF_URL = {{ pdf_url }};
+        window.CLIENT_EMBED_URL = {{ client_embed_url }};
     </script>
 
     <script src="{{ static_url("via:static/js/pdfjs-init.min.js") }}"></script>

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -1,4 +1,5 @@
 """View presenting the PDF viewer."""
+import json
 
 from markupsafe import Markup
 from pyramid import view
@@ -22,8 +23,16 @@ def view_pdf(context, request):
     _, h_config = Configuration.extract_from_params(request.params)
 
     return {
-        "pdf_url": Markup(pdf_url),
-        "client_embed_url": Markup(request.registry.settings["client_embed_url"]),
+        "pdf_url": _string_literal(pdf_url),
+        "client_embed_url": _string_literal(
+            request.registry.settings["client_embed_url"]
+        ),
         "static_url": request.static_url,
         "hypothesis_config": h_config,
     }
+
+
+def _string_literal(string):
+    """Return a JSON escaped, but otherwise un-modified string."""
+
+    return Markup(json.dumps(str(string)))


### PR DESCRIPTION
We also add it to the setting for consistency, even though it's not technically required.

Previously a URL with non-quoted double quotes could break out of the quoting and execute arbitrary code.

e.g.

* http://0.0.0.0:9082/pdf?url=http://example.com%22%3Balert%28%22Hellothere%22%29%3B%22
* **⚠️ DON'T TRY THIS IN PROD / QA WITHOUT READING BELOW ⚠️**

To test:

 * Try the above URL with and without the PR
 * Also try the "Aggressively horrible filename" assignments in Canvas under the scratch area

----

We need to be very careful that this doesn't break Canvas file authentication.

----

**⚠️ You might get blocked by following these links⚠️**

I think the block is temporary, but I'm not sure. I appear to be able to access other parts of via3 normally afterwards.

 * ~https://qa-via3.hypothes.is/pdf?url=http://example.com%22%3Balert%28%22Hellothere%22%29%3B%22~
* ~https://via3.hypothes.is/pdf?url=http://example.com%22%3Balert%28%22Hellothere%22%29%3B%22~

These links appear to trigger Cloudflare XSS protection:

![image](https://user-images.githubusercontent.com/7131143/80491265-63a45f00-895a-11ea-9d0b-19a1aade2eaa.png)

So it seems Cloudflare has our back even when we mess up some times.