### PR TITLE
Separate components of `get_url` out so they can be re-used

### DIFF
--- a/tests/unit/via/requests_tools/error_handling_test.py
+++ b/tests/unit/via/requests_tools/error_handling_test.py
@@ -1,0 +1,39 @@
+import pytest
+from requests import exceptions
+
+from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
+from via.requests_tools.error_handling import handle_errors
+
+
+class TestHandleErrors:
+    @pytest.mark.parametrize(
+        "request_exception,expected_exception",
+        (
+            (exceptions.MissingSchema, BadURL),
+            (exceptions.InvalidSchema, BadURL),
+            (exceptions.InvalidURL, BadURL),
+            (exceptions.URLRequired, BadURL),
+            (exceptions.ConnectionError, UpstreamServiceError),
+            (exceptions.Timeout, UpstreamServiceError),
+            (exceptions.TooManyRedirects, UpstreamServiceError),
+            (exceptions.SSLError, UpstreamServiceError),
+            (exceptions.UnrewindableBodyError, UnhandledException),
+        ),
+    )
+    def test_it_catches_requests_exceptions(
+        self, raiser, request_exception, expected_exception
+    ):
+        with pytest.raises(expected_exception):
+            raiser(request_exception("Oh noe"))
+
+    def test_it_does_not_catch_regular_exceptions(self, raiser):
+        with pytest.raises(ValueError):
+            raiser(ValueError())
+
+    @pytest.fixture
+    def raiser(self):
+        @handle_errors
+        def raiser(exception):
+            raise exception
+
+        return raiser

--- a/tests/unit/via/requests_tools/headers_test.py
+++ b/tests/unit/via/requests_tools/headers_test.py
@@ -2,10 +2,11 @@ from collections import OrderedDict
 
 import pytest
 
-from via.get_url.headers import (
+from via.requests_tools.headers import (
     BANNED_HEADERS,
     HEADER_DEFAULTS,
     HEADER_MAP,
+    add_request_headers,
     clean_headers,
 )
 
@@ -48,3 +49,14 @@ class TestCleanHeaders:
 
         assert result[mapped_name] == "value"
         assert header_name not in result
+
+
+class TestAddHeaders:
+    def test_it(self):
+        headers = add_request_headers({"X-Existing": "existing"})
+
+        assert headers == {
+            "X-Abuse-Policy": "https://web.hypothes.is/abuse-policy/",
+            "X-Complaints-To": "https://web.hypothes.is/report-abuse/",
+            "X-Existing": "existing",
+        }

--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -1,23 +1,9 @@
 """Application specific exceptions."""
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPExpectationFailed
-from requests import exceptions
 
 # pylint: disable=too-many-ancestors
 # It's ok to have a hierarchy of exceptions
-
-REQUESTS_BAD_URL = (
-    exceptions.MissingSchema,
-    exceptions.InvalidSchema,
-    exceptions.InvalidURL,
-    exceptions.URLRequired,
-)
-REQUESTS_UPSTREAM_SERVICE = (
-    exceptions.ConnectionError,
-    exceptions.Timeout,
-    exceptions.TooManyRedirects,
-    exceptions.SSLError,
-)
 
 
 class BadURL(HTTPBadRequest):

--- a/via/get_url/__init__.py
+++ b/via/get_url/__init__.py
@@ -1,4 +1,0 @@
-"""A collection of tools for getting URL and inspecting the contents."""
-
-from via.get_url.details import get_url_details
-from via.get_url.headers import clean_headers

--- a/via/requests_tools/__init__.py
+++ b/via/requests_tools/__init__.py
@@ -1,0 +1,2 @@
+from via.requests_tools.error_handling import handle_errors
+from via.requests_tools.headers import add_request_headers, clean_headers

--- a/via/requests_tools/error_handling.py
+++ b/via/requests_tools/error_handling.py
@@ -1,0 +1,40 @@
+"""Helpers for capturing requests exceptions."""
+
+from functools import wraps
+
+from requests import RequestException, exceptions
+
+from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
+
+REQUESTS_BAD_URL = (
+    exceptions.MissingSchema,
+    exceptions.InvalidSchema,
+    exceptions.InvalidURL,
+    exceptions.URLRequired,
+)
+REQUESTS_UPSTREAM_SERVICE = (
+    exceptions.ConnectionError,
+    exceptions.Timeout,
+    exceptions.TooManyRedirects,
+    exceptions.SSLError,
+)
+
+
+def handle_errors(inner):
+    """Translate errors into our application errors."""
+
+    @wraps(inner)
+    def deco(*args, **kwargs):
+        try:
+            return inner(*args, **kwargs)
+
+        except REQUESTS_BAD_URL as err:
+            raise BadURL() from err
+
+        except REQUESTS_UPSTREAM_SERVICE as err:
+            raise UpstreamServiceError() from err
+
+        except RequestException as err:
+            raise UnhandledException() from err
+
+    return deco

--- a/via/requests_tools/headers.py
+++ b/via/requests_tools/headers.py
@@ -73,3 +73,13 @@ def clean_headers(headers):
         clean[header_name] = value
 
     return clean
+
+
+def add_request_headers(headers):
+    """Add headers for 3rd party providers which we access data from."""
+
+    # Pass our abuse policy in request headers for third-party site admins.
+    headers["X-Abuse-Policy"] = "https://web.hypothes.is/abuse-policy/"
+    headers["X-Complaints-To"] = "https://web.hypothes.is/report-abuse/"
+
+    return headers


### PR DESCRIPTION
This makes some components like the error handling and header adding separate from the `get_url` method so they can be re-used. Specifically so we can re-use them in the Google Drive work.

This moves `via.get_url.details` to `via.get_url`. At this point it should almost certainly be a service as this would allow us to have a single HTTP session which would speed up requests to the same domain (as we'd skip SSL verification).

The rest of the error handling code and header things have moved to `via.requests_tools` which are generic(ish) helpers for working with `requests`.