### PR TITLE
Remove legacy Via options and simplify related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Environment variables:
 | Name             | Purpose | Example |
 |------------------|---------|---------|
 | `VIA_HTML_URL`     | The URL of the Via HTML component | `https://viahtml3.hypothes.is/proxy`
-| `VIA_HTML_RATIO`   | A ratio of HTML request (between 0 and 1) to send to Via HTML | `0.25`
 
 Updating the PDF viewer
 -----------------------

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -4,4 +4,3 @@ use = call:via.app:create_app
 nginx_server: http://localhost:9083
 client_embed_url: http://localhost:5000/embed.js
 via_html_url: http://localhost:9085/proxy
-legacy_via_url: http://localhost:9080

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,7 +42,6 @@ def pyramid_settings():
     return {
         "client_embed_url": "http://hypothes.is/embed.js",
         "nginx_server": "http://via3.hypothes.is",
-        "legacy_via_url": "http://via.hypothes.is",
         "via_html_url": "https://viahtml3.hypothes.is/proxy",
     }
 

--- a/tests/unit/via/views/route_by_content/_html_rewriter_test.py
+++ b/tests/unit/via/views/route_by_content/_html_rewriter_test.py
@@ -6,37 +6,33 @@ from pyramid.testing import DummyRequest
 
 from via.views.route_by_content._html_rewriter import HTMLRewriter
 
+# pylint: disable=protected-access
+
 
 class TestHTMLRewriter:
     def test_from_request(self, pyramid_request):
         settings = {
-            "legacy_via_url": sentinel.legacy_via_url,
             "via_html_url": sentinel.via_html_url,
         }
         pyramid_request.registry.settings.update(settings)
 
         rewriter = HTMLRewriter.from_request(pyramid_request)
 
-        assert rewriter == Any.instance_of(HTMLRewriter).with_attrs(settings)
-
-    def test_it_defaults_to_original_via(self):
-        rewriter = HTMLRewriter(legacy_via_url=sentinel.legacy_via_url)
-        assert rewriter.via_html_url == sentinel.legacy_via_url
+        assert rewriter == Any.instance_of(HTMLRewriter).with_attrs(
+            {"_via_html_url": sentinel.via_html_url}
+        )
 
     def test_it_extracts_the_url_and_prepends_it(self, rewriter):
         doc_url = "http://example.com/doc"
 
-        url, cacheable = rewriter.url_for({"url": doc_url})
+        url = rewriter.url_for({"url": doc_url})
 
-        assert url.startswith(f"{rewriter.legacy_via_url}/{doc_url}")
-        assert cacheable
+        assert url.startswith(f"{rewriter._via_html_url}/{doc_url}")
 
     def test_it_merges_params(self, rewriter):
         doc_url = "http://example.com/doc?a=1&b=2"
 
-        url, cacheable = rewriter.url_for(
-            {"url": doc_url, "via.openSidebar": "1", "other": "any"}
-        )
+        url = rewriter.url_for({"url": doc_url, "via.openSidebar": "1", "other": "any"})
 
         assert url == Any.url.with_query(
             {
@@ -47,48 +43,13 @@ class TestHTMLRewriter:
                 "other": "any",
             }
         )
-        assert cacheable
-
-    @pytest.mark.parametrize(
-        "env_value,random_value,expected_url,is_cacheable",
-        (
-            ("0.5", 0.1, "via_html_url", False),
-            (" 0.5  ", 0.1, "via_html_url", False),
-            ("0.5", 0.9, "legacy_via_url", False),
-            ("not_a_number", 0.1, "legacy_via_url", True),
-            (..., 0.5, "legacy_via_url", True),
-        ),
-    )
-    # pylint: disable=too-many-arguments
-    def test_it_switches_rewriter_based_on_ratio(
-        self, rewriter, os, random, env_value, random_value, expected_url, is_cacheable
-    ):
-        os.environ = {}
-        if env_value is not ...:
-            os.environ["VIA_HTML_RATIO"] = env_value
-
-        random.return_value = random_value
-
-        url, cacheable = rewriter.url_for({"url": "anything"})
-
-        assert url.startswith(getattr(rewriter, expected_url))
-        assert cacheable == is_cacheable
 
     @pytest.fixture
     def rewriter(self):
         return HTMLRewriter(
-            legacy_via_url="http://example.com/legacy_via_url",
             via_html_url="http://example.com/via_html_url",
         )
 
     @pytest.fixture
     def pyramid_request(self, make_request):
         return DummyRequest()
-
-    @pytest.fixture
-    def os(self, patch):
-        return patch("via.views.route_by_content._html_rewriter.os")
-
-    @pytest.fixture
-    def random(self, patch):
-        return patch("via.views.route_by_content._html_rewriter.random")

--- a/tests/unit/via/views/route_by_content/view_test.py
+++ b/tests/unit/via/views/route_by_content/view_test.py
@@ -16,8 +16,8 @@ class TestRouteByContent:
         (
             ("application/x-pdf", Any.url.with_path("/pdf")),
             ("application/pdf", Any.url.with_path("/pdf")),
-            ("text/html", Any.url.with_host("via.hypothes.is")),
-            ("other", Any.url.with_host("via.hypothes.is")),
+            ("text/html", Any.url.with_host("viahtml3.hypothes.is")),
+            ("other", Any.url.with_host("viahtml3.hypothes.is")),
         ),
     )
     def test_it_routes_by_content_type(
@@ -50,15 +50,13 @@ class TestRouteByContent:
     def test_html_payloads_are_handled_by_the_html_rewriter_service(
         self, call_route_by_content, HTMLRewriter
     ):
-        html_rewriter = HTMLRewriter.from_request.return_value
-        html_rewriter.url_for.return_value = "http://example.com", True
-
         url = "http://example.com/path%2C?a=b"
         results = call_route_by_content(url, params={"other": "value"})
 
         HTMLRewriter.from_request.assert_called_once_with(Any.instance_of(Request))
+        html_rewriter = HTMLRewriter.from_request.return_value
         html_rewriter.url_for.assert_called_once_with({"other": "value", "url": url})
-        assert results.location == "http://example.com"
+        assert results.location == html_rewriter.url_for.return_value
 
     @pytest.mark.parametrize(
         "content_type,max_age", [("application/pdf", 300), ("text/html", 60)]

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,7 @@ passenv =
     dev: NEW_RELIC_LICENSE_KEY
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
-    dev: LEGACY_VIA_URL
     dev: GOOGLE_API_KEY
-    dev: VIA_HTML_RATIO
 deps =
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt

--- a/via/app.py
+++ b/via/app.py
@@ -8,7 +8,7 @@ from whitenoise import WhiteNoise
 from via.cache_buster import PathCacheBuster
 from via.sentry_filters import SENTRY_FILTERS
 
-REQUIRED_PARAMS = ["client_embed_url", "nginx_server", "legacy_via_url", "via_html_url"]
+REQUIRED_PARAMS = ["client_embed_url", "nginx_server", "via_html_url"]
 
 
 def load_settings(settings):

--- a/via/views/route_by_content/view.py
+++ b/via/views/route_by_content/view.py
@@ -21,14 +21,8 @@ def route_by_content(context, request):
 
         return exc.HTTPFound(redirect_url, headers=_caching_headers(max_age=300))
 
-    url, cacheable = HTMLRewriter.from_request(request).url_for(request.params)
-    headers = (
-        _cache_headers_for_http(status_code)
-        if cacheable
-        else {"Cache-Control": "no-cache"}
-    )
-
-    return exc.HTTPFound(url, headers=headers)
+    url = HTMLRewriter.from_request(request).url_for(request.params)
+    return exc.HTTPFound(url, headers=_cache_headers_for_http(status_code))
 
 
 def _cache_headers_for_http(status_code):


### PR DESCRIPTION
If we want to switch back at any point, we can cut over by setting the VIA_HTML_URL to be original Via.

For: https://github.com/hypothesis/via3/issues/244