### PR TITLE
Don't emit caching headers on HTML redirects if we switching to ViaHTML

### DIFF
--- a/tests/unit/via/views/route_by_content/_html_rewriter_test.py
+++ b/tests/unit/via/views/route_by_content/_html_rewriter_test.py
@@ -26,14 +26,17 @@ class TestHTMLRewriter:
     def test_it_extracts_the_url_and_prepends_it(self, rewriter):
         doc_url = "http://example.com/doc"
 
-        url = rewriter.url_for({"url": doc_url})
+        url, cacheable = rewriter.url_for({"url": doc_url})
 
         assert url.startswith(f"{rewriter.legacy_via_url}/{doc_url}")
+        assert cacheable
 
     def test_it_merges_params(self, rewriter):
         doc_url = "http://example.com/doc?a=1&b=2"
 
-        url = rewriter.url_for({"url": doc_url, "via.openSidebar": "1", "other": "any"})
+        url, cacheable = rewriter.url_for(
+            {"url": doc_url, "via.openSidebar": "1", "other": "any"}
+        )
 
         assert url == Any.url.with_query(
             {
@@ -44,20 +47,21 @@ class TestHTMLRewriter:
                 "other": "any",
             }
         )
+        assert cacheable
 
     @pytest.mark.parametrize(
-        "env_value,random_value,expected_url",
+        "env_value,random_value,expected_url,is_cacheable",
         (
-            ("0.5", 0.1, "via_html_url"),
-            (" 0.5  ", 0.1, "via_html_url"),
-            ("0.5", 0.9, "legacy_via_url"),
-            ("not_a_number", 0.1, "legacy_via_url"),
-            (..., 0.5, "legacy_via_url"),
+            ("0.5", 0.1, "via_html_url", False),
+            (" 0.5  ", 0.1, "via_html_url", False),
+            ("0.5", 0.9, "legacy_via_url", False),
+            ("not_a_number", 0.1, "legacy_via_url", True),
+            (..., 0.5, "legacy_via_url", True),
         ),
     )
     # pylint: disable=too-many-arguments
     def test_it_switches_rewriter_based_on_ratio(
-        self, rewriter, os, random, env_value, random_value, expected_url
+        self, rewriter, os, random, env_value, random_value, expected_url, is_cacheable
     ):
         os.environ = {}
         if env_value is not ...:
@@ -65,9 +69,10 @@ class TestHTMLRewriter:
 
         random.return_value = random_value
 
-        url = rewriter.url_for({"url": "anything"})
+        url, cacheable = rewriter.url_for({"url": "anything"})
 
         assert url.startswith(getattr(rewriter, expected_url))
+        assert cacheable == is_cacheable
 
     @pytest.fixture
     def rewriter(self):

--- a/tests/unit/via/views/route_by_content/view_test.py
+++ b/tests/unit/via/views/route_by_content/view_test.py
@@ -50,13 +50,15 @@ class TestRouteByContent:
     def test_html_payloads_are_handled_by_the_html_rewriter_service(
         self, call_route_by_content, HTMLRewriter
     ):
+        html_rewriter = HTMLRewriter.from_request.return_value
+        html_rewriter.url_for.return_value = "http://example.com", True
+
         url = "http://example.com/path%2C?a=b"
         results = call_route_by_content(url, params={"other": "value"})
 
         HTMLRewriter.from_request.assert_called_once_with(Any.instance_of(Request))
-        html_rewriter = HTMLRewriter.from_request.return_value
         html_rewriter.url_for.assert_called_once_with({"other": "value", "url": url})
-        assert results.location == html_rewriter.url_for.return_value
+        assert results.location == "http://example.com"
 
     @pytest.mark.parametrize(
         "content_type,max_age", [("application/pdf", 300), ("text/html", 60)]

--- a/via/views/route_by_content/view.py
+++ b/via/views/route_by_content/view.py
@@ -21,8 +21,12 @@ def route_by_content(context, request):
 
         return exc.HTTPFound(redirect_url, headers=_caching_headers(max_age=300))
 
-    url = HTMLRewriter.from_request(request).url_for(request.params)
-    headers = _cache_headers_for_http(status_code)
+    url, cacheable = HTMLRewriter.from_request(request).url_for(request.params)
+    headers = (
+        _cache_headers_for_http(status_code)
+        if cacheable
+        else {"Cache-Control": "no-cache"}
+    )
 
     return exc.HTTPFound(url, headers=headers)
 


### PR DESCRIPTION
If the ratio is anything other than 0 or 1, then don't allow caching.

For: https://github.com/hypothesis/via3/issues/236

This isn't very nice, and kind of messes up the design, but we should remove all of this once the cross over is complete.

## Testing notes

* `VIA_HTML_RATIO=0.5 make dev`
* `curl -I http://localhost:9083/route?url=http%3A%2F%2Fexample.com`
* Run the curl command a few times
* You should see `Cache-Control: no-cache`
* The URL should flip between the two

Run either:
* `VIA_HTML_RATIO=0.0 make dev` or...
* `VIA_HTML_RATIO=1.0 make dev`
* `curl -I http://localhost:9083/route?url=http%3A%2F%2Fexample.com`
* You should see `Cache-Control: public, max-age=60, stale-while-revalidate=86400`
* The URL should be one or the other consistently