### PR TITLE
Add Content-Type parsing so we don't assume it's a mime-type

### DIFF
--- a/via/get_url_details.py
+++ b/via/get_url_details.py
@@ -1,4 +1,5 @@
 """Retrieve details about a resource at a URL."""
+import cgi
 import re
 from functools import wraps
 
@@ -50,7 +51,7 @@ def get_url_details(url, headers):
 
     :param url: URL to retrieve
     :param headers: The original headers the request was made with
-    :return: 2-tuple of (content type, status code)
+    :return: 2-tuple of (mime type, status code)
 
     :raise BadURL: When the URL is malformed
     :raise UpstreamServiceError: If we server gives us errors
@@ -67,4 +68,10 @@ def get_url_details(url, headers):
         headers={"User-Agent": headers.get("User-Agent", BACKUP_USER_AGENT)},
         timeout=10,
     ) as rsp:
-        return rsp.headers.get("Content-Type"), rsp.status_code
+        content_type = rsp.headers.get("Content-Type")
+        if content_type:
+            mime_type, _ = cgi.parse_header(content_type)
+        else:
+            mime_type = None
+
+        return mime_type, rsp.status_code


### PR DESCRIPTION
Content-Type headers can contain more data than just a mime-type. This adds parsing so we get out the mime type part only.

The bug was triggered getting Content-Type's like "application/pdf; qs=0.001" which does not equal "application/pdf".

# Testing

 * `make services dev`
 * Go to: http://localhost:9082/route?url=https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf
 * Previously this would redirect to original Via (port 9080)
 * Now this should be handled by Via 3 (port 9082)