### PR TITLE
Don't turn crashes into 417's

### DIFF
--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -26,7 +26,7 @@ class TestErrorView:
                 HTTPUnsupportedMediaType.code,
                 id="Pyramid error",
             ),
-            param(BlockingIOError, 417, id="Unknown python error"),
+            param(BlockingIOError, 500, id="Unknown python error"),
         ),
     )
     def test_values_are_copied_from_the_exception(

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -1,12 +1,7 @@
 """Error views to handle when things go wrong in the app."""
 
 import h_pyramid_sentry
-from pyramid.httpexceptions import (
-    HTTPClientError,
-    HTTPError,
-    HTTPExpectationFailed,
-    HTTPNotFound,
-)
+from pyramid.httpexceptions import HTTPClientError, HTTPError, HTTPNotFound
 from pyramid.view import exception_view_config
 
 from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
@@ -79,8 +74,7 @@ def all_exceptions(exc, request):
     try:
         status_code = exc.status_int
     except AttributeError:
-        # This is our 501, chosen to not scare Cloudflare.
-        status_code = HTTPExpectationFailed.code  # 417
+        status_code = 500
 
     request.response.status_int = status_code
 


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via/issues/598

Via currently turns all crashes (even ones caused by straight bugs in the code) into HTTP 417 responses.

When Via is crashing due to a bug in our code we want that to be a 500 Internal Server Error as it would normally be. We don't want to turn it into a 417. Turning all 500s into 417s will make monitoring systems think the app is healthy when it's broken which could allow bugs to be deployed when the deployment would otherwise be automatically backed out, or could cause alarms to fail to trigger. It's also misleading to anyone observing and debugging Via.

Note that error/invalid/unexpected responses from third-party sites that Via is proxying are a different issue: if Via tries to make an external request and it fails we may not want to return an HTTP 500 in that case. This issue isn't about that. It's about straight bugs in our own code.

For example this diff will make the Google Drive endpoint crash:

```
diff --git a/via/services/google_drive.py b/via/services/google_drive.py
index 80be077..ac2c549 100644
--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -71,6 +71,8 @@ class GoogleDriveAPI:
         :raises HTTPNotFound: If the file id is not valid
         :raises UpstreamServiceError: For other errors
         """
+        raise RuntimeError("Foobar")
+
         # https://developers.google.com/drive/api/v3/reference/files/get
         url = f"https://www.googleapis.com/drive/v3/files/{file_id}?alt=media"

```

If you now launch [localhost (make devdata) Google Drive Assignment](https://hypothesis.instructure.com/courses/125/assignments/876) and look for the `/google_drive/` response in dev tools you'll see that it's a 417. This should be a 500 (as should all unexpected errors in general).