### PR TITLE
Handle timeouts in Google Drive and other end-points

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -26,3 +26,17 @@ disable=bad-continuation,
 [REPORTS]
 output-format=colorized
 score=no
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=no
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=no
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+# Set a slightly higher base for repeated code
+min-similarity-lines=14

--- a/tests/unit/via/requests_tools/error_handling_test.py
+++ b/tests/unit/via/requests_tools/error_handling_test.py
@@ -1,7 +1,12 @@
 import pytest
 from requests import exceptions
 
-from via.exceptions import BadURL, UnhandledUpstreamException, UpstreamServiceError
+from via.exceptions import (
+    BadURL,
+    UnhandledUpstreamException,
+    UpstreamServiceError,
+    UpstreamTimeout,
+)
 from via.requests_tools.error_handling import handle_errors, iter_handle_errors
 
 EXCEPTION_MAP = (
@@ -9,8 +14,8 @@ EXCEPTION_MAP = (
     (exceptions.InvalidSchema, BadURL),
     (exceptions.InvalidURL, BadURL),
     (exceptions.URLRequired, BadURL),
+    (exceptions.Timeout, UpstreamTimeout),
     (exceptions.ConnectionError, UpstreamServiceError),
-    (exceptions.Timeout, UpstreamServiceError),
     (exceptions.TooManyRedirects, UpstreamServiceError),
     (exceptions.SSLError, UpstreamServiceError),
     (exceptions.UnrewindableBodyError, UnhandledUpstreamException),

--- a/tests/unit/via/requests_tools/error_handling_test.py
+++ b/tests/unit/via/requests_tools/error_handling_test.py
@@ -46,13 +46,23 @@ class TestIterHandleErrors:
         with pytest.raises(expected_exception):
             list(iter_raiser(request_exception("Oh noe")))
 
+    def test_it_matches_custom_exceptions(self, iter_raiser):
+        with pytest.raises(NotADirectoryError):
+            list(iter_raiser(FileNotFoundError("Oh noe")))
+
     def test_it_does_not_catch_regular_exceptions(self, iter_raiser):
         with pytest.raises(ValueError):
             list(iter_raiser(ValueError()))
 
     @pytest.fixture
     def iter_raiser(self):
-        @iter_handle_errors
+        def error_mapper(err):
+            if isinstance(err, FileNotFoundError):
+                return NotADirectoryError("Translated")
+
+            return None
+
+        @iter_handle_errors(error_mapper)
         def iter_raiser(exception):
             yield 1
             raise exception

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -8,7 +8,7 @@ from h_matchers import Any
 from pyramid.httpexceptions import HTTPNotFound
 from pytest import param
 from requests import Response, TooManyRedirects
-from requests.exceptions import HTTPError, InvalidJSONError, Timeout
+from requests.exceptions import HTTPError, InvalidJSONError
 
 from via.exceptions import (
     ConfigurationError,
@@ -131,15 +131,6 @@ class TestGoogleDriveAPI:
             list(api.iter_file(sentinel.file_id))
 
         assert exception.value.status_int == status_code
-
-    def test_iter_file_catches_timeouts(self, api):
-        # pylint: disable=protected-access
-        api._session.get.return_value.raise_for_status.side_effect = Timeout
-
-        with pytest.raises(GoogleDriveServiceError) as exception:
-            list(api.iter_file(sentinel.file_id))
-
-        assert exception.value.status_int == 598
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -8,7 +8,7 @@ from h_matchers import Any
 from pyramid.httpexceptions import HTTPNotFound
 from pytest import param
 from requests import Response, TooManyRedirects
-from requests.exceptions import HTTPError, InvalidJSONError
+from requests.exceptions import HTTPError, InvalidJSONError, Timeout
 
 from via.exceptions import (
     ConfigurationError,
@@ -131,6 +131,15 @@ class TestGoogleDriveAPI:
             list(api.iter_file(sentinel.file_id))
 
         assert exception.value.status_int == status_code
+
+    def test_iter_file_catches_timeouts(self, api):
+        # pylint: disable=protected-access
+        api._session.get.return_value.raise_for_status.side_effect = Timeout
+
+        with pytest.raises(GoogleDriveServiceError) as exception:
+            list(api.iter_file(sentinel.file_id))
+
+        assert exception.value.status_int == 598
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -10,10 +10,21 @@ class UpstreamServiceError(Exception):
     status_int = 409
 
 
-class UnhandledUpstreamException(Exception):
+class UnhandledUpstreamException(UpstreamServiceError):
     """Something we did not plan for went wrong."""
 
     status_int = 417
+
+
+class UpstreamTimeout(UpstreamServiceError):
+    """We timed out waiting for an upstream service."""
+
+    # "504 - Gateway Timeout" is the correct thing to raise, but this
+    # will cause Cloudflare to intercept it:
+    # https://support.cloudflare.com/hc/en-us/articles/115003011431-Troubleshooting-Cloudflare-5XX-errors#502504error
+    # We're using "408 - Request Timeout" which is technically
+    # incorrect as it implies the user took too long, but has good semantics
+    status_int = 408
 
 
 class GoogleDriveServiceError(UpstreamServiceError):

--- a/via/requests_tools/error_handling.py
+++ b/via/requests_tools/error_handling.py
@@ -23,7 +23,7 @@ def handle_errors(inner):
     """Translate errors into our application errors."""
 
     @wraps(inner)
-    def deco(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         try:
             return inner(*args, **kwargs)
 
@@ -35,29 +35,37 @@ def handle_errors(inner):
 
             raise
 
+    return wrapper
+
+
+def iter_handle_errors(custom_mapper):
+    def deco(inner):
+        """Translate errors into our application errors."""
+
+        @wraps(inner)
+        def wrapper(*args, **kwargs):
+            try:
+                yield from inner(*args, **kwargs)
+
+            except Exception as err:
+                # Pylint thinks we are raising None, but the if takes care of it
+                # pylint: disable=raising-bad-type
+                if mapped_err := _translate_error(
+                    err, DEFAULT_ERROR_MAP, custom_mapper
+                ):
+                    raise mapped_err from err
+
+                raise
+
+        return wrapper
+
     return deco
 
 
-def iter_handle_errors(inner):
-    """Translate errors into our application errors."""
+def _translate_error(err, mapping, custom_mapper=None):
+    if custom_mapper and (mapped := custom_mapper(err)):
+        return mapped
 
-    @wraps(inner)
-    def deco(*args, **kwargs):
-        try:
-            yield from inner(*args, **kwargs)
-
-        except Exception as err:
-            # Pylint thinks we are raising None, but the if takes care of it
-            # pylint: disable=raising-bad-type
-            if mapped_err := _translate_error(err, DEFAULT_ERROR_MAP):
-                raise mapped_err from err
-
-            raise
-
-    return deco
-
-
-def _translate_error(err, mapping):
     for error_class, target_class in mapping.items():
         if isinstance(err, error_class):
             return target_class(err.args[0] if err.args else None)

--- a/via/requests_tools/error_handling.py
+++ b/via/requests_tools/error_handling.py
@@ -4,15 +4,20 @@ from functools import wraps
 
 from requests import RequestException, exceptions
 
-from via.exceptions import BadURL, UnhandledUpstreamException, UpstreamServiceError
+from via.exceptions import (
+    BadURL,
+    UnhandledUpstreamException,
+    UpstreamServiceError,
+    UpstreamTimeout,
+)
 
 DEFAULT_ERROR_MAP = {
     exceptions.MissingSchema: BadURL,
     exceptions.InvalidSchema: BadURL,
     exceptions.InvalidURL: BadURL,
     exceptions.URLRequired: BadURL,
+    exceptions.Timeout: UpstreamTimeout,
     exceptions.ConnectionError: UpstreamServiceError,
-    exceptions.Timeout: UpstreamServiceError,
     exceptions.TooManyRedirects: UpstreamServiceError,
     exceptions.SSLError: UpstreamServiceError,
     RequestException: UnhandledUpstreamException,

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs, urlparse
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import Credentials
 from pyramid.httpexceptions import HTTPNotFound
-from requests import HTTPError, Timeout
+from requests import HTTPError
 
 from via.exceptions import ConfigurationError, GoogleDriveServiceError
 from via.requests_tools import add_request_headers, stream_bytes
@@ -18,19 +18,6 @@ LOG = getLogger(__name__)
 
 def translate_google_error(error):
     """Get a specific error instance from the provided error or None."""
-
-    if isinstance(error, Timeout):
-        return GoogleDriveServiceError(
-            "Timeout attempting to retrieve file",
-            error_json=None,
-            # 504 - Gateway Timeout is the correct thing to raise, but this
-            # will cause Cloudflare to intercept it:
-            # https://support.cloudflare.com/hc/en-us/articles/115003011431-Troubleshooting-Cloudflare-5XX-errors#502504error
-            # We're using the non standard: 598 - Network read timeout error
-            status_int=598,
-            # If we don't want a 5xx error, then 408 - Request Timeout is
-            # technically incorrect, but has good semantics
-        )
 
     # This isn't a requests exception we can get meaningful data from
     if not isinstance(error, HTTPError) or error.response is None:

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -42,7 +42,7 @@ def translate_google_error(error):
     # Check carefully to see that this is Google telling us the file isn't
     # found rather than this being us going to the wrong end-point
     if error.response.status_code == 404 and google_error.get("reason") == "notFound":
-        return HTTPNotFound("File id not found")
+        return HTTPNotFound(google_error.get("message", "File id not found"))
 
     if (
         error.response.status_code == 403

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -142,8 +142,7 @@ class GoogleDriveAPI:
             response.raise_for_status()
 
         except HTTPError as http_error:
-            # Pylint thinks we are raising None here, but the if takes care
-            # of that
+            # Pylint thinks we are raising None, but the if takes care of it
             # pylint: disable=raising-bad-type
             if translated_error := self._translate_http_error(http_error, file_id):
                 raise translated_error from http_error

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -94,7 +94,7 @@ class GoogleDriveAPI:
 
     # Pylint doesn't understand our error translation
     # pylint:disable=missing-raises-doc
-    @iter_handle_errors
+    @iter_handle_errors({})
     def iter_file(self, file_id, resource_key=None) -> Iterator[ByteString]:
         """Get a generator of chunks of bytes for the specified file.
 


### PR DESCRIPTION
This annoyingly late in the day, contains the probably correct way of handling errors, which is to provide a helper method which gives us an opportunity to do any fancy manipulation we want.

This went through a few revisions and contains a unification of the error mapping which isn't technically needed, but might be a good idea anyway.

We could raise a general timeout, as this could happen with regular things as well. We don't need to make this Google specific.