### PR TITLE
Fix make devdata ModuleNotFoundError

### DIFF
--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -6,8 +6,6 @@ from shutil import copyfile
 from subprocess import check_call
 from tempfile import TemporaryDirectory
 
-import via
-
 
 def _get_devdata():
     # The directory that we'll clone the devdata git repo into.
@@ -19,7 +17,7 @@ def _get_devdata():
         # Copy devdata env file into place.
         copyfile(
             os.path.join(git_dir, "via/devdata.env"),
-            os.path.join(Path(via.__file__).parent.parent, ".devdata.env"),
+            os.path.join(Path(__file__).parent.parent, ".devdata.env"),
         )
 
 


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'via'` when running
`make devdata`

Fixes https://github.com/hypothesis/via3/issues/166. I think getting rid
of pserve (https://github.com/hypothesis/via3/pull/172) has fixed #166
for `make dev`. This commit fixes it for `make devdata` which seems to
be the only command still suffering from the error.