### PR TITLE
Run the app through Docker in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 
 USER hypothesis
 
-CMD /usr/bin/envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf
+CMD /usr/bin/envsubst '$${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This will start the server on port 9082 (http://localhost:9082), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
 
+To simulate how the app works in production, you should access it through NGINX
+on port 9093 (http://localhost:9083)
+
 **That's it!** You’ve finished setting up your Via 3 development environment. Run
 `make help` to see all the commands that're available for running the tests,
 linting, code formatting, etc.

--- a/conf/nginx/dev_host_bridge.sh
+++ b/conf/nginx/dev_host_bridge.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Write the network of the host to the /etc/hosts file if "host.docker.internal"
+# is not supported on the system.
+# From: https://dev.to/bufferings/access-host-from-a-docker-container-4099
+
+# Check if we are on a supported system
+HOST_DOMAIN="host.docker.internal"
+ping -q -c1 $HOST_DOMAIN > /dev/null 2>&1
+
+# If not, then write find our IP and map "host.docker.internal" to it
+if [ $? -ne 0 ]; then
+  HOST_IP=$(ip route | awk 'NR==1 {print $3}')
+  echo -e "$HOST_IP\t$HOST_DOMAIN" >> /etc/hosts
+fi

--- a/conf/nginx/envsubst.conf.template
+++ b/conf/nginx/envsubst.conf.template
@@ -1,2 +1,1 @@
-set $access_control_allow_origin "${ACCESS_CONTROL_ALLOW_ORIGIN}";
 set $google_api_key "${GOOGLE_API_KEY}";

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -94,7 +94,7 @@ http {
             proxy_read_timeout 10s;
             proxy_redirect off;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Server $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Request-Start "t=${msec}";

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -27,7 +27,7 @@ http {
     # request fails (e.g. if gunicorn kills a worker for taking too long to handle
     # a single request).
     upstream web {
-        server unix:/tmp/gunicorn-web.sock fail_timeout=0;
+        include via/app_upstream.conf;
     }
 
     server {
@@ -93,6 +93,7 @@ http {
             proxy_send_timeout 10s;
             proxy_read_timeout 10s;
             proxy_redirect off;
+
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Server $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/conf/nginx/via/app_upstream.conf
+++ b/conf/nginx/via/app_upstream.conf
@@ -1,0 +1,1 @@
+server unix:/tmp/gunicorn-web.sock fail_timeout=0;

--- a/conf/nginx/via/direct_proxy.conf
+++ b/conf/nginx/via/direct_proxy.conf
@@ -37,5 +37,10 @@ proxy_set_header Authorization "";
 
 # Do not allow the third party server to set cookies.
 add_header "Set-Cookie" "";
+
+# Prevent the third party from adding CORS controls
 proxy_hide_header "Access-Control-Allow-Origin";
-add_header "Access-Control-Allow-Origin" $access_control_allow_origin;
+proxy_hide_header "Access-Control-Allow-Credentials";
+proxy_hide_header "Access-Control-Allow-Methods";
+proxy_hide_header "Access-Control-Allow-Headers";
+proxy_hide_header "Access-Control-Expose-Headers";

--- a/conf/nginx/via_dev/app_upstream.conf
+++ b/conf/nginx/via_dev/app_upstream.conf
@@ -1,0 +1,1 @@
+server host.docker.internal:9082;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     ports:
       - '127.0.0.1:9083:9083'
     environment:
-      - ACCESS_CONTROL_ALLOW_ORIGIN=http://localhost:9082
       - GOOGLE_API_KEY
     volumes:
-      - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./conf/nginx/via:/etc/nginx/via
-      - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template
-    command: /bin/sh -c "envsubst '$${ACCESS_CONTROL_ALLOW_ORIGIN} $${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
+      - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./conf/nginx/via/direct_proxy.conf:/etc/nginx/via/direct_proxy.conf:ro
+      - ./conf/nginx/via_dev/app_upstream.conf:/etc/nginx/via/app_upstream.conf:ro
+      - ./conf/nginx/dev_host_bridge.sh:/etc/nginx/dev_host_bridge.sh:ro
+      - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template:ro
+    command: /bin/sh -c "/etc/nginx/dev_host_bridge.sh && envsubst '$${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
 


### PR DESCRIPTION
This _shouldn't_ have any effect in live at all, but makes local testing much more representative of how we run in live. This has been seen working in Ubuntu and MacOS during the spike.

This means we don't need any of the CORS stuff any more (as everything goes through the same domain).

# Testing

 * Rebuild NGINX
 * `docker stop via3_nginx-proxy_1; docker rm via3_nginx-proxy_1; make services`
 * `make dev`
 * Go to: http://localhost:9083
 * All normal Via 3 stuff should work