### PR TITLE
URL normalisation improvements

### DIFF
--- a/via/views/index.py
+++ b/via/views/index.py
@@ -3,8 +3,6 @@ from urllib.parse import urlparse
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNotFound
 from pyramid.view import view_config, view_defaults
 
-from via.views.exceptions import BadURL
-
 
 @view_defaults(route_name="index")
 class IndexViews:
@@ -39,11 +37,9 @@ class IndexViews:
         # This means we need to pop off the query string and then add it
         # separately from the URL, otherwise we'll get the query string encoded
         # inside the URL portion of the path.
-        try:
-            parsed = urlparse(url)
-        except ValueError as exc:
-            raise BadURL(url) from exc
 
+        # `context.url_from_query` protects us from parsing failing
+        parsed = urlparse(url)
         url_without_query = parsed._replace(query="", fragment="").geturl()
 
         return HTTPFound(


### PR DESCRIPTION
Discovered during: https://github.com/hypothesis/via/pull/621

There are quite a few cases where the naive approach here fails. I've added in the solution we have in Checkmate for this:

https://github.com/hypothesis/checkmate/blob/main/checkmate/url/canonicalize.py#L83

It's not super intuitive as `urlparse`'s behavior is a bit strange.

These aren't common cases, but if a user is quickly copy pasting URLs they could easily miss bits. We can't account for everything of course.

## Not that important?

It turns out some of this isn't hugely consequential, because we accidentally fix it else where in the code by re-parsing the URL. This converts things like:

 * `http:////example.com` to `http://example.com`

Even if we emit that it would probably work in most browsers. However it does seem nice that our code works on purpose rather than as a side effect of how we process the URL later on. If we skipped or changed that part it might stop working or behave strangely.

### Testing notes

It's easy enough to test the other changes though:

 * `make dev`
 * Goto the landing page: http://0.0.0.0:9082
 * Paste in`ftp://example.com`
 * In master we get an error page about not being able to retrieve `https://ftp://example.com`
 * In this branch you get a "BadURL" message saying your URL is wrong (which is better)