### PR TITLE
Remove `-e file:.#egg=via` from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Updating the PDF viewer
 
 Via 3 serves PDFs using [PDF.js](https://mozilla.github.io/pdf.js/). PDF.js is
 vendored into the source tree and the viewer HTML is patched to load the Hypothesis
-client. To update the PDF viewer, run `tools/update-pdfjs`.
+client. To update the PDF viewer, run `make update-pdfjs`.
 
 How Via 3 works
 ---------------

--- a/requirements/build.in
+++ b/requirements/build.in
@@ -1,4 +1,3 @@
--e file:.#egg=via
 whitenoise
 rcssmin
 rjsmin

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile requirements/build.in
 #
--e file:.#egg=via         # via -r requirements/build.in
 htmlmin==0.1.12           # via -r requirements/build.in
 rcssmin==1.0.6            # via -r requirements/build.in
 rjsmin==1.1.0             # via -r requirements/build.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,4 @@
 -r requirements.txt
--e file:.#egg=via
 ipython
 ipdb
 supervisor

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile requirements/dev.in
 #
--e file:.#egg=via         # via -r requirements/dev.in
 attrs==20.2.0             # via jsonschema
 babel==2.8.0              # via -r requirements/requirements.txt, pywb
 backcall==0.2.0           # via ipython

--- a/requirements/updatepdfjs.in
+++ b/requirements/updatepdfjs.in
@@ -1,1 +1,0 @@
--e file:.#egg=via

--- a/requirements/updatepdfjs.txt
+++ b/requirements/updatepdfjs.txt
@@ -4,4 +4,3 @@
 #
 #    pip-compile requirements/updatepdfjs.in
 #
--e file:.#egg=via         # via -r requirements/updatepdfjs.in

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ tox_pyenv_fallback = false
 [testenv]
 skip_install = true
 setenv =
+    PYTHONPATH = .
     PYTHONUNBUFFERED = 1
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:via3}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}


### PR DESCRIPTION
Putting `-e .` in requirements files doesn't work, see:

https://github.com/hypothesis/lms/pull/2111
https://github.com/jazzband/pip-tools/issues/204#issuecomment-550051424

The workaround of putting `-e file:.#egg=via` in the requirements files
instead doesn't work with Dependabot:

https://github.com/hypothesis/via3/issues/261
https://github.com/hypothesis/via3/pull/257#issuecomment-688825972

The `-e .` / `-e file:.#egg=via` appears to be unnecessary anyway: most
of the virtualenvs across most of our apps don't use, only _some_ of Via
3's and some of LMS's venvs use it, for unknown reasons.

Fix the issue by removing the `-e .` / `-e file:.#egg=via`. As far as I
can tell it's unnecessary, everything still works fine. Use of
`pkg_resources.resource_filename()` in `create_pdf_template.py` needed
to be fixed, but that appears to be all.