### PR TITLE
Pass through a cleaned version of the users headers, instead of just User-Agent

### DIFF
--- a/tests/unit/via/get_url/headers_test.py
+++ b/tests/unit/via/get_url/headers_test.py
@@ -1,0 +1,50 @@
+from collections import OrderedDict
+
+import pytest
+
+from via.get_url.headers import (
+    BANNED_HEADERS,
+    HEADER_DEFAULTS,
+    HEADER_MAP,
+    clean_headers,
+)
+
+
+class TestCleanHeaders:
+    def test_basics(self):
+        headers = {"Most-Headers": "are passed through", "Preserving": "order"}
+
+        result = clean_headers(headers)
+
+        assert result == headers
+        assert list(result.keys()) == ["Most-Headers", "Preserving"]
+        assert isinstance(result, OrderedDict)
+
+    # For the following tests we are going to lean heavily on the defined lists
+    # of headers, and just test that the function applies them correctly. Other
+    # wise we just end-up copy pasting them here to no real benefit
+
+    @pytest.mark.parametrize("header_name", BANNED_HEADERS)
+    def test_we_remove_banned_headers(self, header_name):
+        result = clean_headers({header_name: "value"})
+
+        assert header_name not in result
+
+    @pytest.mark.parametrize("header_name,default_value", HEADER_DEFAULTS.items())
+    def test_we_assign_to_defaults_if_present(self, header_name, default_value):
+        result = clean_headers({header_name: "some custom default"})
+
+        assert result[header_name] == default_value
+
+    @pytest.mark.parametrize("header_name", HEADER_DEFAULTS.keys())
+    def test_we_do_not_assign_to_defaults_if_absent(self, header_name):
+        result = clean_headers({})
+
+        assert header_name not in result
+
+    @pytest.mark.parametrize("header_name,mapped_name", HEADER_MAP.items())
+    def test_we_map_mangled_header_names(self, header_name, mapped_name):
+        result = clean_headers({header_name: "value"})
+
+        assert result[mapped_name] == "value"
+        assert header_name not in result

--- a/via/get_url/__init__.py
+++ b/via/get_url/__init__.py
@@ -1,3 +1,4 @@
 """A collection of tools for getting URL and inspecting the contents."""
 
+from via.get_url.details import get_url_details
 from via.get_url.headers import clean_headers

--- a/via/get_url/details.py
+++ b/via/get_url/details.py
@@ -13,15 +13,10 @@ from via.exceptions import (
     UnhandledException,
     UpstreamServiceError,
 )
+from via.get_url.headers import clean_headers
 
 GOOGLE_DRIVE_REGEX = re.compile(
     r"^https://drive.google.com/uc\?id=(.*)&export=download$", re.IGNORECASE
-)
-
-# The Chrome user-agent as of 24/06/2020
-BACKUP_USER_AGENT = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
-    "snap Chromium/83.0.4103.106 Chrome/83.0.4103.106 Safari/537.36"
 )
 
 
@@ -65,7 +60,7 @@ def get_url_details(url, headers):
         url,
         stream=True,
         allow_redirects=True,
-        headers={"User-Agent": headers.get("User-Agent", BACKUP_USER_AGENT)},
+        headers=clean_headers(headers),
         timeout=10,
     ) as rsp:
         content_type = rsp.headers.get("Content-Type")

--- a/via/views/debug.py
+++ b/via/views/debug.py
@@ -33,7 +33,10 @@ def debug_headers(_context, request):
             </ol>
 
             <a href="{request.route_url('debug_headers')}?raw=1">Show all headers</a>
+
             <hr>
+
+            <h1>Headers received</h1>
             <pre>{json.dumps(headers, indent=4)}</pre><br>
         """,
         status=200,

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -6,7 +6,7 @@ from pyramid import httpexceptions as exc
 from pyramid import view
 from webob.multidict import MultiDict
 
-from via.get_url_details import get_url_details
+from via.get_url import get_url_details
 
 
 @view.view_config(route_name="route_by_content")


### PR DESCRIPTION
 * Remove lots of Cloudflare and other platform stuff
 * Remove some essentials like `Host` and `Cookie`
 * Map a few values to sensible defaults (after potential AWS mangling)
 * Remove un-used "cookie passing mode" flag
 * Nest `get_url_details` into `get_url.details` to give space for `get_url.headers`

This is in an attempt to get the Seattle Times working