### PR TITLE
Remove all overrides of upstream errors

### DIFF
--- a/conf/nginx/includes/errors.conf
+++ b/conf/nginx/includes/errors.conf
@@ -10,8 +10,13 @@
 recursive_error_pages on;
 
 # Intercept 3xx, 4xx and 5xx responses from the servers we're
-# proxying and process them through the error_page directives
+# proxying so we can optionally process them through error_page directives
 # below: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
+#
+# If no matching `error_page` is defined then the upstream error status and
+# response will be returned to the client. We currently do not modify 4xx or 5xx
+# responses so that we can debug interactions between Via and upstream services
+# in production.
 proxy_intercept_errors on;
 
 # Don't pass 3xx responses from the servers we're proxying back to
@@ -19,27 +24,3 @@ proxy_intercept_errors on;
 # location (which is defined in nginx.conf).
 # http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
 error_page 301 302 307 = @handle_redirect;
-
-# Don't pass 4xx or 5xx responses from the servers we're proxying
-# back to the browser. Instead process them through the @proxy_*
-# locations defined below.
-#
-# If users are proxying a third-party server that is returning
-# error responses we don't want Via to return those same 4xx or
-# 5xx status codes to the browser because this would mess up our
-# monitoring and alerting. For example it might trigger an alarm
-# that Via is unhealthy because it's sending too many error
-# responses.
-#
-# So pass third-party error responses through our various @proxy_* locations
-# (which are defined in nginx.conf) to modify them.
-#
-# http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
-
-# 2021-08-23: Replacement of error responses from the upstream server has been disabled
-#             to enable debugging of a production issue.
-#
-# error_page 404 410 = @proxy_not_found;
-# error_page 420 429 = @proxy_too_many_requests;
-# error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
-# error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;

--- a/conf/nginx/includes/secure_links.conf
+++ b/conf/nginx/includes/secure_links.conf
@@ -43,5 +43,4 @@ secure_link_md5 "/proxy/static/$secure_link_expires/$uri $nginx_secure_link_secr
 if ($secure_link = "") { return 403; }
 
 # If the expiry time has passed respond with a 410.
-# (FIXME: This 410 gets converted into a 404 by our @proxy_not_found below.)
 if ($secure_link = "0") { return 410; }

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -140,26 +140,6 @@ http {
             add_header "X-Via" "static-proxy, redirect";
         }
 
-        location @proxy_not_found {
-            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
-            return 404;
-        }
-
-        location @proxy_too_many_requests {
-            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
-            return 429;
-        }
-
-        location @proxy_client_error {
-            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
-            return 400;
-        }
-
-        location @proxy_upstream_error {
-            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
-            return 409;
-        }
-
         location / {
             # Proxy to the Gunicorn/Pyramid app.
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass


### PR DESCRIPTION
Overriding upstream 4xx and 5xx responses with generic 400 responses made it difficult to debug interactions between Via and upstreams in production because all information about the original upstream response was lost.

This commit completes the change started in https://github.com/hypothesis/via/pull/557 by removing all such overrides.

We will find another way to solve the problem described in the comments where proxied 4xx or 5xx responses from upstream could confuse monitoring tools about the health of the service.

One possibility that I haven't implemented here would be to return a fixed status code for an upstream 4xx or 5xx error but include the original response status in an HTTP header or body. I don't know if this is possible to do in nginx.

----

On a broader note, this leads me to ask whether we should consider replacing nginx as the proxying system entirely with something Python-based. That will give us much easier control over all details of the response and error logging. It would also enable us to use New Relic's Python integration for more advanced alerting (eg. observing baseline deviations in the error response rate).