### PR TITLE
Remove `make docstrings` and `make checkdocstrings`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,14 +43,6 @@ node {
             }
         }
     },
-    "Docs": {
-        stage("Docs") {
-            testApp(image: img, runArgs: runArgs) {
-                installDeps()
-                run("make checkdocstrings")
-            }
-        }
-    },
     "Tests": {
         stage("Tests") {
             testApp(image: img, runArgs: "${runArgs}") {

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ help:
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests and produce a coverage report"
-	@echo "make docstrings        View all the docstrings locally as HTML"
-	@echo "make checkdocstrings   Crash if building the docstrings fails"
 	@echo "make sure              Make sure that the formatter, linter, tests, etc all pass"
 	@echo "make update-pdfjs      Update our copy of PDF-js"
 	@echo "make pip-compile       Compile requirements.in to requirements.txt"
@@ -58,14 +56,6 @@ sure: checkformatting lint test
 .PHONY: update-pdfjs
 update-pdfjs: python
 	@tox -qe update-pdfjs
-
-.PHONY: docstrings
-docstrings: python
-	@tox -qe docstrings
-
-.PHONY: checkdocstrings
-checkdocstrings: python
-	@tox -qe checkdocstrings
 
 .PHONY: pip-compile
 pip-compile: python

--- a/tox.ini
+++ b/tox.ini
@@ -37,14 +37,12 @@ passenv =
 deps =
     dev: -r requirements-dev.in
     tests: coverage
-    {tests,docstrings,checkdocstrings,lint}: -r requirements.txt
-    {tests,docstrings,checkdocstrings,lint}: -r requirements-test.in
+    {tests,lint}: -r requirements.txt
+    {tests,lint}: -r requirements-test.in
     lint: pylint<2.5
     lint: pydocstyle
     {format,checkformatting}: black
     {format,checkformatting}: isort
-    docstrings: sphinx-autobuild
-    {docstrings,checkdocstrings}: sphinx
     docker-compose: docker-compose
     pip-compile: pip-tools
     update-pdfjs: -e .
@@ -71,9 +69,6 @@ commands =
     tests: coverage run -m pytest {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report
-    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
-    docstrings: sphinx-autobuild -BqT -z via -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
-    checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     pip-compile: pip-compile {posargs}
     update-pdfjs: sh bin/update-pdfjs
     update-pdfjs: python bin/create_pdf_template.py


### PR DESCRIPTION
As we've already done in lms
(https://github.com/hypothesis/lms/pull/1523), these commands aren't
very useful and `make lint` already does some docstring checking for us.