### PR TITLE
Fixing bad coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 parallel = True
 source =
-    py_proxy
+    via
     tests/unit
 
 [report]

--- a/tests/unit/via/views/debug_test.py
+++ b/tests/unit/via/views/debug_test.py
@@ -1,0 +1,62 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+from h_matchers import Any
+from pyramid.testing import DummyRequest
+
+from via.views.debug import debug_headers
+
+
+class TestDebugHeaders:
+    def test_it(self, pyramid_request):
+        pyramid_request.headers = {"Key": "Value"}
+        response = debug_headers(sentinel.context, pyramid_request)
+
+        pyramid_request.route_url.assert_called_once_with("debug_headers")
+
+        assert response.status_code == 200
+        assert response.text == Any.string.containing(
+            pyramid_request.route_url.return_value
+        )
+        assert response.text == Any.string.containing("Key")
+        assert response.text == Any.string.containing("Value")
+
+    def test_it_does_not_clean_headers_with_raw_true(
+        self, pyramid_request, clean_headers, OrderedDict
+    ):
+        pyramid_request.GET["raw"] = "1"
+
+        debug_headers(sentinel.context, pyramid_request)
+
+        clean_headers.assert_not_called()
+        OrderedDict.assert_called_once_with(pyramid_request.headers)
+
+    def test_it_cleans_headers_with_raw_false(
+        self, pyramid_request, clean_headers, OrderedDict
+    ):
+        pyramid_request.GET["raw"] = ""
+
+        debug_headers(sentinel.context, pyramid_request)
+
+        OrderedDict.assert_not_called()
+        clean_headers.assert_called_once_with(pyramid_request.headers)
+
+    @pytest.fixture
+    def OrderedDict(self, patch):
+        return patch("via.views.debug.OrderedDict")
+
+    @pytest.fixture
+    def clean_headers(self, patch):
+        clean_headers = patch("via.views.debug.clean_headers")
+        clean_headers.return_value = {"something": "JSON serialisable"}
+        return clean_headers
+
+    @pytest.fixture
+    def pyramid_request(self):
+        pyramid_request = DummyRequest()
+
+        # `route_url` seems to go big time bonkers if you use the built in one
+        pyramid_request.route_url = create_autospec(pyramid_request.route_url)
+        pyramid_request.route_url.return_value = "ROUTE_URL"
+
+        return pyramid_request

--- a/via/views/debug.py
+++ b/via/views/debug.py
@@ -18,6 +18,8 @@ def debug_headers(_context, request):
     else:
         headers = clean_headers(request.headers)
 
+    self_url = request.route_url("debug_headers")
+
     return Response(
         body=f"""
             <h1>Instructions</h1>
@@ -25,14 +27,14 @@ def debug_headers(_context, request):
                 <li>Access the service directly (not thru *.hypothes.is)
                 <li>Enable Do-Not-Track if supported</li>
                 <li>
-                    <a href="{request.route_url('debug_headers')}">
+                    <a href="{self_url}">
                         Click here to get referer
                     </a>
                 </li>
                 <li>Press F5 to get 'Cache-Control'</li>
             </ol>
 
-            <a href="{request.route_url('debug_headers')}?raw=1">Show all headers</a>
+            <a href="{self_url}?raw=1">Show all headers</a>
 
             <hr>
 


### PR DESCRIPTION
 * We now cover the right package name
 * We've suppressed a lot of output, which makes this hard to spot
 * Added some so-so coverage of debug, which was the only thing not covered

I knew there was something up with our coverage being wonky and always at 100%. Turns out quite some time ago when the package name changed, the reference in the coverage config didn't. This meant our 100% was 100% of the tests, not the code. As it goes we were basically at 100% (99.1%) bar a kind of throw away view for debugging headers.