### PR TITLE
Extend NGINX timeout to give enough space for internal timeouts

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -89,9 +89,14 @@ http {
         location / {
             proxy_pass http://web;
             proxy_http_version 1.1;
+
             proxy_connect_timeout 10s;
             proxy_send_timeout 10s;
-            proxy_read_timeout 10s;
+            # This is how long we will wait for a response from the service
+            # This has to be longer than the time we wait for websites to
+            # allow us to handle timeouts inside the app
+            proxy_read_timeout 20s;
+
             proxy_redirect off;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Server $http_host;


### PR DESCRIPTION
We timeout requests internally after 10s, so we need this timeout to be longer to give it a chance to kick in. This is for: https://github.com/hypothesis/via3/issues/187

This can be tested locally with the PR to run through docker in dev (https://github.com/hypothesis/via3/pull/190)

# Testing

 * `make services dev`
 * Go to: http://localhost:9083/route?url=https%3A%2F%2Freqres.in%2Fapi%2Fusers%3Fdelay%3D30
 * You should see 409 conflict with this match (502 before)