### PR TITLE
Attempt to fix logging in production

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -1,0 +1,48 @@
+[pipeline:main]
+pipeline:
+  proxy-prefix
+  via
+
+[app:via]
+use = call:via.app:create_app
+
+[filter:proxy-prefix]
+use: egg:PasteDeploy#prefix
+
+###
+# logging configuration
+# https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, via, alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_via]
+level = DEBUG
+handlers =
+qualname = via
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=newrelic-admin run-program gunicorn via.app:create_app() -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn --paste conf/production.ini -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
Via's logging to Papertrail doesn't seem to be working properly in production. For example no messages from pyramid_exclog are showing. I think it might be due to the absence of a production.ini file with logging config. I'm hoping this (copied from LMS) will fix it.