### PR TITLE
Removing NGINX stats end-point as the New Relic spike is over.

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -35,10 +35,6 @@ http {
         listen 9083;
         merge_slashes off;
 
-        location = /_stats {
-            stub_status on;
-        }
-
         location ~ /proxy/static/ {
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirect;


### PR DESCRIPTION
Removing the stubs as there is no protection and it could conceivably be used nefariously.