### PR TITLE
Don't timeout gunicorn workers in dev

### DIFF
--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -3,4 +3,4 @@
 workers = 4
 reload = True
 bind = "0.0.0.0:9082"
-timeout = 20
+timeout = 0


### PR DESCRIPTION
In development you often want to drop into a debug shell at some point during the handling of the request. You don't want Gunicorn to timeout the worker after 20s and break your debugging session. Let Gunicorn workers run forever in dev, like we do for the rest of our apps.