### PR TITLE
Add requests timeout of 10s and extend gunicorn timeout to 20s

### DIFF
--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -3,3 +3,4 @@
 workers = 4
 reload = True
 bind = "0.0.0.0:9082"
+timeout = 20

--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -38,6 +38,7 @@ class TestGetURLDetails:
             allow_redirects=True,
             stream=True,
             headers={"User-Agent": sentinel.user_agent},
+            timeout=10,
         )
 
     def test_it_assumes_pdf_with_a_google_drive_url(self, requests):

--- a/via/get_url_details.py
+++ b/via/get_url_details.py
@@ -65,5 +65,6 @@ def get_url_details(url, headers):
         stream=True,
         allow_redirects=True,
         headers={"User-Agent": headers.get("User-Agent", BACKUP_USER_AGENT)},
+        timeout=10,
     ) as rsp:
         return rsp.headers.get("Content-Type"), rsp.status_code


### PR DESCRIPTION
We need a longer gunicorn timeout to let the requests one kick in and to allow time for error handling. This should mean that gunicorn timeouts are only due to something being very wrong.

This is to help with https://github.com/hypothesis/via3/issues/187

# Testing

 * Checkout master
   * Start Via
    * Go to: http://localhost:9082/route?url=https%3A%2F%2Freqres.in%2Fapi%2Fusers%3Fdelay%3D30
    * Weidly this works after about 30s for me, but it should get Gunicorn timed out too
 * Checkout add-timeout
    * Go to: http://localhost:9082/route?url=https%3A%2F%2Freqres.in%2Fapi%2Fusers%3Fdelay%3D30
   * You should now see 409 conflict error in about 10 seconds