### PR TITLE
Filter which exceptions get reported to Sentry

### DIFF
--- a/tests/unit/via/requests_tools/error_handling_test.py
+++ b/tests/unit/via/requests_tools/error_handling_test.py
@@ -1,7 +1,7 @@
 import pytest
 from requests import exceptions
 
-from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
+from via.exceptions import BadURL, UnhandledUpstreamException, UpstreamServiceError
 from via.requests_tools.error_handling import handle_errors, iter_handle_errors
 
 EXCEPTION_MAP = (
@@ -13,7 +13,7 @@ EXCEPTION_MAP = (
     (exceptions.Timeout, UpstreamServiceError),
     (exceptions.TooManyRedirects, UpstreamServiceError),
     (exceptions.SSLError, UpstreamServiceError),
-    (exceptions.UnrewindableBodyError, UnhandledException),
+    (exceptions.UnrewindableBodyError, UnhandledUpstreamException),
 )
 
 

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -2,22 +2,24 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
-from pyramid.httpexceptions import HTTPClientError, HTTPUnsupportedMediaType
+from pyramid.httpexceptions import (
+    HTTPClientError,
+    HTTPGatewayTimeout,
+    HTTPNotFound,
+    HTTPUnsupportedMediaType,
+)
 from pyramid.testing import DummyRequest
 from pytest import param
 
-from via.exceptions import BadURL, UnhandledException
-from via.views.exceptions import EXCEPTION_MAP, all_exceptions
+from via.exceptions import BadURL, UnhandledUpstreamException, UpstreamServiceError
+from via.views.exceptions import (
+    EXCEPTION_MAP,
+    google_drive_exceptions,
+    other_exceptions,
+)
 
 
-class TestErrorView:
-    def test_it_reports_the_exception_to_Sentry(
-        self, h_pyramid_sentry, pyramid_request
-    ):
-        all_exceptions(RuntimeError(), pyramid_request)
-
-        h_pyramid_sentry.report_exception.assert_called_once_with()
-
+class TestExceptionViews:
     @pytest.mark.parametrize(
         "exception_class,status_code",
         (
@@ -30,11 +32,11 @@ class TestErrorView:
         ),
     )
     def test_values_are_copied_from_the_exception(
-        self, exception_class, status_code, pyramid_request
+        self, exception_view, exception_class, status_code, pyramid_request
     ):
         exception = exception_class("details string")
 
-        values = all_exceptions(exception, pyramid_request)
+        values = exception_view(exception, pyramid_request)
 
         assert values == Any.dict.containing(
             {
@@ -52,34 +54,85 @@ class TestErrorView:
         (
             param(BadURL, BadURL, id="Mapped directly"),
             param(HTTPUnsupportedMediaType, HTTPClientError, id="Inherited"),
-            param(BlockingIOError, UnhandledException, id="Unmapped"),
+            param(BlockingIOError, UnhandledUpstreamException, id="Unmapped"),
         ),
     )
     def test_we_fill_in_other_values_based_on_exception_lookup(
-        self, exception_class, mapped_exception, pyramid_request
+        self, exception_view, exception_class, mapped_exception, pyramid_request
     ):
         exception = exception_class("details string")
 
-        values = all_exceptions(exception, pyramid_request)
+        values = exception_view(exception, pyramid_request)
 
         assert values["exception"] == Any.dict.containing(
             EXCEPTION_MAP[mapped_exception]
         )
 
     @pytest.mark.parametrize("doc_url", (sentinel.doc_url, None))
-    def test_it_reads_the_urls_from_the_request(self, pyramid_request, doc_url):
+    def test_it_reads_the_urls_from_the_request(
+        self, exception_view, pyramid_request, doc_url
+    ):
         pyramid_request.GET["url"] = doc_url
         pyramid_request.url = sentinel.request_url
 
-        values = all_exceptions(ValueError(), pyramid_request)
+        values = exception_view(ValueError(), pyramid_request)
 
         assert values["url"] == {"original": doc_url, "retry": sentinel.request_url}
+
+    @pytest.mark.parametrize(
+        "exception_class,should_report",
+        (
+            (UpstreamServiceError, False),
+            (UnhandledUpstreamException, False),
+            (BadURL, False),
+            (HTTPClientError, False),
+            (ValueError, True),
+            (HTTPGatewayTimeout, True),
+        ),
+    )
+    def test_other_exceptions_reporting_to_sentry(
+        self, pyramid_request, h_pyramid_sentry, exception_class, should_report
+    ):
+        exception = exception_class("Oh no")
+
+        other_exceptions(exception, pyramid_request)
+
+        if should_report:
+            h_pyramid_sentry.report_exception.assert_called_once_with(exception)
+        else:
+            h_pyramid_sentry.report_exception.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "exception_class,should_report",
+        (
+            (HTTPNotFound, True),
+            (UnhandledUpstreamException, True),
+            (BadURL, True),
+            (HTTPClientError, True),
+            (ValueError, True),
+            (HTTPGatewayTimeout, True),
+        ),
+    )
+    def test_google_drive_exceptions_reporting_to_sentry(
+        self, pyramid_request, h_pyramid_sentry, exception_class, should_report
+    ):
+        exception = exception_class("Oh no")
+
+        google_drive_exceptions(exception, pyramid_request)
+
+        # if should_report:
+        h_pyramid_sentry.report_exception.assert_called_once_with(exception)
+        # else:
+        #     h_pyramid_sentry.report_exception.assert_not_called()
+
+    @pytest.fixture(params=[other_exceptions, google_drive_exceptions])
+    def exception_view(self, request):
+        return request.param
 
     @pytest.fixture
     def pyramid_request(self):
         return DummyRequest()
 
-
-@pytest.fixture(autouse=True)
-def h_pyramid_sentry(patch):
-    return patch("via.views.exceptions.h_pyramid_sentry")
+    @pytest.fixture(autouse=True)
+    def h_pyramid_sentry(self, patch):
+        return patch("via.views.exceptions.h_pyramid_sentry")

--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -10,7 +10,7 @@ class UpstreamServiceError(Exception):
     status_int = 409
 
 
-class UnhandledException(Exception):
+class UnhandledUpstreamException(Exception):
     """Something we did not plan for went wrong."""
 
     status_int = 417

--- a/via/requests_tools/error_handling.py
+++ b/via/requests_tools/error_handling.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from requests import RequestException, exceptions
 
-from via.exceptions import BadURL, UnhandledException, UpstreamServiceError
+from via.exceptions import BadURL, UnhandledUpstreamException, UpstreamServiceError
 
 REQUESTS_BAD_URL = (
     exceptions.MissingSchema,
@@ -39,7 +39,7 @@ def handle_errors(inner):
             raise UpstreamServiceError(_get_message(err)) from err
 
         except RequestException as err:
-            raise UnhandledException(_get_message(err)) from err
+            raise UnhandledUpstreamException(_get_message(err)) from err
 
     return deco
 
@@ -59,6 +59,6 @@ def iter_handle_errors(inner):
             raise UpstreamServiceError(_get_message(err)) from None
 
         except RequestException as err:
-            raise UnhandledException(_get_message(err)) from None
+            raise UnhandledUpstreamException(_get_message(err)) from None
 
     return deco


### PR DESCRIPTION
For: https://github.com/hypothesis/via/issues/612

Currently we over report issues, which means for public Via in particular Sentry will get filled up with lots of things to do with 3rd parties going wrong.

This PR:

 * Adds a separate view for Google Drive
 * Doesn't report on errors we aren't interested in

## Testing notes

 * Get the Sentry DSN listed here: https://sentry.io/settings/hypothesis/projects/sentry-test-environment/keys/
 * `SENTRY_DSN=<dsn-here> make dev`
 * BREAK STUFF!
 * Specifically you can try: http://0.0.0.0:9082/google_drive/NOTATHING/proxied.pdf
 * You should see _non_ filtered exceptions show up here: https://sentry.io/organizations/hypothesis/projects/sentry-test-environment/?project=5952630
