### PR TITLE
Show non 500 default NGINX error pages for various upstream errors

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -40,6 +40,13 @@ http {
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirect;
 
+            # Handle most errors upstream listed at:
+            # https://www.restapitutorial.com/httpstatuscodes.html
+            error_page 404 410 = @proxy_not_found;
+            error_page 420 429 = @proxy_too_many_requests;
+            error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
+            error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;
+
             include via/direct_proxy.conf;
 
             # Cache for a 1 day, but allow serving from cache while revalidating for a week
@@ -58,6 +65,26 @@ http {
             add_header "Cache-Control" "no-cache, no-store, must-revalidate";
 
             add_header "X-Via" "static-proxy, redirect";
+        }
+
+        location @proxy_not_found {
+            # Not found / gone => 404 not found
+            try_files /proxy/not_found.html =404;
+        }
+
+        location @proxy_too_many_requests {
+            # Too many requests => 429 too many requests
+            try_files /proxy/too_many_requests.html =429;
+        }
+
+        location @proxy_client_error {
+            # All other 40x -> 400 bad request
+            try_files /proxy/client_error.html =400;
+        }
+
+        location @proxy_upstream_error {
+            # All 50x -> 409 -> 409 conflict (with state of resource)
+            try_files /proxy/upstream_error.html =409;
         }
 
         location / {


### PR DESCRIPTION
Currently this uses `try_files` but we don't actually have any of them. This means we get the NGINX fallback page instead with the right code.

In future we can add nicer pages.

### Testing notes

The mapping is pretty clear from the `nginx.conf` file in the diff. Pick any code from the left and you should end-up with the code listed in the named section.

You can test this by:

 * Running `make services`
 * Open: `http://localhost:9083/proxy/static/http://httpbin.org/status/<STATUS CODE HERE>`
 * **Previously**: You would see the `httpbin.org` page with the relevant status code, or your browser interpretation of the error
 * **Now**: You should see the default NGINX page with the relevant code