### PR TITLE
Google Drive credentials in a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 via/static/**/*.gz
 node_modules/
 build.tar
-.devdata.env
+.devdata*
 supervisord.log
 supervisord.pid

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Environment variables:
 | `CHECKMATE_ALLOW_ALL` | Whether to bypass Checkmate's allow-list (and use only the blocklist) | `true`
 | `CHECKMATE_IGNORE_REASONS` | Comma-separated list of Checkmate block reasons to ignore | `publisher-blocked,high-io` |
 | `CLIENT_EMBED_URL` | The URL of the client's embed script | `https://hypothes.is/embed.js`
+| `DATA_DIRECTORY` | Directory for externally provided data | `/via-data`
 | `ENABLE_FRONT_PAGE` | Show a front page at the root URL | `true` |
 | `GOOGLE_API_KEY` | The API key to use to authenticate with the Google Drive API |
-| `GOOGLE_DRIVE_CREDENTIALS` | Service account credentials in JSON to authenticate with the Google Drive API |
-| `GOOGLE_DRIVE_IN_PYTHON` | Process Google Drive in Python (feature flag) (requires `GOOGLE_DRIVE_CREDENTIALS`) |
+| `GOOGLE_DRIVE_IN_PYTHON` | Process Google Drive in Python (feature flag) (requires `google_drive_credentials.json` specified below.) |
 | `NEW_RELIC_*` | Various New Relic settings. See New Relic's docs for details |
 | `NGINX_SECURE_LINK_SECRET` | The NGINX secure links signing secret. This is used by Via's Python endpoints to generate the signed URLs required by its NGINX-implemented `/proxy/static/` endpoint. All instances of Via must have this setting |
 | `NGINX_SERVER` | The URL of Via's NGINX server for proxying PDF files | `https://via.hypothes.is`
@@ -86,6 +86,12 @@ Environment variables:
 | `SIGNED_URLS_REQUIRED` | Require URLs to Via's Python endpoints to be signed so that Via can only be used by something that has the URL signing secret. Public instances of Via should _not_ enable this. Private instances of Via (e.g. the LMS app's instance of Via) _should_ enable this | `true`
 | `VIA_HTML_URL` | The URL of the Via HTML instance to redirect to for proxying HTML pages | `https://viahtml.hypothes.is/proxy`
 | `VIA_SECRET` | The secret that must be used to sign URLs to Via's Python endpoints if `SIGNED_URLS_REQUIRED` is on |
+
+Expected data:
+
+The following data is expected to be provided in the `DATA_DIRECTORY`:
+
+ * `google_drive_credentials.json` - A list of credential JSON objects provided by the Google API console if using `GOOGLE_DRIVE_IN_PYTHON`
 
 Updating the PDF viewer
 -----------------------

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -15,10 +15,17 @@ def _get_devdata():
         check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir])
 
         # Copy devdata env file into place.
-        copyfile(
-            os.path.join(git_dir, "via/devdata.env"),
-            os.path.join(Path(__file__).parent.parent, ".devdata.env"),
-        )
+        for source, target in (
+            ("via/devdata.env", ".devdata.env"),
+            (
+                "via/devdata/google_drive_credentials.json",
+                ".devdata/google_drive_credentials.json",
+            ),
+        ):
+            copyfile(
+                os.path.join(git_dir, source),
+                os.path.join(Path(__file__).parent.parent, target),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def pyramid_settings():
         "checkmate_ignore_reasons": None,
         "checkmate_allow_all": False,
         "enable_front_page": True,
-        "google_drive_credentials": None,
+        "data_directory": ".devdata",
         "google_drive_in_python": False,
     }
 

--- a/tests/unit/via/app_test.py
+++ b/tests/unit/via/app_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from via.app import create_app, load_settings
@@ -11,6 +13,7 @@ def test_settings_raise_value_error_if_environment_variable_is_not_set():
 
 def test_settings_are_configured_from_environment_variables(os, pyramid_settings):
     expected_settings = pyramid_settings
+    expected_settings["data_directory"] = Path(pyramid_settings["data_directory"])
 
     settings = load_settings({})
 
@@ -24,6 +27,7 @@ def test_app(configurator, pyramid, os, pyramid_settings):
     expected_settings = dict(
         {"h_pyramid_sentry.filters": SENTRY_FILTERS}, **pyramid_settings
     )
+    expected_settings["data_directory"] = Path(pyramid_settings["data_directory"])
 
     pyramid.config.Configurator.assert_called_once_with(settings=expected_settings)
     configurator.make_wsgi_app.assert_called_once_with()

--- a/tests/unit/via/services/__init___test.py
+++ b/tests/unit/via/services/__init___test.py
@@ -1,0 +1,64 @@
+import pytest
+
+from via.exceptions import ConfigurationError
+from via.services import create_google_api, load_injected_json
+
+
+class TestLoadInjectedJSON:
+    def test_it(self, settings, tmpdir):
+        json_file = tmpdir / "data.json"
+        json_file.write('{"a": 1}')
+
+        data = load_injected_json(settings, "data.json")
+
+        assert data == {"a": 1}
+
+    @pytest.mark.parametrize("required", (True, False))
+    def test_it_with_malformed_data(self, settings, tmpdir, required):
+        json_file = tmpdir / "data.json"
+        json_file.write("{malformed ...")
+
+        with pytest.raises(ConfigurationError):
+            load_injected_json(settings, "data.json", required=required)
+
+    def test_it_with_missing_data(self, settings):
+        with pytest.raises(ConfigurationError):
+            load_injected_json(settings, "missing.json")
+
+    def test_it_with_missing_but_not_required_data(self, settings):
+        assert load_injected_json(settings, "missing.json", required=False) is None
+
+    @pytest.fixture
+    def settings(self, tmpdir):
+        return {"data_directory": tmpdir}
+
+
+class TestCreateGoogleAPI:
+    def test_it_with_credentials(
+        self, pyramid_request, GoogleDriveAPI, load_injected_json
+    ):
+        settings = {"google_drive_in_python": True, "noise": "other"}
+
+        api = create_google_api(settings)
+
+        load_injected_json.assert_called_once_with(
+            settings, "google_drive_credentials.json"
+        )
+        GoogleDriveAPI.assert_called_once_with(load_injected_json.return_value)
+        assert api == GoogleDriveAPI.return_value
+
+    def test_it_without_credentials(self, pyramid_request, GoogleDriveAPI):
+        settings = {"google_drive_in_python": False, "noise": "other"}
+
+        api = create_google_api(settings)
+
+        GoogleDriveAPI.assert_called_once_with(credentials_list=None)
+        assert api == GoogleDriveAPI.return_value
+
+    @pytest.fixture(autouse=True)
+    def load_injected_json(self, patch):
+        return patch("via.services.load_injected_json")
+
+    @pytest.fixture(autouse=True)
+    def GoogleDriveAPI(self, patch):
+        return patch("via.services.GoogleDriveAPI")

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -5,7 +5,7 @@ from h_matchers import Any
 from requests import TooManyRedirects
 
 from via.exceptions import ConfigurationError, UpstreamServiceError
-from via.services.google_drive import GoogleDriveAPI, factory, load_injected_json
+from via.services.google_drive import GoogleDriveAPI
 
 
 class TestGoogleDriveAPI:
@@ -98,67 +98,3 @@ class TestGoogleDriveAPI:
     @pytest.fixture(autouse=True)
     def Credentials(self, patch):
         return patch("via.services.google_drive.Credentials")
-
-
-class TestLoadInjectedJSON:
-    def test_it(self, pyramid_request, tmpdir):
-        json_file = tmpdir / "data.json"
-        json_file.write('{"a": 1}')
-
-        data = load_injected_json(pyramid_request, "data.json")
-
-        assert data == {"a": 1}
-
-    @pytest.mark.parametrize("required", (True, False))
-    def test_it_with_malformed_data(self, pyramid_request, tmpdir, required):
-        json_file = tmpdir / "data.json"
-        json_file.write("{malformed ...")
-
-        with pytest.raises(ConfigurationError):
-            load_injected_json(pyramid_request, "data.json", required=required)
-
-    def test_it_with_missing_data(self, pyramid_request):
-        with pytest.raises(ConfigurationError):
-            load_injected_json(pyramid_request, "missing.json")
-
-    def test_it_with_missing_but_not_required_data(self, pyramid_request):
-        assert (
-            load_injected_json(pyramid_request, "missing.json", required=False) is None
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request, tmpdir):
-        pyramid_request.registry.settings["data_directory"] = tmpdir
-
-        return pyramid_request
-
-
-class TestFactory:
-    def test_it_with_credentials(
-        self, pyramid_request, GoogleDriveAPI, load_injected_json
-    ):
-        pyramid_request.registry.settings["google_drive_in_python"] = True
-
-        api = factory(sentinel.context, pyramid_request)
-
-        load_injected_json.assert_called_once_with(
-            pyramid_request, "google_drive_credentials.json"
-        )
-        GoogleDriveAPI.assert_called_once_with(load_injected_json.return_value)
-        assert api == GoogleDriveAPI.return_value
-
-    def test_it_without_credentials(self, pyramid_request, GoogleDriveAPI):
-        pyramid_request.registry.settings["google_drive_in_python"] = False
-
-        api = factory(sentinel.context, pyramid_request)
-
-        GoogleDriveAPI.assert_called_once_with(credentials_list=None)
-        assert api == GoogleDriveAPI.return_value
-
-    @pytest.fixture(autouse=True)
-    def load_injected_json(self, patch):
-        return patch("via.services.google_drive.load_injected_json")
-
-    @pytest.fixture(autouse=True)
-    def GoogleDriveAPI(self, patch):
-        return patch("via.services.google_drive.GoogleDriveAPI")

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
     dev: CHECKMATE_API_KEY = dev_api_key
     dev: ENABLE_FRONT_PAGE = {env:ENABLE_FRONT_PAGE:true}
     dev: GOOGLE_DRIVE_IN_PYTHON = 1
+    dev: DATA_DIRECTORY = .devdata/
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 passenv =
     HOME
@@ -41,7 +42,6 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: GOOGLE_API_KEY
-    dev: GOOGLE_DRIVE_CREDENTIALS
     dev: SIGNED_URLS_REQUIRED
 deps =
     dev: -r requirements/dev.txt

--- a/via/app.py
+++ b/via/app.py
@@ -1,5 +1,6 @@
 """The main application entrypoint module."""
 import os
+from pathlib import Path
 
 import importlib_resources
 import pyramid.config
@@ -22,7 +23,7 @@ PARAMETERS = {
     # Optional
     "checkmate_ignore_reasons": {},
     "checkmate_allow_all": {"formatter": asbool},
-    "google_drive_credentials": {},
+    "data_directory": {"required": True, "formatter": Path},
     "google_drive_in_python": {"formatter": asbool},
     "signed_urls_required": {"formatter": asbool},
     "enable_front_page": {"formatter": asbool},


### PR DESCRIPTION
We're moving to a single mechanism for adding new things to the container which is to copy files from S3. This loads from a specific directory instead of an environment variable.

This also takes the opportunity to swap to a list. This should hopefully prevent any kind of cliff edge deployment if we need to add more credentials in future.