### PR TITLE
Pass through the callers User-Agent to fix picky sites

### DIFF
--- a/tests/unit/via/get_url_details_test.py
+++ b/tests/unit/via/get_url_details_test.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+from mock import sentinel
 from requests import Response
 from requests.exceptions import (
     MissingSchema,
@@ -10,7 +11,7 @@ from requests.exceptions import (
 )
 
 from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
-from via.get_url_details import get_url_details
+from via.get_url_details import BACKUP_USER_AGENT, get_url_details
 
 
 class TestGetURLDetails:
@@ -26,14 +27,22 @@ class TestGetURLDetails:
 
         url = "http://example.com"
 
-        result = get_url_details(url)
+        result = get_url_details(
+            url,
+            headers={"User-Agent": sentinel.user_agent, "Other-Nonsense": "ignored"},
+        )
 
         assert result == (content_type, status_code)
-        requests.get.assert_called_once_with(url, allow_redirects=True, stream=True)
+        requests.get.assert_called_once_with(
+            url,
+            allow_redirects=True,
+            stream=True,
+            headers={"User-Agent": sentinel.user_agent},
+        )
 
     def test_it_assumes_pdf_with_a_google_drive_url(self, requests):
         result = get_url_details(
-            "https://drive.google.com/uc?id=--FILEID--&export=download"
+            "https://drive.google.com/uc?id=--FILEID--&export=download", {}
         )
 
         assert result == ("application/pdf", 200)
@@ -43,7 +52,7 @@ class TestGetURLDetails:
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))
     def test_it_raises_BadURL_for_invalid_urls(self, bad_url):
         with pytest.raises(BadURL):
-            get_url_details(bad_url)
+            get_url_details(bad_url, {})
 
     @pytest.mark.parametrize(
         "request_exception,expected_exception",
@@ -60,7 +69,13 @@ class TestGetURLDetails:
         requests.get.side_effect = request_exception("Oh noe")
 
         with pytest.raises(expected_exception):
-            get_url_details("http://example.com")
+            get_url_details("http://example.com", {})
+
+    def test_it_uses_default_user_agent_if_none_found(self, requests):
+        get_url_details("http://example.com", {})
+
+        _, kwargs = requests.get.call_args
+        assert kwargs["headers"] == {"User-Agent": BACKUP_USER_AGENT}
 
     @pytest.fixture
     def requests(self, patch):

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -1,6 +1,7 @@
 import pytest
 from h_matchers import Any
 from mock import sentinel
+from webob.headers import EnvironHeaders
 
 from tests.unit.conftest import assert_cache_control
 from via.resources import URLResource
@@ -32,7 +33,7 @@ class TestRouteByContent:
         url = "http://example.com/path%2C?a=b"
         call_route_by_content(url, params={"other": "value"})
 
-        get_url_details.assert_called_once_with(url)
+        get_url_details.assert_called_once_with(url, Any.instance_of(EnvironHeaders))
 
     @pytest.mark.usefixtures("pdf_response")
     def test_redirects_to_pdf_view_for_pdfs_have_the_correct_params(

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -12,7 +12,7 @@ from via.get_url_details import get_url_details
 @view.view_config(route_name="route_by_content")
 def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
-    mime_type, status_code = get_url_details(context.url())
+    mime_type, status_code = get_url_details(context.url(), request.headers)
 
     # Can PDF mime types get extra info on the end like "encoding=?"
     if mime_type in ("application/x-pdf", "application/pdf"):


### PR DESCRIPTION
Some sites check the user agent to deny bot access. We can send through the original user User-Agent to get the right page for them.

This is to address https://github.com/hypothesis/via3/issues/187

# Testing

Start Via 3 and visit:

 * http://localhost:9082/route?url=https://www.seattletimes.com/seattle-news/health/coronavirus-daily-news-updates-june-23-what-to-know-today-about-covid-19-in-the-seattle-area-washington-state-and-the-world/
 * This should fail without the PR (timeout) and work with it
