### PR TITLE
Report exceptions to Sentry

### DIFF
--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -11,6 +11,13 @@ from via.views.exceptions import EXCEPTION_MAP, all_exceptions
 
 
 class TestErrorView:
+    def test_it_reports_the_exception_to_Sentry(
+        self, h_pyramid_sentry, pyramid_request
+    ):
+        all_exceptions(RuntimeError(), pyramid_request)
+
+        h_pyramid_sentry.report_exception.assert_called_once_with()
+
     @pytest.mark.parametrize(
         "exception_class,status_code",
         (
@@ -71,3 +78,8 @@ class TestErrorView:
     @pytest.fixture
     def pyramid_request(self):
         return DummyRequest()
+
+
+@pytest.fixture(autouse=True)
+def h_pyramid_sentry(patch):
+    return patch("via.views.exceptions.h_pyramid_sentry")

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -1,5 +1,6 @@
 """Error views to handle when things go wrong in the app."""
 
+import h_pyramid_sentry
 from pyramid.httpexceptions import (
     HTTPClientError,
     HTTPError,
@@ -72,6 +73,8 @@ def _get_meta(exception):
 @exception_view_config(HTTPError, renderer="via:templates/exception.html.jinja2")
 def all_exceptions(exc, request):
     """Catch all errors (Pyramid or Python) and display an HTML page."""
+
+    h_pyramid_sentry.report_exception()
 
     try:
         status_code = exc.status_int


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via/issues/585 and https://github.com/hypothesis/via/issues/599.

Right now reporting exceptions to Sentry is not working at all in Via.

For example you can break the Google Drive service to always raise
`RuntimeError`:

```diff
diff --git a/via/services/google_drive.py b/via/services/google_drive.py
index 80be077..94470bb 100644
--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -71,6 +71,7 @@ class GoogleDriveAPI:
         :raises HTTPNotFound: If the file id is not valid
         :raises UpstreamServiceError: For other errors
         """
+        raise RuntimeError("foobar")
         # https://developers.google.com/drive/api/v3/reference/files/get
         url = f"https://www.googleapis.com/drive/v3/files/{file_id}?alt=media"
```

Then go and launch [localhost (make devdata) Google Drive Assignment](https://hypothesis.instructure.com/courses/125/assignments/876)
and the app will crash but nothing will be reported to Sentry.

**Out of scope:** given a random crasher bug like the above the app also
won't log anything to Papertrail, and will also respond with a 417
rather than a 500 which will make our monitoring think that the app is
working correctly even though it's completely broken. Those two will be
dealt with in separate PRs.

The reason that nothing gets reported to Sentry is that Via has an
exception view that catches all exceptions and turns them into **417
Expectation Failed** responses (if the exception doesn't have a custom
`status_int`):

```python
@exception_view_config(Exception, renderer="via:templates/exception.html.jinja2")
@exception_view_config(HTTPError, renderer="via:templates/exception.html.jinja2")
def all_exceptions(exc, request):
    try:
        status_code = exc.status_int
    except AttributeError:
        # This is our 501, chosen to not scare Cloudflare.
        status_code = HTTPExpectationFailed.code  # 417

    request.response.status_int = status_code

    ...
```

Sentry's Pyramid integration automatically reports all exceptions _that
lead to a 500 Internal Server Error_. Specifically, it reports:

1. Exceptions that are not handled by an exception view

2. Exceptions that *are* handled by an exception view but the resulting
   HTTP response still has a status code of 500

See: https://docs.sentry.io/platforms/python/guides/pyramid/

It makes good sense to have an exception view that catches all exceptions
so that you can show a nice error page. We have one in LMS:

https://github.com/hypothesis/lms/blob/e602cdf6417a93ab6b8d13f566ded10587b68941/lms/views/exceptions.py#L80-L104

And another for the LMS API:

https://github.com/hypothesis/lms/blob/e602cdf6417a93ab6b8d13f566ded10587b68941/lms/views/api/exceptions.py#L122-L131

h also has them:

https://github.com/hypothesis/h/blob/9de8e2cada240cb7d1250bf2b8b4229358b8c1fc/h/views/errors.py#L22-L28
https://github.com/hypothesis/h/blob/9de8e2cada240cb7d1250bf2b8b4229358b8c1fc/h/views/api/errors.py#L67-L76

But if writing a catch-all exception view you need to make sure the
exception gets reported to Sentry by either:

1. Setting `status_int` to 500, then `sentry_sdk` will report it
   automatically. This is the right thing to do for random, unexpected
   exceptions (that must have happened due to a bug)

2. Or, if you don't want to return a 500 but still do want to report the
   exception to Sentry, you need to call
   `h_pyramid_sentry.report_exception()` manually from your exception view

For now this PR fixes Sentry reporting by calling `report_exception()`
manually.

In many cases (such as a random code bug raising an uncaught
`ValueError` or something) Via should be setting the status code to 500
which would mean that calling `report_exception()` is unnecessary in
those cases and the exception still gets reported to Sentry automatically.
This'll be dealt with in a following PR.