### PR TITLE
Add a fake name to let Cloudflare know this is a PDF

### DIFF
--- a/tests/unit/via/views/__init___test.py
+++ b/tests/unit/via/views/__init___test.py
@@ -16,7 +16,7 @@ class TestIncludeMe:
             mock.call("view_pdf", "/pdf", factory=URLResource),
             mock.call("route_by_content", "/route", factory=URLResource),
             mock.call("debug_headers", "/debug/headers"),
-            mock.call("proxy_google_drive_file", "/google_drive/{file_id}"),
+            mock.call("proxy_google_drive_file", "/google_drive/{file_id}/proxied.pdf"),
             mock.call("proxy", "/{url:.*}"),
         ]
         config.scan.assert_called_once_with("via.views")

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -62,7 +62,7 @@ class TestViewPDF:
         response = call_view_pdf(sentinel.url)
 
         secure_link_service.sign_url.assert_called_once_with(
-            "http://example.com/google_drive/FILE_ID?url=sentinel.url"
+            "http://example.com/google_drive/FILE_ID/proxied.pdf?url=sentinel.url"
         )
         assert response["proxy_pdf_url"] == secure_link_service.sign_url.return_value
 

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -9,7 +9,7 @@ def add_routes(config):
     config.add_route("view_pdf", "/pdf", factory=URLResource)
     config.add_route("route_by_content", "/route", factory=URLResource)
     config.add_route("debug_headers", "/debug/headers")
-    config.add_route("proxy_google_drive_file", "/google_drive/{file_id}")
+    config.add_route("proxy_google_drive_file", "/google_drive/{file_id}/proxied.pdf")
     config.add_route("proxy", "/{url:.*}")
 
 


### PR DESCRIPTION
Cloudflare's caching isn't based on Content-Type, but file extension instead. So we need to introduce a fake name to let Cloudflare know these are PDFs:

 * https://developers.cloudflare.com/cache/about/default-cache-behavior