### PR TITLE
Redirect users according to a ratio to ViaHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ your browser.
 `make help` to see all the commands that're available for running the tests,
 linting, code formatting, etc.
 
+Configuration
+-------------
+
+Environment variables:
+
+| Name             | Purpose | Example |
+|------------------|---------|---------|
+| `VIA_HTML_URL`     | The URL of the Via HTML component | `https://viahtml3.hypothes.is/proxy`
+| `VIA_HTML_RATIO`   | A ratio of HTML request (between 0 and 1) to send to Via HTML | `0.25`
+
 Updating the PDF viewer
 -----------------------
 

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -3,5 +3,5 @@ use = call:via.app:create_app
 
 nginx_server: http://localhost:9083
 client_embed_url: http://localhost:5000/embed.js
-via_html_url: http://localhost:9083/html/v
+via_html_url: http://localhost:9085/proxy
 legacy_via_url: http://localhost:9080

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,7 +43,7 @@ def pyramid_settings():
         "client_embed_url": "http://hypothes.is/embed.js",
         "nginx_server": "http://via3.hypothes.is",
         "legacy_via_url": "http://via.hypothes.is",
-        "via_html_url": "https://via3-html.hypothes.is",
+        "via_html_url": "https://viahtml3.hypothes.is/proxy",
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ passenv =
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
     dev: GOOGLE_API_KEY
+    dev: VIA_HTML_RATIO
 deps =
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt

--- a/via/views/route_by_content/_html_rewriter.py
+++ b/via/views/route_by_content/_html_rewriter.py
@@ -1,5 +1,6 @@
 """Logic for interacting with HTML rewriters."""
-
+import os
+from random import random
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 from h_vialib import Configuration
@@ -47,7 +48,18 @@ class HTMLRewriter:
     def _html_rewriter_url(self, params):
         via_config, _ = Configuration.extract_from_params(params)
 
-        if asbool(via_config.get("rewrite")):
+        use_via_html = asbool(via_config.get("rewrite"))
+        if not use_via_html:
+            # Redirect a random portion of requests to ViaHTML if requested
+            try:
+                via_html_ratio = float(os.environ.get("VIA_HTML_RATIO", 0))
+            except ValueError:
+                via_html_ratio = 0.0
+
+            if random() < via_html_ratio:
+                use_via_html = True
+
+        if use_via_html:
             # Attempt to enable internal rewriter if `via.rewrite` is in the
             # query string and truthy
 


### PR DESCRIPTION
For: https://github.com/hypothesis/via3/issues/236

There is a new environment variable `VIA_HTML_RATIO` which can be set to send some traffic towards Via HTML instead of Via for HTML content.

If you set this to `0.25` for example, then roughly 25% of requests should be sent to Via HTML.

The idea is to allow us to cut over a number of users at a time and observe the scaling behavior in ViaHTML.

## Testing notes:

 * `export VIA_HTML_RATIO=0.25 make dev`
 * Visit "http://localhost:9083/"
 * Disable `Use experimental HTML rewriter`
 * Open dev tools and "Disable cache" (otherwise you'll cache the redirect)
 * Then repeatedly enter "http://example.com" and visit it
 * You should end up on:
    * http://localhost:9080/http://example.com (roughly 75% of the time)
    * http://localhost:9085/proxy/http://example.com (roughly 25% of the time)