### PR TITLE
Run NGINX as part of `make dev` not `make services`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,28 @@ help:
 
 .PHONY: dev
 dev: python
-	@tox -qe dev
+	@tox -qe dev -- honcho start
 
 .PHONY: devdata
 devdata: python
 	@tox -qe dev -- python bin/devdata.py
+
+.PHONY: web
+web: python
+	@tox -qe dev
+
+.PHONY: nginx
+nginx: args?=up
+nginx: python
+	@tox -qe docker-compose -- $(args)
 
 .PHONY: build
 build: python
 	@tox -qe build
 
 .PHONY: services
-services: args?=up -d
-services: python
-	@tox -qe docker-compose -- $(args)
+services:
+	@true
 
 .PHONY: lint
 lint: python

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web:   make web
+nginx: make nginx

--- a/README.md
+++ b/README.md
@@ -50,12 +50,9 @@ Create the environment variable settings needed to get Via 3 working nicely with
 The first time you run `make dev` it might take a while to start because it'll
 need to install the application dependencies and build the assets.
 
-This will start the server on port 9082 (http://localhost:9082), reload the
+This will start the server on port 9083 (http://localhost:9083), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
-
-To simulate how the app works in production, you should access it through NGINX
-on port 9093 (http://localhost:9083)
 
 **That's it!** You’ve finished setting up your Via 3 development environment. Run
 `make help` to see all the commands that're available for running the tests,

--- a/README.md
+++ b/README.md
@@ -50,9 +50,14 @@ Create the environment variable settings needed to get Via 3 working nicely with
 The first time you run `make dev` it might take a while to start because it'll
 need to install the application dependencies and build the assets.
 
-This will start the server on port 9083 (http://localhost:9083), reload the
-application whenever changes are made to the source code, and restart it should
-it crash for some reason.
+This will start NGINX running on http://localhost:9083 and reverse proxying to
+Gunicorn on http://localhost:9082, reload the application whenever changes are
+made to the source code, and restart it should it crash for some reason.
+
+**You should use NGINX (http://localhost:9083) as your main entry point** to
+Via 3 in development. This is how it's used in production, and if you visit
+Gunicorn directly you'll get CORS (Cross Origin Resource Sharing) errors from
+your browser.
 
 **That's it!** You’ve finished setting up your Via 3 development environment. Run
 `make help` to see all the commands that're available for running the tests,

--- a/README.md
+++ b/README.md
@@ -43,13 +43,6 @@ Create the environment variable settings needed to get Via 3 working nicely with
 
     make devdata
 
-### Run the services with Docker Compose
-
-Start the services that Via 3 requires (currently just NGINX) using Docker
-Compose:
-
-    make services
-
 ### Start the development server
 
     make dev

--- a/README.md
+++ b/README.md
@@ -171,32 +171,8 @@ in development does use the same `nginx.conf` file as the NGINX running in
 Docker in production.
 
 The Python WSGI server (Gunicorn) runs on the host (no Docker) and is exposed
-at http://localhost:9082/.
-
-NGINX is _not_ "in front of" Gunicorn in development. Rather, NGINX and
-Gunicorn are "alongside" each other:
-
-1. The front page of the app in development is http://localhost:9082/, which is
-   served by Gunicorn directly without involving NGINX.
-
-   Other URLs that're handled by the Pyramid app are also at
-   `http://localhost:9082/*` and served by Gunicorn directly.
-
-2. For requests that should be handled by NGINX directly (for example the
-   `/proxy/static/*` URLs) the Pyramid app redirects the browser to
-   `http://localhost:9083/*` URLs that're handled by the NGINX instance running
-   in Docker Compose without further involving Python.
-
-### But that means development is different from production!
-
-That's true but the difference is small. In production requests that should be
-handled by Gunicorn first go to NGINX which then proxies to Gunicorn. Whereas
-in dev these requests go directly from the browser to Gunicorn. A small part of
-the `nginx.conf` file that does the proxying to Gunicorn is used in production
-but not in dev.
-
-In practice this isn't really a problem and putting NGINX in front of Gunicorn
-in development would likely create more issues than it would solve.
+at http://localhost:9082/. The NGINX running on `:9083` proxies to the Gunicorn
+on `:9082`.
 
 ### WhiteNoise
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -r requirements.txt
 -e .
 
+honcho
 ipython
 ipdb


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via3/issues/134

NGINX is part of the app itself, not a service. Change `make dev` to run both the Gunicorn and NGINX processes just like `make dev` runs all of the app's processes for our other apps (Gunicorn and assets rebuilding for LMS; Gunicorn, assets and Celery beat and workers for h).

1. Change `make services` to a no-op.

   Via 3 no longer has any services. I did leave the `make services` command in there, it just doesn't do anything. This will make scripting easier if every app has a `make services` (we should add a no-op `make services` to our other apps that don't have one too).
   
   I did remove `make services` from the README though, as it's no longer necessary to run it.

2. Change `make dev` to run Honcho.

   Just the same process multiplexer that `make dev` uses in our other apps. Honcho is extremely simple, does exactly what we want and nothing more.
   
   Honcho is added to the dev requirements and a `Procfile` is added telling Honcho which two processes it should run: Gunicorn and NGINX.

Note that you can still run NGINX and Gunicorn separately if you want to. You would just look in `Procfile` to see what commands it runs, and then run them one by one yourself:

```terminal
$ cat Procfile 
web:   make web
nginx: make nginx
$ make web
[2020-06-29 10:41:37 +0100] [236362] [INFO] Starting gunicorn 20.0.4
[2020-06-29 10:41:37 +0100] [236362] [INFO] Listening at: http://0.0.0.0:9082 (236362)
...
```