### PR TITLE
Don't subclass Pyramid's `httpexceptions`

### DIFF
--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -1,22 +1,20 @@
-"""Application specific exceptions."""
-
-from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPExpectationFailed
-
-# pylint: disable=too-many-ancestors
-# It's ok to have a hierarchy of exceptions
-
-
-class BadURL(HTTPBadRequest):
+class BadURL(Exception):
     """An invalid URL was discovered."""
 
+    status_int = 400
 
-class UpstreamServiceError(HTTPConflict):
+
+class UpstreamServiceError(Exception):
     """Something went wrong when calling an upstream service."""
 
+    status_int = 409
 
-class UnhandledException(HTTPExpectationFailed):
+
+class UnhandledException(Exception):
     """Something we did not plan for went wrong."""
 
+    status_int = 417
 
-class ConfigurationError(UnhandledException):
+
+class ConfigurationError(Exception):
     """The application configuration is malformed."""


### PR DESCRIPTION
Depends on https://github.com/hypothesis/via/pull/600.

Even with `pyramid_exclog` added to Via (by https://github.com/hypothesis/via/pull/600) Via still doesn't log errors from requests to upstream services. This is because Via's custom exception classes are subclasses of Pyramid's `HTTPError` and `HTTPError` has special meaning to `pyramid_exclog` (and to Pyramid itself and many Pyramid other extensions). Specifically: `pyramid_exclog` filters `HTTPError`'s out from the logs. There are some more notes on the issue in https://github.com/hypothesis/via/pull/600.

You can simulate an error from Google Drive by hacking the code like this:

```diff
diff --git a/via/services/google_drive.py b/via/services/google_drive.py
index 80be077..166ee52 100644
--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -82,6 +82,7 @@ class GoogleDriveAPI:
             }
         )

+        url = "https://httpbin.org/status/500"
         response = self._session.get(url=url, headers=headers, stream=True, timeout=10)
         response.raise_for_status()
```

**On master** if you now launch [localhost (make devdata) Google Drive Assignment](https://hypothesis.instructure.com/courses/125/assignments/876) the app will crash but you won't see the exception logged in the terminal.

The fix is simple: don't subclass Pyramid httpexceptions. On this branch you will see the exception logged.

It's unnecessary for the custom exception classes in `via/exceptions.py` to be subclasses of Pyramid's builtin `httpexception`'s and it causes a number of problems:

1. Pyramid's `HTTPError` (the base class for all `httpexception`'s) has special meaning to `sentry_sdk`: it doesn't automatically report instances of this class to Sentry. Subclassing `HTTPError` disables automatic Sentry reporting for Via's custom exception classes.

2. Same problem with `pyramid_exclog`: it doesn't log `HTTPError`'s.

3. There could be other cases that we haven't discovered yet, present or future, of subclassing `HTTPError` triggering unexpected and undesirable behavior from Pyramid itself or from Pyramid extensions.  `HTTPError`'s have meaning and significance in Pyramid land that we don't intend for our custom exception classes.

4. Subclassing `HTTPError` tangles Via's custom exception hierarchy up with Pyramid's `httpexceptions` hierarchy.

   For example we might want to treat all exceptions to do with upstream requests one way (defaulting the response status to 417 if the exception doesn't specify its own `status_int`) and all other exceptions another way (setting the response status to 500).

   To implement this you would want all exceptions to do with upstream requests to share a common base class that is subclassed _only_ by upstream request-related exceptions. An exception view for this shared base class can then implement the error response behavior that we want for upstream errors. While an exception view for the base `Exception` class can implement the error response that we want for bugs.

   As long as the hierarchy of our exception classes is entangled with that of Pyramid's `httpexception`'s we can't freely mutate the hierarchy in the way that we need to.

   (This is a hypothetical example.)
