### PR TITLE
Fix relative redirect handling

### DIFF
--- a/conf/nginx/via/direct_proxy.conf
+++ b/conf/nginx/via/direct_proxy.conf
@@ -21,7 +21,8 @@ rewrite ^/proxy/static/(.*)$ $1? break;
 # Add back on the args which we stripped above so we don't get them twice
 proxy_pass $uri$is_args$args;
 
-proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/$1;
+proxy_redirect ~^(https?:\/\/)(.*)$ $original_scheme://$http_host/proxy/static/$1$2;
+proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/https://$proxy_host$1;
 
 # Strip hypothesis cookies and authorization header.
 set $stripped_cookie $http_cookie;


### PR DESCRIPTION
The download URLs for PDFs uploaded to Blackboard return a *relative* redirect (with the leading `https://blackboard.hypothes.is` missing). We apparently haven't encountered relative redirects before because they don't work: Via 3's `/proxy/static` endpoint (the endpoint that is served by NGINX directly) fails to re-add the missing
`https://blackboard.hypothes.is` prefix before redirecting and ends up redirecting the browser to
`https://via3.hypothes.is/proxy/static//bbcswebdav/courses/developer-test-course-1/uploaded-directly.pdf?VxJ...%3D` (note the `//` in `/static//bbcswebdav` where the missing `https://blackboard.hypothes.is` should be).

Fix the static endpoint to insert the missing `https://blackboard.hypothes.is` prefix.

Testing:

To test this with Blackboard Files:

1. Check out this WIP branch of the LMS app: https://github.com/hypothesis/lms/pull/1965

2. Set the `BLACKBOARD_CLIENT_SECRET` envvar: `export BLACKBOARD_CLIENT_SECRET="***"`. See Slack for the secret

2. Log in to https://blackboard.hypothes.is/ using the `administrator` account (it's in 1Password)

3. Go to Developer Test Course 1 and launch Blackboard Files Assignment. Choose Select PDF from Blackboard then click Authorize. **It doesn't actually work**, but the authorization popup window should have caused a temporary Blackboard Files download URL to be printed to the terminal. You can paste the URL into http://localhost:9083/

To test that non-Blackboard files still work:

* An HTTP PDF file: http://localhost:9083/route?url=http%3A%2F%2Fwww.orimi.com%2Fpdf-test.pdf

* An HTTPS PDF file: http://localhost:9083/route?url=https%3A%2F%2Fwww.w3.org%2FWAI%2FER%2Ftests%2Fxhtml%2Ftestfiles%2Fresources%2Fpdf%2Fdummy.pdf

* A PDF file behind a redirect: http://localhost:9083/route?url=https%3A%2F%2Fh.readthedocs.io%2F_%2Fdownloads%2Fen%2Flatest%2Fpdf%2F

Test assignments: https://hypothesis.instructure.com/courses/125/assignments

Known issues:

* This only works for hosts that support https. `https` is hard-coded when inserting the `https://$proxy_host` prefix in `direct_proxy.conf`.  This is because I couldn't find an NGINX variable for the scheme (http or https) of the URL being proxied.

  Having this work for https hosts only is better than it not working at all.