### PR TITLE
Check URLs with Checkmate before retrieving them on the proxy end-point

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,11 +3,11 @@
 import functools
 from unittest.mock import create_autospec
 
-from checkmatelib import CheckmateClient
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from via.checkmate import ViaCheckmateClient
 from via.views import add_routes
 
 
@@ -43,7 +43,7 @@ def pyramid_request(
     apply_request_extensions(pyramid_request)
 
     pyramid_request.checkmate = create_autospec(
-        CheckmateClient, spec_set=True, instance=True
+        ViaCheckmateClient, spec_set=True, instance=True
     )
     pyramid_request.checkmate.check_url.return_value = None
 

--- a/tests/unit/via/checkmate_test.py
+++ b/tests/unit/via/checkmate_test.py
@@ -1,46 +1,57 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import create_autospec, patch, sentinel
 
 import pytest
-from checkmatelib import CheckmateClient, CheckmateException
+from checkmatelib import CheckmateException
 from checkmatelib.client import BlockResponse
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 
-from via.checkmate import checkmate, raise_if_blocked
+from via.checkmate import ViaCheckmateClient
 
 
-def test_it(pyramid_request):
-    assert isinstance(checkmate(pyramid_request), CheckmateClient)
+class TestViaCheckmateClient:
+    def test_it_initialises_correctly(self, client, pyramid_request):
+        # pylint: disable=protected-access
+        client._host = pyramid_request.registry.settings["checkmate_url"]
+        client._api_key = pyramid_request.registry.settings["checkmate_api_key"]
 
-
-class TestRaiseIfBlocked:
-    def test_it(self, pyramid_request):
+    def test_raise_if_blocked(self, client, pyramid_request, check_url):
         pyramid_request.registry.settings = {
             "checkmate_allow_all": sentinel.checkmate_allow_all,
             "checkmate_ignore_reasons": sentinel.checkmate_ignore_reasons,
         }
         pyramid_request.params["via.blocked_for"] = sentinel.via_blocked_for
 
-        raise_if_blocked(pyramid_request, sentinel.url)
+        client.raise_if_blocked(sentinel.url)
 
-        pyramid_request.checkmate.check_url.assert_called_once_with(
+        check_url.assert_called_once_with(
             sentinel.url,
             allow_all=sentinel.checkmate_allow_all,
             blocked_for=sentinel.via_blocked_for,
             ignore_reasons=sentinel.checkmate_ignore_reasons,
         )
 
-    def test_blocked_url(self, pyramid_request, block_response):
-        pyramid_request.checkmate.check_url.return_value = block_response
+    def test_raise_if_blocked_can_block(self, client, check_url, block_response):
+        check_url.return_value = block_response
 
         with pytest.raises(HTTPTemporaryRedirect) as exc:
-            raise_if_blocked(pyramid_request, sentinel.url)
+            client.raise_if_blocked(sentinel.url)
 
         assert exc.value.location == block_response.presentation_url
 
-    def test_we_ignore_CheckmateExceptions(self, pyramid_request):
-        pyramid_request.checkmate.check_url.side_effect = CheckmateException
+    def test_raise_if_blocked_ignores_CheckmateExceptions(self, client, check_url):
+        check_url.side_effect = CheckmateException
 
-        raise_if_blocked(pyramid_request, sentinel.url)
+        client.raise_if_blocked(sentinel.url)
+
+    @pytest.fixture
+    def client(self, pyramid_request):
+        return ViaCheckmateClient(pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def check_url(self, client):
+        with patch.object(client, "check_url") as check_url:
+            check_url.return_value = None
+            yield check_url
 
     @pytest.fixture
     def block_response(self):

--- a/tests/unit/via/checkmate_test.py
+++ b/tests/unit/via/checkmate_test.py
@@ -1,7 +1,47 @@
-from checkmatelib import CheckmateClient
+from unittest.mock import create_autospec, sentinel
 
-from via.checkmate import checkmate
+import pytest
+from checkmatelib import CheckmateClient, CheckmateException
+from checkmatelib.client import BlockResponse
+from pyramid.httpexceptions import HTTPTemporaryRedirect
+
+from via.checkmate import checkmate, raise_if_blocked
 
 
 def test_it(pyramid_request):
     assert isinstance(checkmate(pyramid_request), CheckmateClient)
+
+
+class TestRaiseIfBlocked:
+    def test_it(self, pyramid_request):
+        pyramid_request.registry.settings = {
+            "checkmate_allow_all": sentinel.checkmate_allow_all,
+            "checkmate_ignore_reasons": sentinel.checkmate_ignore_reasons,
+        }
+        pyramid_request.params["via.blocked_for"] = sentinel.via_blocked_for
+
+        raise_if_blocked(pyramid_request, sentinel.url)
+
+        pyramid_request.checkmate.check_url.assert_called_once_with(
+            sentinel.url,
+            allow_all=sentinel.checkmate_allow_all,
+            blocked_for=sentinel.via_blocked_for,
+            ignore_reasons=sentinel.checkmate_ignore_reasons,
+        )
+
+    def test_blocked_url(self, pyramid_request, block_response):
+        pyramid_request.checkmate.check_url.return_value = block_response
+
+        with pytest.raises(HTTPTemporaryRedirect) as exc:
+            raise_if_blocked(pyramid_request, sentinel.url)
+
+        assert exc.value.location == block_response.presentation_url
+
+    def test_we_ignore_CheckmateExceptions(self, pyramid_request):
+        pyramid_request.checkmate.check_url.side_effect = CheckmateException
+
+        raise_if_blocked(pyramid_request, sentinel.url)
+
+    @pytest.fixture
+    def block_response(self):
+        return create_autospec(BlockResponse, instance=True, spec_set=True)

--- a/tests/unit/via/views/decorators_test.py
+++ b/tests/unit/via/views/decorators_test.py
@@ -1,70 +1,13 @@
-from unittest import mock
-
-import checkmatelib
 import pytest
-from checkmatelib import CheckmateException
 from h_vialib.exceptions import TokenException
 from pyramid.response import Response
 
-from via.views.decorators import checkmate_block, has_secure_url_token
-
-
-@checkmate_block
-def dummy_view_checkmate_block(context, request):
-    return Response("ok")
+from via.views.decorators import has_secure_url_token
 
 
 @has_secure_url_token
 def dummy_view_url_token(context, request):
     return Response("ok")
-
-
-class TestCheckMateBlockDecorator:
-    @pytest.mark.parametrize("allow_all", [True, False])
-    def test_allowed_url(self, pyramid_request, allow_all):
-        url = "http://example.com"
-        pyramid_request.params["url"] = url
-        pyramid_request.registry.settings["checkmate_allow_all"] = allow_all
-
-        response = dummy_view_checkmate_block(None, pyramid_request)
-
-        pyramid_request.checkmate.check_url.assert_called_once_with(
-            url, allow_all=allow_all, blocked_for=None, ignore_reasons=None
-        )
-        assert response.status_code == 200
-        assert response.text == "ok"
-
-    @pytest.mark.parametrize("allow_all", [True, False])
-    def test_blocked_url(self, pyramid_request, block_response, allow_all):
-        url = "http://bad.example.com"
-        pyramid_request.checkmate.check_url.return_value = block_response
-        pyramid_request.params["url"] = url
-        pyramid_request.registry.settings["checkmate_allow_all"] = allow_all
-
-        response = dummy_view_checkmate_block(None, pyramid_request)
-
-        pyramid_request.checkmate.check_url.assert_called_once_with(
-            url, allow_all=allow_all, blocked_for=None, ignore_reasons=None
-        )
-        assert response.status_code == 307
-        assert response.location == block_response.presentation_url
-
-    def test_invalid_url(self, pyramid_request):
-        url = "http://bad.example.com]"
-        pyramid_request.checkmate.check_url.side_effect = CheckmateException
-        pyramid_request.params["url"] = url
-
-        response = dummy_view_checkmate_block(None, pyramid_request)
-
-        # Request continues despite Checkmate errors
-        assert response.status_code == 200
-        assert response.text == "ok"
-
-    @pytest.fixture
-    def block_response(self):
-        return mock.create_autospec(
-            checkmatelib.client.BlockResponse, instance=True, spec_set=True
-        )
 
 
 class TestSignedURLDecorator:

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -6,52 +6,38 @@ from via.views.proxy import proxy
 
 
 class TestProxy:
-    @pytest.mark.parametrize(
-        "path,url_to_proxy",
-        [
-            ("/https://example.com/foo", "https://example.com/foo"),
-            ("/http://example.com/foo", "http://example.com/foo"),
-            (
-                "/https://example.com/foo?bar=gar&har=jar#car",
-                "https://example.com/foo?bar=gar&har=jar#car",
-            ),
-        ],
-    )
     def test_it(
-        self, pyramid_request, path, url_to_proxy, get_url_details, via_client_service
+        self,
+        pyramid_request,
+        get_url_details,
+        via_client_service,
+        url_from_user_input,
+        raise_if_blocked,
     ):
-        pyramid_request.path = path
+        pyramid_request.path = "/https://example.org"
 
         result = proxy(pyramid_request)
 
-        get_url_details.assert_called_once_with(url_to_proxy)
+        url_from_user_input.assert_called_with("https://example.org")
+        raise_if_blocked.assert_called_once_with(
+            pyramid_request, url_from_user_input.return_value
+        )
+        get_url_details.assert_called_once_with(url_from_user_input.return_value)
         via_client_service.url_for.assert_called_once_with(
-            url_to_proxy, sentinel.mime_type, pyramid_request.params
+            url_from_user_input.return_value, sentinel.mime_type, pyramid_request.params
         )
         assert result == {"src": via_client_service.url_for.return_value}
-
-    def test_it_normalizes_url(
-        self, pyramid_request, get_url_details, via_client_service, url_from_user_input
-    ):
-        pyramid_request.path = "/https://example.org"
-        url_from_user_input.side_effect = ["https://normalized.com"]
-
-        proxy(pyramid_request)
-
-        url_from_user_input.assert_called_with("https://example.org")
-        get_url_details.assert_called_once_with("https://normalized.com")
-        via_client_service.url_for.assert_called_once_with(
-            "https://normalized.com", sentinel.mime_type, pyramid_request.params
-        )
 
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):
         get_url_details = patch("via.views.proxy.get_url_details")
-        get_url_details.return_value = (sentinel.mime_type, sentinel.status_code)
+        get_url_details.return_value = sentinel.mime_type, sentinel.status_code
         return get_url_details
 
     @pytest.fixture(autouse=True)
     def url_from_user_input(self, patch):
-        url_from_user_input = patch("via.views.proxy.url_from_user_input")
-        url_from_user_input.side_effect = lambda url: url
-        return url_from_user_input
+        return patch("via.views.proxy.url_from_user_input")
+
+    @pytest.fixture(autouse=True)
+    def raise_if_blocked(self, patch):
+        return patch("via.views.proxy.raise_if_blocked")

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -7,20 +7,15 @@ from via.views.proxy import proxy
 
 class TestProxy:
     def test_it(
-        self,
-        pyramid_request,
-        get_url_details,
-        via_client_service,
-        url_from_user_input,
-        raise_if_blocked,
+        self, pyramid_request, get_url_details, via_client_service, url_from_user_input
     ):
         pyramid_request.path = "/https://example.org"
 
         result = proxy(pyramid_request)
 
         url_from_user_input.assert_called_with("https://example.org")
-        raise_if_blocked.assert_called_once_with(
-            pyramid_request, url_from_user_input.return_value
+        pyramid_request.checkmate.raise_if_blocked.assert_called_once_with(
+            url_from_user_input.return_value
         )
         get_url_details.assert_called_once_with(url_from_user_input.return_value)
         via_client_service.url_for.assert_called_once_with(
@@ -37,7 +32,3 @@ class TestProxy:
     @pytest.fixture(autouse=True)
     def url_from_user_input(self, patch):
         return patch("via.views.proxy.url_from_user_input")
-
-    @pytest.fixture(autouse=True)
-    def raise_if_blocked(self, patch):
-        return patch("via.views.proxy.raise_if_blocked")

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -30,6 +30,7 @@ class TestRouteByContent:
         pyramid_request,
         status_code,
         via_client_service,
+        raise_if_blocked,
     ):
         pyramid_request.params = {"url": sentinel.url, "foo": "bar"}
         get_url_details.return_value = (sentinel.mime_type, status_code)
@@ -37,6 +38,9 @@ class TestRouteByContent:
 
         response = route_by_content(context, pyramid_request)
 
+        raise_if_blocked.assert_called_once_with(
+            pyramid_request, context.url.return_value
+        )
         get_url_details.assert_called_once_with(
             context.url.return_value, pyramid_request.headers
         )
@@ -58,3 +62,7 @@ class TestRouteByContent:
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):
         return patch("via.views.route_by_content.get_url_details")
+
+    @pytest.fixture(autouse=True)
+    def raise_if_blocked(self, patch):
+        return patch("via.views.route_by_content.raise_if_blocked")

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -53,10 +53,10 @@ class TestViewPDF:
 
         assert response["hypothesis_config"] == sentinel.h_config
 
-    def test_it_calls_checkmate(self, call_view_pdf, raise_if_blocked, pyramid_request):
+    def test_it_calls_checkmate(self, call_view_pdf, pyramid_request):
         call_view_pdf(sentinel.url)
 
-        raise_if_blocked.assert_called_once_with(pyramid_request, sentinel.url)
+        pyramid_request.checkmate.raise_if_blocked(sentinel.url)
 
     @pytest.fixture
     def call_view_pdf(self, pyramid_request):
@@ -74,11 +74,8 @@ class TestViewPDF:
             sentinel.via_config,
             sentinel.h_config,
         )
-        return Configuration
 
-    @pytest.fixture(autouse=True)
-    def raise_if_blocked(self, patch):
-        return patch("via.views.view_pdf.raise_if_blocked")
+        return Configuration
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -53,14 +53,10 @@ class TestViewPDF:
 
         assert response["hypothesis_config"] == sentinel.h_config
 
-    @pytest.fixture
-    def Configuration(self, patch):
-        Configuration = patch("via.views.view_pdf.Configuration")
-        Configuration.extract_from_params.return_value = (
-            sentinel.via_config,
-            sentinel.h_config,
-        )
-        return Configuration
+    def test_it_calls_checkmate(self, call_view_pdf, raise_if_blocked, pyramid_request):
+        call_view_pdf(sentinel.url)
+
+        raise_if_blocked.assert_called_once_with(pyramid_request, sentinel.url)
 
     @pytest.fixture
     def call_view_pdf(self, pyramid_request):
@@ -70,6 +66,19 @@ class TestViewPDF:
             return view_pdf(context, pyramid_request)
 
         return call_view_pdf
+
+    @pytest.fixture
+    def Configuration(self, patch):
+        Configuration = patch("via.views.view_pdf.Configuration")
+        Configuration.extract_from_params.return_value = (
+            sentinel.via_config,
+            sentinel.h_config,
+        )
+        return Configuration
+
+    @pytest.fixture(autouse=True)
+    def raise_if_blocked(self, patch):
+        return patch("via.views.view_pdf.raise_if_blocked")
 
 
 @pytest.fixture(autouse=True)

--- a/via/app.py
+++ b/via/app.py
@@ -7,7 +7,7 @@ from pyramid.settings import asbool
 from whitenoise import WhiteNoise
 
 from via.cache_buster import PathCacheBuster
-from via.checkmate import checkmate
+from via.checkmate import ViaCheckmateClient
 from via.sentry_filters import SENTRY_FILTERS
 
 PARAMETERS = {
@@ -73,7 +73,7 @@ def create_app(_=None, **settings):
     config.add_cache_buster("via:static", cachebust=cache_buster)
 
     # Make the CheckmateClient object available as request.checkmate.
-    config.add_request_method(checkmate, reify=True)
+    config.add_request_method(ViaCheckmateClient, reify=True, name="checkmate")
 
     config.add_tween("via.tweens.robots_tween_factory")
 

--- a/via/checkmate.py
+++ b/via/checkmate.py
@@ -2,34 +2,35 @@ from checkmatelib import CheckmateClient, CheckmateException
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 
 
-def checkmate(request):
-    """Return the CheckmateClient object."""
-    return CheckmateClient(
-        request.registry.settings["checkmate_url"],
-        request.registry.settings["checkmate_api_key"],
-    )
-
-
-def raise_if_blocked(request, url):
-    """Raise a redirect to Checkmate if the URL is blocked.
-
-    This will sensibly apply all ignore reasons and other configuration for
-    Checkmate.
-
-    :param request: Pyramid request object
-    :param url: The URL to check
-    :raise HTTPTemporaryRedirect: If the URL is blocked
-    """
-    try:
-        blocked = request.checkmate.check_url(
-            url,
-            allow_all=request.registry.settings["checkmate_allow_all"],
-            blocked_for=request.params.get("via.blocked_for"),
-            ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
+class ViaCheckmateClient(CheckmateClient):
+    def __init__(self, request):
+        super().__init__(
+            host=request.registry.settings["checkmate_url"],
+            api_key=request.registry.settings["checkmate_api_key"],
         )
+        self._request = request
 
-    except CheckmateException:
-        blocked = None
+    def raise_if_blocked(self, url):
+        """Raise a redirect to Checkmate if the URL is blocked.
 
-    if blocked:
-        raise HTTPTemporaryRedirect(location=blocked.presentation_url)
+        This will sensibly apply all ignore reasons and other configuration for
+        Checkmate.
+
+        :param url: The URL to check
+        :raise HTTPTemporaryRedirect: If the URL is blocked
+        """
+        try:
+            blocked = self.check_url(
+                url,
+                allow_all=self._request.registry.settings["checkmate_allow_all"],
+                blocked_for=self._request.params.get("via.blocked_for"),
+                ignore_reasons=self._request.registry.settings[
+                    "checkmate_ignore_reasons"
+                ],
+            )
+
+        except CheckmateException:
+            blocked = None
+
+        if blocked:
+            raise HTTPTemporaryRedirect(location=blocked.presentation_url)

--- a/via/checkmate.py
+++ b/via/checkmate.py
@@ -1,4 +1,5 @@
-from checkmatelib import CheckmateClient
+from checkmatelib import CheckmateClient, CheckmateException
+from pyramid.httpexceptions import HTTPTemporaryRedirect
 
 
 def checkmate(request):
@@ -7,3 +8,28 @@ def checkmate(request):
         request.registry.settings["checkmate_url"],
         request.registry.settings["checkmate_api_key"],
     )
+
+
+def raise_if_blocked(request, url):
+    """Raise a redirect to Checkmate if the URL is blocked.
+
+    This will sensibly apply all ignore reasons and other configuration for
+    Checkmate.
+
+    :param request: Pyramid request object
+    :param url: The URL to check
+    :raise HTTPTemporaryRedirect: If the URL is blocked
+    """
+    try:
+        blocked = request.checkmate.check_url(
+            url,
+            allow_all=request.registry.settings["checkmate_allow_all"],
+            blocked_for=request.params.get("via.blocked_for"),
+            ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
+        )
+
+    except CheckmateException:
+        blocked = None
+
+    if blocked:
+        raise HTTPTemporaryRedirect(location=blocked.presentation_url)

--- a/via/views/decorators.py
+++ b/via/views/decorators.py
@@ -1,33 +1,7 @@
 """View decorators to integrate with checkmate's API."""
-from checkmatelib import CheckmateException
 from h_vialib.exceptions import TokenException
 from h_vialib.secure.url import ViaSecureURL
-from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPUnauthorized
-
-
-def checkmate_block(view):
-    """Intended to be used as a decorator for pyramid views.
-
-    The view must accept a url a query param.
-    """
-
-    def view_wrapper(context, request):
-        try:
-            blocked = request.checkmate.check_url(
-                request.params["url"],
-                allow_all=request.registry.settings["checkmate_allow_all"],
-                blocked_for=request.params.get("via.blocked_for"),
-                ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
-            )
-        except CheckmateException:
-            blocked = None
-
-        if blocked:
-            return HTTPTemporaryRedirect(location=blocked.presentation_url)
-
-        return view(context, request)
-
-    return view_wrapper
+from pyramid.httpexceptions import HTTPUnauthorized
 
 
 def has_secure_url_token(view, signature_param="via.sec"):

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -27,6 +27,7 @@ class IndexViews:
         if not self.enabled:
             return HTTPNotFound()
 
+        # Should this be context.url()?
         url = url_from_user_input(self.request.params.get("url", ""))
         try:
             parsed = urlparse(url)

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,6 +1,5 @@
 from pyramid.view import view_config
 
-from via.checkmate import raise_if_blocked
 from via.get_url import get_url_details
 from via.services import ViaClientService
 from via.views._helpers import url_from_user_input
@@ -11,7 +10,7 @@ def proxy(request):
     # Strip leading '/' and normalize URL.
     url = url_from_user_input(request.path[1:])
 
-    raise_if_blocked(request, url)
+    request.checkmate.raise_if_blocked(url)
 
     mime_type, _status_code = get_url_details(url)
 

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,5 +1,6 @@
 from pyramid.view import view_config
 
+from via.checkmate import raise_if_blocked
 from via.get_url import get_url_details
 from via.services import ViaClientService
 from via.views._helpers import url_from_user_input
@@ -9,6 +10,8 @@ from via.views._helpers import url_from_user_input
 def proxy(request):
     # Strip leading '/' and normalize URL.
     url = url_from_user_input(request.path[1:])
+
+    raise_if_blocked(request, url)
 
     mime_type, _status_code = get_url_details(url)
 

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -3,7 +3,6 @@
 from pyramid import httpexceptions as exc
 from pyramid import view
 
-from via.checkmate import raise_if_blocked
 from via.get_url import get_url_details
 from via.services import ViaClientService
 from via.views.decorators import has_secure_url_token
@@ -14,7 +13,7 @@ def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
     url = context.url()
 
-    raise_if_blocked(request, url)
+    request.checkmate.raise_if_blocked(url)
 
     mime_type, status_code = get_url_details(url, request.headers)
     via_client_svc = request.find_service(ViaClientService)

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -3,17 +3,19 @@
 from pyramid import httpexceptions as exc
 from pyramid import view
 
+from via.checkmate import raise_if_blocked
 from via.get_url import get_url_details
 from via.services import ViaClientService
-from via.views.decorators import checkmate_block, has_secure_url_token
+from via.views.decorators import has_secure_url_token
 
 
-@view.view_config(
-    route_name="route_by_content", decorator=(checkmate_block, has_secure_url_token)
-)
+@view.view_config(route_name="route_by_content", decorator=(has_secure_url_token,))
 def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
     url = context.url()
+
+    raise_if_blocked(request, url)
+
     mime_type, status_code = get_url_details(url, request.headers)
     via_client_svc = request.find_service(ViaClientService)
 

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -7,7 +7,8 @@ from h_vialib import Configuration
 from h_vialib.secure import quantized_expiry
 from pyramid import view
 
-from via.views.decorators import checkmate_block, has_secure_url_token
+from via.checkmate import raise_if_blocked
+from via.views.decorators import has_secure_url_token
 
 
 @view.view_config(
@@ -16,10 +17,12 @@ from via.views.decorators import checkmate_block, has_secure_url_token
     # We have to keep the leash short here for caching so we can pick up new
     # immutable assets when they are deployed
     http_cache=0,
-    decorator=(checkmate_block, has_secure_url_token),
+    decorator=(has_secure_url_token,),
 )
 def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""
+
+    raise_if_blocked(request, context.url())
 
     nginx_server = request.registry.settings["nginx_server"]
     proxy_pdf_url = _pdf_url(

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -7,7 +7,6 @@ from h_vialib import Configuration
 from h_vialib.secure import quantized_expiry
 from pyramid import view
 
-from via.checkmate import raise_if_blocked
 from via.views.decorators import has_secure_url_token
 
 
@@ -22,11 +21,13 @@ from via.views.decorators import has_secure_url_token
 def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""
 
-    raise_if_blocked(request, context.url())
+    url = context.url()
+
+    request.checkmate.raise_if_blocked(url)
 
     nginx_server = request.registry.settings["nginx_server"]
     proxy_pdf_url = _pdf_url(
-        context.url(),
+        url,
         nginx_server,
         request.registry.settings["nginx_secure_link_secret"],
     )
@@ -35,7 +36,7 @@ def view_pdf(context, request):
 
     return {
         # The upstream PDF URL that should be associated with any annotations.
-        "pdf_url": context.url(),
+        "pdf_url": url,
         # The CORS-proxied PDF URL which the viewer should actually load the PDF from.
         "proxy_pdf_url": proxy_pdf_url,
         "client_embed_url": request.registry.settings["client_embed_url"],


### PR DESCRIPTION
For: https://github.com/hypothesis/via/issues/543

This was a lot more annoying than I was expected. It looks like the conversion to make Via work as the public interface didn't follow some of the style of what came before, so there are a number of patterns and assumptions which have been broken:

 * The URL does not reliably contain `url=` anymore
 * This means we can't have a single decorator which handles checkmate checks
 * We're still passing around a checkmate object but we don't use it much any more (only in status)
 * We've introduced a `views/_helpers.py` which replicates the purpose of the `resource.py` and feels like a step backwards to old ways of doing things. Checkmate doesn't really have a helpers pattern

This PR:

 * Removes some random empty files
 * Converts the decorator to be a method call on the checkmate object

### Random musings

Should this all be on the context object?

### Testing notes

 * Start `viahtml` (just in case), and `checkmate`
 * Run `CHECKMATE_ALLOW_ALL=False make dev`
 * Visit: http://localhost:9083/https://bad.example.com
 * On `master` you should get an error page
 * On this branch you should be blocked