### PR TITLE
Log whenever we map a Google Drive resource key

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -4,3 +4,41 @@ use = call:via.app:create_app
 nginx_server: http://localhost:9083
 client_embed_url: http://localhost:5000/embed.js
 via_html_url: http://localhost:9085/proxy
+
+###
+# logging configuration
+# https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, via, alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = DEBUG
+handlers = console
+
+[logger_via]
+level = DEBUG
+handlers =
+qualname = via
+
+[logger_alembic]
+level = DEBUG
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -1,4 +1,5 @@
 import re
+from logging import getLogger
 from typing import ByteString, Iterator
 from urllib.parse import parse_qs, urlparse
 
@@ -8,6 +9,8 @@ from google.oauth2.service_account import Credentials
 from via.exceptions import ConfigurationError
 from via.requests_tools import add_request_headers, stream_bytes
 from via.requests_tools.error_handling import iter_handle_errors
+
+LOG = getLogger(__name__)
 
 
 class GoogleDriveAPI:
@@ -109,6 +112,12 @@ class GoogleDriveAPI:
             # If we are being called, we should have been initialised with a
             # set of resource keys. See the factory below
             resource_key = self._resource_keys.get(file_id)
+            if resource_key:
+                LOG.info(
+                    "Mapped Google Drive file id '%s' to resource key '%s'",
+                    file_id,
+                    resource_key,
+                )
 
         if resource_key:
             headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"


### PR DESCRIPTION
This PR does two things:

 * Enabled detailed logging in dev
 * Logs whenever we map a Google Drive resource key

### Testing notes

 * `make devdata dev`
 * Paste this URL into the landing page:
 * https://drive.google.com/file/d/0ByrDah1tVd5qMmVzeTF3a0dDOWc/view?usp=sharing
 * You should see much more logging output
 * In there should be a line like this:
 * `web (stderr)         | 2021-09-08 15:07:55,686 INFO  [via.services.google_drive:116][MainThread] Mapped Google Drive file id '0ByrDah1tVd5qMmVzeTF3a0dDOWc' to resource key '0-9FE5GjdW3kEkf3dRJ-Kdow'`
