### PR TITLE
Replace Honcho with Supervisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 via/static/**/*.gz
 build.tar
 .devdata.env
+supervisord.log
+supervisord.pid

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,14 @@ clean:
 	@find . -type d -name "__pycache__" -delete
 	@find . -type f -name "*.gz" -delete
 
+.PHONY: web
+web: python
+	@tox -qe dev --run-command 'gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini'
+
+.PHONY: nginx
+nginx: python
+	@tox -qe dev --run-command 'docker-compose run --rm --service-ports nginx-proxy'
+
 .PHONY: python
 python:
 	@./bin/install-python

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 help:
 	@echo "make help              Show this help message"
 	@echo "make dev               Run the app in the development server"
+	@echo "make supervisor        Launch a supervisorctl shell for managing the processes "
+	@echo '                       that `make dev` starts, type `help` for docs'
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo 'make build             Prepare the build files'
 	@echo "make lint              Run the code linter(s) and print any warnings"
@@ -19,20 +21,15 @@ help:
 
 .PHONY: dev
 dev: python
-	@tox -qe dev -- honcho start
+	@tox -qe dev
+
+.PHONY: supervisor
+supervisor: python
+	@tox -qe dev --run-command 'supervisorctl -c conf/supervisord-dev.conf $(command)'
 
 .PHONY: devdata
 devdata: python
 	@tox -qe dev -- python bin/devdata.py
-
-.PHONY: web
-web: python
-	@tox -qe dev
-
-.PHONY: nginx
-nginx: args?=up
-nginx: python
-	@tox -qe docker-compose -- $(args)
 
 .PHONY: build
 build: python

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web:   make web
-nginx: make nginx

--- a/bin/logger
+++ b/bin/logger
@@ -64,24 +64,69 @@ we redirect the aggregated output back to STDOUT (FD 1). You can also log the
 aggregated output to a single file.
 """
 
+import itertools
 import sys
 
 WIDTH = 20
 
 
+class Colors:
+    colors = itertools.cycle(
+        {
+            "cyan": "36",
+            "yellow": "33",
+            "green": "32",
+            "magenta": "35",
+            "blue": "34",
+            "intense_cyan": "36;1",
+            "intense_yellow": "33;1",
+            "intense_green": "32;1",
+            "intense_magenta": "35;1",
+            "intense_blue": "34;1",
+        }.values()
+    )
+
+    intense_red = "31;1"
+
+    def __init__(self):
+        self._process_colors = {}
+
+    def color(self, process_name, s, error=False):
+        if error:
+            color = self.intense_red
+        else:
+            color = self._process_colors.get(process_name)
+
+            if not color:
+                color = self._process_colors[process_name] = next(self.colors)
+
+        return self._color_string(color, s)
+
+    @staticmethod
+    def _ansi(code):
+        return "\033[{0}m".format(code)
+
+    @classmethod
+    def _color_string(cls, color, s):
+        return "{0}{1}{2}{3}".format(cls._ansi(0), cls._ansi(color), s, cls._ansi(0))
+
+
+colors = Colors()
+
+
 def main():
     while True:
-        _write('READY\n')
+        _write("READY\n")
         header = _parse_header(sys.stdin.readline())
-        payload = sys.stdin.read(int(header['len']))
+        payload = sys.stdin.read(int(header["len"]))
 
         # Only handle PROCESS_LOG_* events and just ACK anything else.
-        if header['eventname'] == 'PROCESS_LOG_STDOUT':
+        if header["eventname"] == "PROCESS_LOG_STDOUT":
             _log_payload(payload)
-        elif header['eventname'] == 'PROCESS_LOG_STDERR':
+        elif header["eventname"] == "PROCESS_LOG_STDERR":
             _log_payload(payload, err=True)
 
-        _write('RESULT 2\nOK')
+        _write("RESULT 2\nOK")
 
 
 def _write(s):
@@ -90,20 +135,36 @@ def _write(s):
 
 
 def _parse_header(data):
-    return dict([x.split(':') for x in data.split()])
+    return dict([x.split(":") for x in data.split()])
+
+
+# Patterns in log lines that identify them as not being errors, even if the
+# log line was written to stderr.
+NON_ERROR_MARKERS = ["[INFO]"]
 
 
 def _log_payload(payload, err=False):
-    headerdata, data = payload.split('\n', 1)
+    headerdata, data = payload.split("\n", 1)
     header = _parse_header(headerdata)
-    name = header['processname']
+    name = header["processname"]
     if err:
-        name += ' (stderr)'
-    prefix = '{name:{width}} | '.format(name=name, width=WIDTH)
+        name += " (stderr)"
+    prefix = "{name:{width}} | ".format(name=name, width=WIDTH)
+
     for line in data.splitlines():
-        sys.stderr.write(prefix + line + '\n')
+        format_as_error = err and all(
+            [marker not in line for marker in NON_ERROR_MARKERS]
+        )
+
+        output_line = prefix + line + "\n"
+
+        if "--dev" in sys.argv:
+            output_line = colors.color(name, output_line, error=format_as_error)
+
+        sys.stderr.write(output_line)
+
     sys.stderr.flush()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -10,10 +10,10 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:nginx]
-command=docker-compose up --no-color --exit-code-from nginx-proxy nginx-proxy
+command=docker-compose run --rm --service-ports nginx-proxy
 stdout_events_enabled=true
 stderr_events_enabled=true
-stopsignal = KILL
+stopsignal = INT
 stopasgroup = true
 
 [eventlistener:logger]

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -1,0 +1,35 @@
+[supervisord]
+nodaemon = true
+silent = true
+
+[program:web]
+command=gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
+[program:nginx]
+command=docker-compose up --no-color --exit-code-from nginx-proxy nginx-proxy
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
+[eventlistener:logger]
+command=bin/logger --dev
+buffer_size=100
+events=PROCESS_LOG
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/null
+
+[unix_http_server]
+file = .supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix://.supervisor.sock
+prompt = via3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,7 @@
 -r requirements.txt
 -e .
 
-honcho
 ipython
 ipdb
+supervisor
+docker-compose

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ xfail_strict=true
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.8.0
+minversion = 3.16.1
 requires =
     tox-pip-extensions
     tox-pyenv
@@ -21,6 +21,7 @@ tox_pyenv_fallback = false
 [testenv]
 skip_install = true
 setenv =
+    PYTHONUNBUFFERED = 1
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:via3}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
@@ -33,7 +34,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
-    docker-compose: GOOGLE_API_KEY
+    dev: GOOGLE_API_KEY
 deps =
     dev: -r requirements-dev.in
     tests: coverage
@@ -43,7 +44,6 @@ deps =
     lint: pydocstyle
     {format,checkformatting}: black
     {format,checkformatting}: isort
-    docker-compose: docker-compose
     pip-compile: pip-tools
     update-pdfjs: -e .
     build: -e .
@@ -56,8 +56,7 @@ whitelist_externals =
     dev: newrelic-admin
     update-pdfjs: sh
 commands =
-    dev: {posargs:gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini}
-    docker-compose: docker-compose {posargs}
+    dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     lint: pydocstyle --explain via
     lint: pydocstyle --config tests/.pydocstyle --explain tests
     lint: pylint {posargs:via bin}
@@ -74,3 +73,16 @@ commands =
     update-pdfjs: python bin/create_pdf_template.py
     build: python bin/minify_assets.py -c conf/minify_assets.json
     build: python -m whitenoise.compress via/static
+
+[testenv:dev]
+# By default when you Ctrl-c the `make dev` command tox is too aggressive about
+# killing supervisor. tox kills supervisor before supervisor has had time to
+# stop or kill its child processes, resulting in detached child processes being
+# left running and other problems.
+#
+# Fix this by configuring tox to wait a long time before sending any further
+# SIGINTs (after the first one) or SIGTERMs or SIGKILLs to supervisor.
+# Just trust supervisor to clean up all its child processes and stop.
+suicide_timeout = 60.0
+interrupt_timeout = 60.0
+terminate_timeout = 60.0


### PR DESCRIPTION
Same as we've done for lms and h:

https://github.com/hypothesis/lms/pull/1897
https://github.com/hypothesis/h/pull/6103

This seems to have been working well for h and lms: `make dev` is stopping quickly and reliably when Ctrl-C'd.

Via 3 has still been having the old problems and is now inconsistent with h and lms so let's bring it into line.

This is the last app to remove Honcho from: bouncer and legacy Via don't use Honcho (`make dev` only runs one process)