### PR TITLE
Log exceptions to Papertrail

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -150,9 +150,12 @@ pyramid==2.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
+    #   pyramid-exclog
     #   pyramid-ipython
     #   pyramid-jinja2
     #   pyramid-services
+pyramid-exclog==1.0
+    # via -r requirements/requirements.txt
 pyramid-ipython==0.2
     # via -r requirements/dev.in
 pyramid-jinja2==2.8

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -113,8 +113,11 @@ pyramid==2.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
+    #   pyramid-exclog
     #   pyramid-jinja2
     #   pyramid-services
+pyramid-exclog==1.0
+    # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
     # via -r requirements/requirements.txt
 pyramid-services==2.2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -178,8 +178,13 @@ pyramid==2.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   h-pyramid-sentry
+    #   pyramid-exclog
     #   pyramid-jinja2
     #   pyramid-services
+pyramid-exclog==1.0
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
 pyramid-jinja2==2.8
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,6 +5,7 @@ h-vialib
 importlib_resources
 newrelic
 pyramid
+pyramid-exclog
 pyramid-jinja2
 pyramid-services
 requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -66,8 +66,11 @@ pyramid==2.0
     # via
     #   -r requirements/requirements.in
     #   h-pyramid-sentry
+    #   pyramid-exclog
     #   pyramid-jinja2
     #   pyramid-services
+pyramid-exclog==1.0
+    # via -r requirements/requirements.in
 pyramid-jinja2==2.8
     # via -r requirements/requirements.in
 pyramid-services==2.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -119,8 +119,11 @@ pyramid==2.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
+    #   pyramid-exclog
     #   pyramid-jinja2
     #   pyramid-services
+pyramid-exclog==1.0
+    # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
     # via -r requirements/requirements.txt
 pyramid-services==2.2

--- a/via/app.py
+++ b/via/app.py
@@ -60,6 +60,7 @@ def create_app(_=None, **settings):
     """Configure and return the WSGI app."""
     config = pyramid.config.Configurator(settings=load_settings(settings))
 
+    config.include("pyramid_exclog")
     config.include("pyramid_jinja2")
     config.include("pyramid_services")
     config.include("h_pyramid_sentry")


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via/issues/597.

Currently Via doesn't log any exceptions to Papertrail. This is out of line with the rest of our apps which log all exceptions.

For example this diff will make proxying Google Drive files crash:

```diff
diff --git a/via/services/google_drive.py b/via/services/google_drive.py
index 80be077..ac2c549 100644
--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -71,6 +71,8 @@ class GoogleDriveAPI:
         :raises HTTPNotFound: If the file id is not valid
         :raises UpstreamServiceError: For other errors
         """
+        raise RuntimeError("Foobar")
+
         # https://developers.google.com/drive/api/v3/reference/files/get
         url = f"https://www.googleapis.com/drive/v3/files/{file_id}?alt=media"

```

If you now launch [localhost (make devdata) Google Drive Assignment](https://hypothesis.instructure.com/courses/125/assignments/876) **on master** the app will crash but no exception will be logged to the terminal.

This PR uses [pyramid_exclog](https://docs.pylonsproject.org/projects/pyramid-exclog/en/latest/) to add exception logging to Via, the same as we do for the rest of our apps. On **this branch** `pyramid_exclog` will log the request's URL and the exception with traceback for us:

```
'http://localhost:9083/google_drive/1-YXZ***UJOS/proxied.pdf?url=...'
Traceback (most recent call last):
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/pyramid/tweens.py", line 41, in excview_tween
    response = handler(request)
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/pyramid/router.py", line 143, in handle_request
    response = _call_view(
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/sentry_sdk/integrations/pyramid.py", line 90, in sentry_patched_call_view
    return old_call_view(registry, request, *args, **kwargs)
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/pyramid/view.py", line 674, in _call_view
    response = view_callable(context, request)
  File "/home/seanh/Projects/via/via/services/secure_link.py", line 13, in view_wrapper
    return view(context, request)
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/pyramid/viewderivers.py", line 392, in viewresult_to_response
    result = view(context, request)
  File "/home/seanh/Projects/via/.tox/dev/lib/python3.8/site-packages/pyramid/viewderivers.py", line 141, in _requestonly_view
    response = view(request)
  File "/home/seanh/Projects/via/via/views/google_drive.py", line 25, in proxy_google_drive_file
    response.app_iter = _reify_first(
  File "/home/seanh/Projects/via/via/views/google_drive.py", line 39, in _reify_first
    return chain((next(iterable),), iterable)
  File "/home/seanh/Projects/via/via/requests_tools/error_handling.py", line 53, in deco
    yield from inner(*args, **kwargs)
  File "/home/seanh/Projects/via/via/services/google_drive.py", line 74, in iter_file
    raise RuntimeError("Foobar")
RuntimeError: Foobar
```

Some notes about `pyramid_exclog`:

* This is what we already use in [Checkmate](https://github.com/hypothesis/checkmate/blob/7df6485e0e1a01fcf12b9d4c9cb10610a3afeb86/requirements/requirements.in#L11), [LMS](https://github.com/hypothesis/lms/blob/e602cdf6417a93ab6b8d13f566ded10587b68941/requirements/requirements.in#L15) and [h](https://github.com/hypothesis/h/blob/9de8e2cada240cb7d1250bf2b8b4229358b8c1fc/requirements/requirements.in#L36). We have special `pyramid_exclog` support [in h-pyramid-sentry](https://github.com/hypothesis/h-pyramid-sentry) as well. `pyramid_exclog` was just omitted from Via by accident.

* [The source code](https://github.com/Pylons/pyramid_exclog/blob/master/pyramid_exclog/__init__.py) is pretty simple (176 lines)

* See [the docs](https://docs.pylonsproject.org/projects/pyramid_exclog/en/latest/)

* By default it logs all exceptions even ones handled by exception views, which is what we want.

  There's one exception: **it does not log exceptions that are subclasses of Pyramid's `HTTPError`**. This is unfortunate for Via because [Via's own custom exceptions are subclasses of `HTTPError`](https://github.com/hypothesis/via/blob/0b34ab93093381cc4655adad456b6f789f560fce/via/exceptions.py#L9-L22). Subclassing `HTTPError` also breaks Sentry: `sentry_sdk` also reports all exceptions except `HTTPError`'s. Subclassing `HTTPError` likely has other unexpected and undesirable consequences as well, either from Pyramid itself or from other Pyramid extensions. This needs to be fixed in a separate PR: there's no need for Via's custom exceptions to be subclasses of Pyramid's HTTP exceptions, it has broken both exception logging and exception reporting to Sentry and is asking for more trouble in future. It's usually best not to subclass third-party classes that aren't specifically intended for subclassing, for this reason and others. This is even more true with exceptions: it's best to keep your exception classes very simple, little more than sentinel values, with maybe just a _little_ code (e.g. a `__str__()`). Inheriting your exception class from a complex third-party class with potential meaning to third-party code is asking for trouble

  You can use the `exclog.ignore` setting to filter out exceptions that you don't want it to log.

* By default `pyramid_exclog` logs the request's URL, the exception's `__str__()`, and the traceback. (It [calls `logger.error(message, exc_info=exc_info)`](https://github.com/Pylons/pyramid_exclog/blob/14c5c7ad1fa2b295d7a57d5d0bfb8269c7778ac2/pyramid_exclog/__init__.py#L114) where `message` is a string containing the request's URL.) You can enable the `exclog.extra_info` setting to also log the environment and params.

* You can use the `exclog.get_message` setting to provide your own custom function for rendering requests to strings. This is [the default `get_message()`](https://github.com/Pylons/pyramid_exclog/blob/14c5c7ad1fa2b295d7a57d5d0bfb8269c7778ac2/pyramid_exclog/__init__.py#L69-L94).

* If you want to customize how *exceptions* are rendered to strings you write your own exception class with a `__str__()` and raise that (wrapping a third-party exception class if relevant). This will customize the stringification of your exception in exclog and everywhere else it appears (Sentry, New Relic)