### PR TITLE
Update the Google Drive timeout to 10 seconds

### DIFF
--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -47,7 +47,7 @@ class TestGoogleDriveAPI:
                 "X-Complaints-To": Any.string(),
             },
             stream=True,
-            timeout=1,
+            timeout=10,
         )
 
         api._session.get.return_value.raise_for_status.assert_called_once_with()

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -84,7 +84,7 @@ class GoogleDriveAPI:
             }
         )
 
-        response = self._session.get(url=url, headers=headers, stream=True, timeout=1)
+        response = self._session.get(url=url, headers=headers, stream=True, timeout=10)
         response.raise_for_status()
 
         yield from stream_bytes(response)


### PR DESCRIPTION
This matches the timeout we have for regular URLs as 1 second does not appear to be enough.