### PR TITLE
Fix the route URL to include query parameters

### DIFF
--- a/tests/unit/via/views/_helpers_test.py
+++ b/tests/unit/via/views/_helpers_test.py
@@ -10,6 +10,7 @@ class TestURLFromUserInput:
             # URLs that should be returned unchanged
             ("http://example.com", "http://example.com"),
             ("https://example.com", "https://example.com"),
+            ("http://example.com?a=1", "http://example.com?a=1"),
             # URLs without a protocol that should have `https://` prefixed
             ("example.com", "https://example.com"),
             # Leading and trailing whitespace that should be stripped
@@ -18,6 +19,8 @@ class TestURLFromUserInput:
             # Empty URLs that should return an empty string
             ("", ""),
             ("  ", ""),
+            # Check we remove Via stuff
+            ("http://example.com?a=1&via.sec=TOKEN", "http://example.com?a=1"),
         ],
     )
     def test_it(self, input_url, expected):

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -6,20 +6,16 @@ from via.views.proxy import proxy
 
 
 class TestProxy:
-    def test_it(
-        self, pyramid_request, get_url_details, via_client_service, url_from_user_input
-    ):
-        pyramid_request.path = "/https://example.org"
+    def test_it(self, pyramid_request, get_url_details, via_client_service):
+        pyramid_request.path_qs = "/https://example.org?a=1&via.sec=HEX"
 
         result = proxy(pyramid_request)
 
-        url_from_user_input.assert_called_with("https://example.org")
-        pyramid_request.checkmate.raise_if_blocked.assert_called_once_with(
-            url_from_user_input.return_value
-        )
-        get_url_details.assert_called_once_with(url_from_user_input.return_value)
+        url = "https://example.org?a=1"
+        pyramid_request.checkmate.raise_if_blocked.assert_called_once_with(url)
+        get_url_details.assert_called_once_with(url)
         via_client_service.url_for.assert_called_once_with(
-            url_from_user_input.return_value, sentinel.mime_type, pyramid_request.params
+            url, sentinel.mime_type, pyramid_request.params
         )
         assert result == {"src": via_client_service.url_for.return_value}
 
@@ -28,7 +24,3 @@ class TestProxy:
         get_url_details = patch("via.views.proxy.get_url_details")
         get_url_details.return_value = sentinel.mime_type, sentinel.status_code
         return get_url_details
-
-    @pytest.fixture(autouse=True)
-    def url_from_user_input(self, patch):
-        return patch("via.views.proxy.url_from_user_input")

--- a/via/views/_helpers.py
+++ b/via/views/_helpers.py
@@ -1,3 +1,6 @@
+from h_vialib import Configuration
+
+
 def url_from_user_input(url):
     """Return a normalized URL from user input.
 
@@ -10,5 +13,7 @@ def url_from_user_input(url):
 
     if not (url.startswith("http://") or url.startswith("https://")):
         url = "https://" + url
+
+    url = Configuration.strip_from_url(url)
 
     return url

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,3 +1,4 @@
+from h_vialib.configuration import Configuration
 from pyramid.view import view_config
 
 from via.get_url import get_url_details
@@ -8,7 +9,8 @@ from via.views._helpers import url_from_user_input
 @view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")
 def proxy(request):
     # Strip leading '/' and normalize URL.
-    url = url_from_user_input(request.path[1:])
+    url = url_from_user_input(request.path_qs[1:])
+    url = Configuration.strip_from_url(url)
 
     request.checkmate.raise_if_blocked(url)
 

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,4 +1,3 @@
-from h_vialib.configuration import Configuration
 from pyramid.view import view_config
 
 from via.get_url import get_url_details
@@ -10,7 +9,6 @@ from via.views._helpers import url_from_user_input
 def proxy(request):
     # Strip leading '/' and normalize URL.
     url = url_from_user_input(request.path_qs[1:])
-    url = Configuration.strip_from_url(url)
 
     request.checkmate.raise_if_blocked(url)
 


### PR DESCRIPTION
At the moment if you put a URL into the index page which has URL parameters, the parameters are stripped from it. Amongst many other URLs, this means Google Drive URLs don't work.

This PR does two things:

 * Uses `request.path_qs` instead of `request.path` so the query params are included
 * Use `h-vialib` routines to strip off Via params from the URL