### PR TITLE
Ensure we get the right route if we get `resourceKey=None`

### DIFF
--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -61,6 +61,10 @@ class TestViewPDF:
                 "http://example.com/google_drive/FILE_ID/proxied.pdf?url=sentinel.url",
             ),
             (
+                {"file_id": "FILE_ID", "resource_key": None},
+                "http://example.com/google_drive/FILE_ID/proxied.pdf?url=sentinel.url",
+            ),
+            (
                 {"file_id": "FILE_ID", "resource_key": "RESOURCE_KEY"},
                 "http://example.com/google_drive/FILE_ID/RESOURCE_KEY/proxied.pdf?url=sentinel.url",
             ),

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -57,7 +57,7 @@ class ProxyURLBuilder:
     @staticmethod
     def google_file_url(request, file_details, url):
         route = "proxy_google_drive_file"
-        if "resource_key" in file_details:
+        if file_details.get("resource_key"):
             route += ":resource_key"
 
         return request.find_service(SecureLinkService).sign_url(


### PR DESCRIPTION
There are two ways to go about this:

* Change the parsing to not return the key if it's None
* Change the routing to handle it correctly

I chose the latter because in general it's nicer to always have a key/attribute instead of having to "if key, get key value" and to let the presence of None tell the story.

### Testing notes

 * Paste the following URL into the landing page:
 * https://drive.google.com/file/d/0ByrDah1tVd5qMmVzeTF3a0dDOWc/view?usp=sharing
 * In master this gets routed as:
`http://0.0.0.0:9082/google_drive/0ByrDah1tVd5qMmVzeTF3a0dDOWc/None/proxied.pdf?url=...`
* In this PR it gets routed as:
`http://0.0.0.0:9082/google_drive/0ByrDah1tVd5qMmVzeTF3a0dDOWc/proxied.pdf?url=...`