### PR TITLE
Allow `experimentalPDFSideBySide` URL config parameter

### DIFF
--- a/via/configuration.py
+++ b/via/configuration.py
@@ -45,6 +45,7 @@ class Configuration(object):
         "requestConfigFromFrame",
         # Things which seem safe
         "enableExperimentalNewNoteButton",
+        "enableExperimentalPDFSideBySide",
         "externalContainerSelector",
         "focus",
         "showHighlights",


### PR DESCRIPTION
I'd like to add `enableExperimentalPDFSideBySide` to the whitelist of allowed URL query parameters so that folks can preview the PDF side-by-side mode.