### PR TITLE
Use Google resource key if available in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Expected data:
 The following data is expected to be provided in the `DATA_DIRECTORY`:
 
  * `google_drive_credentials.json` - A list of credential JSON objects provided by the Google API console if using `GOOGLE_DRIVE_IN_PYTHON`
+ * `google_drive_resource_keys.json` - A dict of file ids to resource keys if using `GOOGLE_DRIVE_IN_PYTHON`
 
 Updating the PDF viewer
 -----------------------

--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -21,6 +21,10 @@ def _get_devdata():
                 "via/devdata/google_drive_credentials.json",
                 ".devdata/google_drive_credentials.json",
             ),
+            (
+                "via/devdata/google_drive_resource_keys.json",
+                ".devdata/google_drive_resource_keys.json",
+            ),
         ):
             copyfile(
                 os.path.join(git_dir, source),

--- a/tests/unit/via/get_url_test.py
+++ b/tests/unit/via/get_url_test.py
@@ -56,14 +56,12 @@ class TestGetURLDetails:
         assert kwargs["headers"] == add_request_headers.return_value
 
     def test_it_assumes_pdf_with_a_google_drive_url(self, requests, GoogleDriveAPI):
-        GoogleDriveAPI.google_drive_id.return_value = "truthy_value"
+        GoogleDriveAPI.parse_file_url.return_value = {"file_id": "FILE_ID"}
 
         result = get_url_details(sentinel.google_drive_url)
 
         assert result == ("application/pdf", 200)
-        GoogleDriveAPI.google_drive_id.assert_called_once_with(
-            sentinel.google_drive_url
-        )
+        GoogleDriveAPI.parse_file_url.assert_called_once_with(sentinel.google_drive_url)
         requests.get.assert_not_called()
 
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -42,6 +42,8 @@ class TestGoogleDriveAPI:
                 "Accept": "*/*",
                 "Accept-Encoding": "gzip, deflate",
                 "User-Agent": "(gzip)",
+                # This is looked up from the resource mapping
+                "X-Goog-Drive-Resource-Keys": "FILE_ID/RESOURCE_ID",
                 # Quick check to show we use `add_request_headers`
                 "X-Abuse-Policy": Any.string(),
                 "X-Complaints-To": Any.string(),
@@ -110,7 +112,8 @@ class TestGoogleDriveAPI:
                 {"file_id": "FILE_ID", "resource_key": "RESOURCE_KEY"},
             ),
             (
-                "https://drive.google.com/uc?id=FILE_ID&export=download&via.open_sidebar=1&via.request_config_from_frame=https%3A%2F%2Flms.hypothes.is",
+                "https://drive.google.com/uc?id=FILE_ID&export=download&via.open_sidebar=1&"
+                "via.request_config_from_frame=https%3A%2F%2Flms.hypothes.is",
                 {"file_id": "FILE_ID", "resource_key": None},
             ),
             (
@@ -150,7 +153,10 @@ class TestGoogleDriveAPI:
 
     @pytest.fixture
     def api(self):
-        return GoogleDriveAPI([sentinel.credentials, sentinel.credentials_two])
+        return GoogleDriveAPI(
+            credentials_list=[sentinel.credentials, sentinel.credentials_two],
+            resource_keys={"FILE_ID": "RESOURCE_ID"},
+        )
 
     @pytest.fixture(autouse=True)
     def stream_bytes(self, patch):

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -54,6 +54,21 @@ class TestGoogleDriveAPI:
         stream_bytes.assert_called_once_with(api._session.get.return_value)
         assert result == [0, 1, 2]
 
+    def test_iter_file_accepts_resource_key(self, api):
+        list(api.iter_file("FILE_ID", "SPECIFIED_RESOURCE_ID"))
+
+        # pylint: disable=no-member,protected-access
+        api._session.get.assert_called_once_with(
+            url=Any(),
+            headers=Any.dict.containing(
+                {
+                    "X-Goog-Drive-Resource-Keys": "FILE_ID/SPECIFIED_RESOURCE_ID",
+                }
+            ),
+            stream=Any(),
+            timeout=Any(),
+        )
+
     def test_iter_file_handles_errors(self, api, stream_bytes):
         # We aren't going to go crazy here as `iter_handle_errors` is better
         # tested elsewhere

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -74,14 +74,64 @@ class TestGoogleDriveAPI:
     @pytest.mark.parametrize(
         "url,expected",
         (
-            ("https://drive.google.com/uc?id=FILE_ID&export=download", "FILE_ID"),
-            ("https://drive.google.com/uc?id=FILE_ID&export=download-MORE", None),
-            ("https://drive.google.com/uc?id=FILE_ID", None),
-            ("", None),
+            (
+                "https://drive.google.com/uc?id=FILE_ID",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/uc?Id=FILE_ID",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/uc?id=FILE_ID&export=download",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/uc?id=FILE_ID&export=download&resourceKey=RESOURCE_KEY",
+                {"file_id": "FILE_ID", "resource_key": "RESOURCE_KEY"},
+            ),
+            (
+                "https://drive.google.com/uc?id=FILE_ID&export=download&resourcekey=RESOURCE_KEY",
+                {"file_id": "FILE_ID", "resource_key": "RESOURCE_KEY"},
+            ),
+            (
+                "https://drive.google.com/uc?id=FILE_ID&export=download&via.open_sidebar=1&via.request_config_from_frame=https%3A%2F%2Flms.hypothes.is",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/uc?id=FILE_ID&authuser=0&export=download",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/u/1/uc?id=FILE_ID&export=download",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/open?id=FILE_ID",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/file/d/FILE_ID/view?usp=sharing&resourceKey=RESOURCE_KEY",
+                {"file_id": "FILE_ID", "resource_key": "RESOURCE_KEY"},
+            ),
+            (
+                "https://drive.google.com/file/d/FILE_ID/view",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            (
+                "https://drive.google.com/a/su.edu/file/d/FILE_ID/view?usp=sharing",
+                {"file_id": "FILE_ID", "resource_key": None},
+            ),
+            # Failure conditions
+            ("https://drive.google.com/drive/u/0/folders/FOLDER_ID", None),
+            ("https://drive.google.com/drive/u/0/folders/?id=FOLDER_ID", None),
+            ("https://drive.google.com/drive/my-drive", None),
+            ("https://drive.google.com/drive/priority?ths=true", None),
+            ("https://not.google.com/uc?id=FILE_ID", None),
         ),
     )
-    def test_google_drive_id(self, url, expected):
-        assert GoogleDriveAPI.google_drive_id(url) == expected
+    def test_parse_file_url(self, url, expected):
+        assert GoogleDriveAPI.parse_file_url(url) == expected
 
     @pytest.fixture
     def api(self):

--- a/tests/unit/via/views/__init___test.py
+++ b/tests/unit/via/views/__init___test.py
@@ -17,6 +17,10 @@ class TestIncludeMe:
             mock.call("route_by_content", "/route", factory=URLResource),
             mock.call("debug_headers", "/debug/headers"),
             mock.call("proxy_google_drive_file", "/google_drive/{file_id}/proxied.pdf"),
+            mock.call(
+                "proxy_google_drive_file:resource_key",
+                "/google_drive/{file_id}/{resource_key}/proxied.pdf",
+            ),
             mock.call("proxy", "/{url:.*}"),
         ]
         config.scan.assert_called_once_with("via.views")

--- a/via/get_url.py
+++ b/via/get_url.py
@@ -24,7 +24,7 @@ def get_url_details(url, headers=None):
     if headers is None:
         headers = OrderedDict()
 
-    if GoogleDriveAPI.google_drive_id(url):
+    if GoogleDriveAPI.parse_file_url(url):
         return "application/pdf", 200
 
     headers = add_request_headers(clean_headers(headers))

--- a/via/services/__init__.py
+++ b/via/services/__init__.py
@@ -31,7 +31,10 @@ def create_google_api(settings):
         return GoogleDriveAPI(credentials_list=None)
 
     return GoogleDriveAPI(
-        credentials_list=load_injected_json(settings, "google_drive_credentials.json")
+        credentials_list=load_injected_json(settings, "google_drive_credentials.json"),
+        resource_keys=load_injected_json(
+            settings, "google_drive_resource_keys.json", required=False
+        ),
     )
 
 

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -89,10 +89,11 @@ class GoogleDriveAPI:
         return data
 
     @iter_handle_errors
-    def iter_file(self, file_id) -> Iterator[ByteString]:
+    def iter_file(self, file_id, resource_key=None) -> Iterator[ByteString]:
         """Get a generator of chunks of bytes for the specified file.
 
         :param file_id: Google Drive file id to retrieve
+        :param resource_key: Google Drive resources key (if any)
         :returns: A generator of byte strings which taken together form the
             document
 
@@ -109,6 +110,9 @@ class GoogleDriveAPI:
                 "User-Agent": "(gzip)",
             }
         )
+
+        if resource_key:
+            headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
 
         response = self._session.get(url=url, headers=headers, stream=True, timeout=10)
         response.raise_for_status()

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -20,14 +20,18 @@ class GoogleDriveAPI:
         "https://www.googleapis.com/auth/drive.readonly",
     ]
 
-    def __init__(self, credentials_list=None):
+    def __init__(self, credentials_list=None, resource_keys=None):
         """Initialise the service.
 
         :param credentials_list: A list of dicts of credentials info as
             provided by Google console's JSON format.
+        :param resource_keys: A dict of file ids to resource keys, to fill out
+            any missing resource keys.
 
         :raises ConfigurationError: If the credentials are not accepted by Google
         """
+        self._resource_keys = resource_keys or {}
+
         if credentials_list:
             try:
                 credentials = Credentials.from_service_account_info(
@@ -100,6 +104,11 @@ class GoogleDriveAPI:
                 "User-Agent": "(gzip)",
             }
         )
+
+        if not resource_key:
+            # If we are being called, we should have been initialised with a
+            # set of resource keys. See the factory below
+            resource_key = self._resource_keys.get(file_id)
 
         if resource_key:
             headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -51,16 +51,6 @@ class GoogleDriveAPI:
     _FILE_PATH_REGEX = re.compile("/file/d/(?P<file_id>[^/]+)")
 
     @classmethod
-    def google_drive_id(cls, public_url):
-        """Extract the google drive ID from a URL if there is one."""
-
-        details = cls.parse_file_url(public_url)
-        if details:
-            return details.get("file_id")
-
-        return None
-
-    @classmethod
     def parse_file_url(cls, public_url):
         """Extract the Google Drive data from a URL if there is one.
 

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -10,6 +10,10 @@ def add_routes(config):
     config.add_route("route_by_content", "/route", factory=URLResource)
     config.add_route("debug_headers", "/debug/headers")
     config.add_route("proxy_google_drive_file", "/google_drive/{file_id}/proxied.pdf")
+    config.add_route(
+        "proxy_google_drive_file:resource_key",
+        "/google_drive/{file_id}/{resource_key}/proxied.pdf",
+    )
     config.add_route("proxy", "/{url:.*}")
 
 

--- a/via/views/google_drive.py
+++ b/via/views/google_drive.py
@@ -7,6 +7,9 @@ from via.services.secure_link import has_secure_url_token
 
 
 @view_config(route_name="proxy_google_drive_file", decorator=(has_secure_url_token,))
+@view_config(
+    route_name="proxy_google_drive_file:resource_key", decorator=(has_secure_url_token,)
+)
 def proxy_google_drive_file(request):
     """Proxy a file from Google Drive."""
 
@@ -23,7 +26,10 @@ def proxy_google_drive_file(request):
     )
     # Add an iterable to stream the content instead of holding it all in memory
     response.app_iter = _reify_first(
-        request.find_service(GoogleDriveAPI).iter_file(request.matchdict["file_id"])
+        request.find_service(GoogleDriveAPI).iter_file(
+            file_id=request.matchdict["file_id"],
+            resource_key=request.matchdict.get("resource_key"),
+        ),
     )
 
     return response


### PR DESCRIPTION
This also includes much fancier Google Drive URL parsing as we've seen the URLs have more variation in them than we previously thought.

Based on:

 * https://github.com/hypothesis/via/pull/583
 * https://github.com/hypothesis/via/pull/581
 * https://github.com/hypothesis/via/pull/580
 
Requires:

 * https://github.com/hypothesis/devdata/pull/31

## Testing notes

All of this should be done with caching diabled.

Either drop a debug point into `via/services/google_drive.py` or modify it to log when it adds a resource key:

```diff
--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -111,6 +111,9 @@ class GoogleDriveAPI:
             resource_key = self._resource_keys.get(file_id)
 
         if resource_key:
+            from logging import getLogger
+            getLogger(__name__).warning(f"Resource key {resource_key}")
+
             headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
 
         response = self._session.get(url=url, headers=headers, stream=True, timeout=10)
```

You should be able to see the resource key printed out when you visit:

 * http://0.0.0.0:9082/google_drive/0ByrDah1tVd5qMmVzeTF3a0dDOWc/AMADEUPRESOURCEKEY/proxied.pdf
 * The above demonstrates proxying the resource key
 * http://0.0.0.0:9082/google_drive/0ByrDah1tVd5qMmVzeTF3a0dDOWc/proxied.pdf
 * The above demonstrates looking up the value

We should extract the key from URLs. Try pasting these into the root:

 * https://drive.google.com/uc?id=0ByrDah1tVd5qMmVzeTF3a0dDOWc&export=download&resourceKey=AMADEUPRESOURCEKEY
* https://drive.google.com/uc?id=0ByrDah1tVd5qMmVzeTF3a0dDOWc&export=download&resourcekey=AMADEUPRESOURCEKEY

We also accept a wider range of URLs now:

 * https://drive.google.com/file/d/17zLSXuH87GhQJRqTXDxP-vGO--GkeaC8/view?usp=sharing
 * https://drive.google.com/uc?id=0BzxGAA_njUeBSE5wdHlxblJtck0

Try pasting these into the landing page and observe the mapped URL