### PR TITLE
Add back development port and remove New Relic in dev

### DIFF
--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -2,3 +2,4 @@
 
 workers = 4
 reload = True
+bind = "0.0.0.0:9082"

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ whitelist_externals =
     dev: newrelic-admin
     update-pdfjs: sh
 commands =
-    dev: {posargs:newrelic-admin run-program gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini}
+    dev: {posargs:gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini}
     docker-compose: docker-compose {posargs}
     lint: pydocstyle --explain via
     lint: pydocstyle --config tests/.pydocstyle --explain tests


### PR DESCRIPTION
The recent work caused gunicorn to run on the default port 8000, which would likely clash with other products.

This only effects dev.