### PR TITLE
Ensure our error responses from Google Drive are JSON serialisable

### DIFF
--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -168,6 +168,8 @@ class TestGoogleDriveExceptions:
             },
         }
 
+        json.dumps(result)  # Check we are serialisable
+
         assert pyramid_request.response.status_int == 419
 
     @pytest.mark.parametrize(
@@ -192,7 +194,16 @@ class TestGoogleDriveExceptions:
             },
         }
 
+        json.dumps(result)  # Check we are serialisable
+
     def test_it_with_normal_exception(self, pyramid_request):
         result = google_drive_exceptions(ValueError("message"), pyramid_request)
 
         assert result == {"exception": "ValueError", "message": "message"}
+
+    def test_it_with_an_exception_with_a_non_string_arg(self, pyramid_request):
+        exception = ValueError(set("a"))
+
+        result = google_drive_exceptions(exception, pyramid_request)
+
+        json.dumps(result)  # Check we are serialisable

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -90,7 +90,7 @@ def google_drive_exceptions(exc, request):
 
     data = {
         "exception": exc.__class__.__name__,
-        "message": exc.args[0] if exc.args else None,
+        "message": str(exc.args[0]) if exc.args else None,
     }
 
     if hasattr(exc, "response") and exc.response is not None:


### PR DESCRIPTION
Some exceptions appear to have a non-string, non-serialisable first argument. It's easy enough to get around but this was causing our error handling to fail in some cases.