### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,9 @@ commands =
     lint: pylint {posargs:via bin}
     lint: pylint --rcfile=tests/.pylintrc tests
     format: black via tests bin
-    format: isort --recursive --quiet --atomic via tests bin
+    format: isort --quiet --atomic via tests bin
     checkformatting: black --check via tests bin
-    checkformatting: isort --recursive --quiet --check-only via tests bin
+    checkformatting: isort --quiet --check-only via tests bin
     tests: coverage run -m pytest {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always
recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020