### PR TITLE
Disable replacement of 4xx and 5xx errors from upstream

### DIFF
--- a/conf/nginx/includes/errors.conf
+++ b/conf/nginx/includes/errors.conf
@@ -35,7 +35,11 @@ error_page 301 302 307 = @handle_redirect;
 # (which are defined in nginx.conf) to modify them.
 #
 # http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
-error_page 404 410 = @proxy_not_found;
-error_page 420 429 = @proxy_too_many_requests;
-error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
-error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;
+
+# 2021-08-23: Replacement of error responses from the upstream server has been disabled
+#             to enable debugging of a production issue.
+#
+# error_page 404 410 = @proxy_not_found;
+# error_page 420 429 = @proxy_too_many_requests;
+# error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
+# error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;


### PR DESCRIPTION
We are having a production issue with requests for some PDFs from Google Drive
failing with generic nginx 400 responses, where the 400 response is
coming from the @proxy_client_error handler and is masking the upstream
error.

Disable the error replacement of 4xx and 5xx responses via the
/proxy/static/* route to enable debugging of the issue.

A bonus of this change is that invalid secure links now result in more useful error codes, eg. 410 for an expired link.

Slack thread: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1629749442452600