### PR TITLE
Adding a view to help debugging headers

### DIFF
--- a/html_test_harness/dump_headers.py
+++ b/html_test_harness/dump_headers.py
@@ -1,0 +1,19 @@
+import json
+from collections import OrderedDict
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route('/')
+def dump_headers():
+    headers = OrderedDict(request.headers)
+
+    for bad_header in ('Cookie', 'Host'):
+        headers.pop(bad_header, None)
+
+    return f"<pre>{json.dumps(headers, indent=4)}</pre>", 200
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tests/unit/via/views/__init___test.py
+++ b/tests/unit/via/views/__init___test.py
@@ -14,5 +14,6 @@ class TestIncludeMe:
             mock.call("get_status", "/_status"),
             mock.call("view_pdf", "/pdf", factory=URLResource),
             mock.call("route_by_content", "/route", factory=URLResource),
+            mock.call("debug_headers", "/debug/headers"),
         ]
         config.scan.assert_called_once_with("via.views")

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -7,6 +7,7 @@ def add_routes(config):
     config.add_route("get_status", "/_status")
     config.add_route("view_pdf", "/pdf", factory=URLResource)
     config.add_route("route_by_content", "/route", factory=URLResource)
+    config.add_route("debug_headers", "/debug/headers")
 
 
 def includeme(config):

--- a/via/views/debug.py
+++ b/via/views/debug.py
@@ -1,0 +1,45 @@
+"""Views for debugging."""
+
+import json
+from collections import OrderedDict
+
+from pyramid import view
+from pyramid.response import Response
+
+
+@view.view_config(route_name="debug_headers")
+def debug_headers(_context, request):
+    """Dump the headers as we receive them for debugging."""
+    headers = OrderedDict()
+
+    for header_name, value in request.headers.items():
+        # Get around something in the stack giving us the wrong value here
+        if header_name == "Dnt":
+            header_name = "DNT"
+        headers[header_name] = value
+
+    # These aren't interesting to us
+    headers.pop("Cookie", None)
+    headers.pop("Host", None)
+
+    # We don't care where they really came from just where Referer appears
+    if "Referer" in headers:
+        headers["Referer"] = "https://www.google.com/"
+
+    return Response(
+        body=f"""
+            <h1>Instructions</h1>
+            <ol>
+                <li>Enable Do-Not-Track if supported</li>
+                <li>
+                    <a href="{request.route_url('debug_headers')}">
+                        Click here to get referer
+                    </a>
+                </li>
+                <li>Press F5 to get 'Cache-Control'</li>
+            </ol>
+            <hr>
+            <pre>{json.dumps(headers, indent=4)}</pre><br>
+        """,
+        status=200,
+    )


### PR DESCRIPTION
This is so we can capture example headers to know where to insert `Referer`.

To test do all the usual stuff then go to:

 * http://0.0.0.0:9082/debug/headers

You should see a page like this:

![image](https://user-images.githubusercontent.com/7131143/86488156-ff39bd80-bd57-11ea-822a-f65aa57f7cef.png)
