### PR TITLE
Add a check box to enable internal rewriting POC

### DIFF
--- a/via/static/index.html
+++ b/via/static/index.html
@@ -62,7 +62,26 @@
     .annotate-btn:hover {
       background-color: #d00032;
     }
+    .input-group {
+      padding-bottom: 10px;
+    }
+
   </style>
+
+  <script type="text/javascript">
+    window.onload = function(){
+        let isChecked = localStorage.getItem("via.rewrite").toLowerCase();
+        isChecked = isChecked !== null && isChecked.toLowerCase() === "true";
+
+        const checkbox = document.getElementById("via.rewrite");
+        checkbox.checked = isChecked;
+    }
+
+    function captureExperimentalState(){
+        const checkbox = document.getElementById("via.rewrite");
+        localStorage.setItem("via.rewrite", checkbox.checked);
+    }
+  </script>
 </head>
 <body>
   <div class="content">
@@ -84,9 +103,16 @@
            name="url"
            placeholder="Paste a link to annotate"
            type="url"
-           >
+     >
+    <div class="input-group">
+      <input type="checkbox" name="via.rewrite" id="via.rewrite" onclick="captureExperimentalState()">
+      <label for="via.rewrite">Use experimental HTML rewriter</label>
+    </div>
+
     <button type="submit" class="annotate-btn">Annotate</button>
   </form>
   </div>
+
+
 </body>
 </html>


### PR DESCRIPTION
Adds a checkbox which will enable the right param for internal HTML rewriting. This should also remember the last state it was in on page refresh.

To test this you might have to run 'make clean' first.