### PR TITLE
Add longer and more timeouts to Google Drive

### DIFF
--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -17,6 +17,7 @@ class TestGoogleDriveAPI:
         )
         AuthorizedSession.assert_called_once_with(
             Credentials.from_service_account_info.return_value,
+            refresh_timeout=GoogleDriveAPI.TIMEOUT,
         )
         # pylint: disable=protected-access
         assert api._session == AuthorizedSession.return_value
@@ -49,7 +50,8 @@ class TestGoogleDriveAPI:
                 "X-Complaints-To": Any.string(),
             },
             stream=True,
-            timeout=10,
+            timeout=GoogleDriveAPI.TIMEOUT,
+            max_allowed_time=GoogleDriveAPI.TIMEOUT,
         )
 
         api._session.get.return_value.raise_for_status.assert_called_once_with()
@@ -69,6 +71,7 @@ class TestGoogleDriveAPI:
             ),
             stream=Any(),
             timeout=Any(),
+            max_allowed_time=Any(),
         )
 
     def test_iter_file_handles_errors(self, api, stream_bytes):

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -23,6 +23,10 @@ class GoogleDriveAPI:
         "https://www.googleapis.com/auth/drive.readonly",
     ]
 
+    # Configure all the various types of timeout available to us, with the hope
+    # that the shortest one will kick in first
+    TIMEOUT = 30
+
     def __init__(self, credentials_list=None, resource_keys=None):
         """Initialise the service.
 
@@ -45,7 +49,7 @@ class GoogleDriveAPI:
                     "The Google Drive service account information is invalid"
                 ) from exc
 
-            self._session = AuthorizedSession(credentials)
+            self._session = AuthorizedSession(credentials, refresh_timeout=self.TIMEOUT)
         else:
             self._session = None
 
@@ -122,7 +126,13 @@ class GoogleDriveAPI:
         if resource_key:
             headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
 
-        response = self._session.get(url=url, headers=headers, stream=True, timeout=10)
+        response = self._session.get(
+            url=url,
+            headers=headers,
+            stream=True,
+            timeout=self.TIMEOUT,
+            max_allowed_time=self.TIMEOUT,
+        )
         response.raise_for_status()
 
         yield from stream_bytes(response)


### PR DESCRIPTION
This is to try and cut down on the number of documents that hang because Google is being slow.

This also possibly prevents us from other situations where Google might run out the clock and cause us to hit, for example, a Gunicorn exception.