### PR TITLE
Push to the "via" Docker image instead of "via3"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@
 // repo: https://github.com/hypothesis/pipeline-library
 @Library("pipeline-library") _
 
-// The the built hypothesis/via3 Docker image.
+// The the built hypothesis/via Docker image.
 def img
 
 node {
@@ -22,7 +22,7 @@ node {
         // Checkout the commit that triggered this pipeline run.
         checkout scm
         // Build the Docker image.
-        img = buildApp(name: "hypothesis/via3")
+        img = buildApp(name: "hypothesis/via")
     }
 
     stage("Tests") {

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ update-pdfjs: python
 docker: build
 	@git archive --format=tar HEAD > build.tar
 	@tar --update -f build.tar via/static
-	@gzip -c build.tar | docker build -t hypothesis/via3:$(DOCKER_TAG) -
+	@gzip -c build.tar | docker build -t hypothesis/via:$(DOCKER_TAG) -
 	@rm build.tar
 
 .PHONY: web


### PR DESCRIPTION
Merging this needs to be coordinated with changes made in Docker Hub and possibly also in the deployement repo.