### PR TITLE
Add 404 handling to Google Drive

### DIFF
--- a/tests/unit/via/services/fixtures/google_404.json
+++ b/tests/unit/via/services/fixtures/google_404.json
@@ -1,0 +1,15 @@
+{
+    "error": {
+        "errors": [
+            {
+                "domain": "global",
+                "reason": "notFound",
+                "message": "File not found: 0ByDOWc.",
+                "locationType": "parameter",
+                "location": "fileId"
+            }
+        ],
+        "code": 404,
+        "message": "File not found: 0ByDOWc."
+    }
+}

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO
 from unittest.mock import sentinel
 
+import importlib_resources
 import pytest
 from h_matchers import Any
 from pyramid.httpexceptions import HTTPNotFound
@@ -100,7 +101,7 @@ class TestGoogleDriveAPI:
             make_requests_exception(
                 HTTPError,
                 status_code=404,
-                json_data={"error": {"errors": [{"reason": "notFound"}]}},
+                json_data=load_fixture("google_404.json"),
             )
         )
 
@@ -238,3 +239,11 @@ def make_requests_exception(error_class, status_code, json_data=None, raw_data=N
         response.raw = BytesIO(json.dumps(json_data).encode("utf-8"))
 
     return error_class(response=response)
+
+
+def load_fixture(filename):
+    ref = importlib_resources.files("tests.unit.via.services.fixtures").joinpath(
+        filename
+    )
+    with ref.open(encoding="utf-8") as handle:
+        return json.load(handle)

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -105,7 +105,7 @@ class TestExceptionViews:
     @pytest.mark.parametrize(
         "exception_class,should_report",
         (
-            (HTTPNotFound, True),
+            (HTTPNotFound, False),
             (UnhandledUpstreamException, True),
             (BadURL, True),
             (HTTPClientError, True),
@@ -120,10 +120,10 @@ class TestExceptionViews:
 
         google_drive_exceptions(exception, pyramid_request)
 
-        # if should_report:
-        h_pyramid_sentry.report_exception.assert_called_once_with(exception)
-        # else:
-        #     h_pyramid_sentry.report_exception.assert_not_called()
+        if should_report:
+            h_pyramid_sentry.report_exception.assert_called_once_with(exception)
+        else:
+            h_pyramid_sentry.report_exception.assert_not_called()
 
     @pytest.fixture(params=[other_exceptions, google_drive_exceptions])
     def exception_view(self, request):

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -77,7 +77,9 @@ def _get_meta(exception):
 def google_drive_exceptions(exc, request):
     """Catch all errors for Google Drive and display an HTML page."""
 
-    h_pyramid_sentry.report_exception(exc)
+    # Don't log 404's as they aren't very interesting
+    if not isinstance(exc, HTTPNotFound):
+        h_pyramid_sentry.report_exception(exc)
 
     return _get_error_body(exc, request)
 


### PR DESCRIPTION
This distinguishes between the 404's we know are to do with the file being gone and other potentially much worse ones. This is quite specific to the format of errors we see right now. If that changes we'll start seeing these as more serious errors.

On the whole it's probably better we err on the side of flipping out instead of potentially concealing errors.