### PR TITLE
Fix dev server stopping and reloading

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -4,9 +4,3 @@ use = call:via.app:create_app
 nginx_server: http://localhost:9083
 client_embed_url: http://localhost:5000/embed.js
 legacy_via_url: http://localhost:9080
-
-[server:main]
-use: egg:gunicorn#main
-host: 0.0.0.0
-port: 9082
-timeout: 0

--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -1,0 +1,4 @@
+# Configuration settings for Gunicorn in dev
+
+workers = 4
+reload = True

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ whitelist_externals =
     dev: newrelic-admin
     update-pdfjs: sh
 commands =
-    dev: {posargs:newrelic-admin run-program pserve --reload conf/development.ini}
+    dev: {posargs:newrelic-admin run-program gunicorn --paste conf/development.ini}
     docker-compose: docker-compose {posargs}
     lint: pydocstyle --explain via
     lint: pydocstyle --config tests/.pydocstyle --explain tests

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ whitelist_externals =
     dev: newrelic-admin
     update-pdfjs: sh
 commands =
-    dev: {posargs:newrelic-admin run-program gunicorn --paste conf/development.ini}
+    dev: {posargs:newrelic-admin run-program gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini}
     docker-compose: docker-compose {posargs}
     lint: pydocstyle --explain via
     lint: pydocstyle --config tests/.pydocstyle --explain tests


### PR DESCRIPTION
I've been having annoying issues with `make dev` and `make web` for a
while now:

1. Auto-reloading the web process on file changes doesn't seem to work
   reliably. While it often does work, changing files often seems to get
   the web process "stuck" and no longer working, requiring a manual
   Ctrl+c and restart

2. Stopping doesn't work well. When I hit Ctrl+c to stop `make dev` or
   `make web` it continues to print lines of logging to the terminal
   after my shell prompt has been rendered, messing up the command line.
   This also seems to break fish shell's interactive command line
   features (auto completion etc)

This used to work reliably.

pserve appears to be the cause of all the problems above. Fix the issues
by changing back to running gunicorn directly (no pserve) using
gunicorn's builtin Paste/ini-file support, and use gunicorn
auto-reloading. Follow the _second_ method in the gunicorn docs, under
"To use the full power of Gunicorn’s reloading and hot code
upgrades...":

https://docs.gunicorn.org/en/stable/run.html#paste-deployment