### PR TITLE
Get the correct original URL for the error page for all views

### DIFF
--- a/tests/unit/via/views/index_test.py
+++ b/tests/unit/via/views/index_test.py
@@ -2,7 +2,7 @@ import pytest
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
 from tests.unit.matchers import temporary_redirect_to
-from via.resources import URLResource
+from via.resources import QueryURLResource
 from via.views.exceptions import BadURL
 from via.views.index import IndexViews
 
@@ -57,4 +57,4 @@ class TestIndexViews:
 
     @pytest.fixture
     def context(self, pyramid_request):
-        return URLResource(pyramid_request)
+        return QueryURLResource(pyramid_request)

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -2,7 +2,7 @@ from unittest.mock import create_autospec, sentinel
 
 import pytest
 
-from via.resources import URLResource
+from via.resources import PathURLResource
 from via.views.proxy import proxy
 
 
@@ -21,7 +21,7 @@ class TestProxy:
 
     @pytest.fixture
     def context(self):
-        return create_autospec(URLResource, spec_set=True, instance=True)
+        return create_autospec(PathURLResource, spec_set=True, instance=True)
 
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.conftest import assert_cache_control
 from tests.unit.matchers import temporary_redirect_to
-from via.resources import URLResource
+from via.resources import QueryURLResource
 from via.views.route_by_content import route_by_content
 
 
@@ -53,7 +53,7 @@ class TestRouteByContent:
 
     @pytest.fixture
     def context(self):
-        return create_autospec(URLResource, spec_set=True, instance=True)
+        return create_autospec(QueryURLResource, spec_set=True, instance=True)
 
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -4,7 +4,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from via.resources import URLResource
+from via.resources import QueryURLResource
 from via.views.view_pdf import view_pdf
 
 
@@ -79,7 +79,7 @@ class TestViewPDF:
     def call_view_pdf(self, pyramid_request):
         def call_view_pdf(url="http://example.com/name.pdf", params=None):
             pyramid_request.params = dict(params or {}, url=url)
-            context = URLResource(pyramid_request)
+            context = QueryURLResource(pyramid_request)
             return view_pdf(context, pyramid_request)
 
         return call_view_pdf

--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -11,6 +11,10 @@ class RequestBasedException(Exception):
 class BadURL(RequestBasedException):
     """An invalid URL was discovered."""
 
+    def __init__(self, message, requests_err=None, url=None):
+        super().__init__(message, requests_err)
+        self.url = url
+
     status_int = 400
 
 

--- a/via/resources.py
+++ b/via/resources.py
@@ -7,42 +7,11 @@ from pyramid.httpexceptions import HTTPBadRequest
 from via.exceptions import BadURL
 
 
-class URLResource:
+class _URLResource:
     """Methods for routes which accept a 'url'."""
 
     def __init__(self, request):
         self._request = request
-
-    def url_from_query(self):
-        """Get the 'url' parameter from the query.
-
-        :return: The URL as a string
-        :raise HTTPBadRequest: If the URL is missing or empty
-        :raise BadURL: If the URL is malformed
-        """
-        try:
-            url = self._request.params["url"].strip()
-        except KeyError as err:
-            raise HTTPBadRequest("Required parameter 'url' missing") from err
-
-        if not url:
-            raise HTTPBadRequest("Required parameter 'url' is blank")
-
-        return self._normalise_url(url)
-
-    def url_from_path(self):
-        """Get the 'url' parameter from the path.
-
-        :return: The URL as a string
-        :raise HTTPBadRequest: If the URL is missing or empty
-        :raise BadURL: If the URL is malformed
-        """
-
-        url = self._request.path_qs[1:].strip()
-        if not url:
-            raise HTTPBadRequest("Required path part 'url` is missing")
-
-        return self._normalise_url(url)
 
     @classmethod
     def _normalise_url(cls, url):
@@ -66,3 +35,42 @@ class URLResource:
             url = parsed._replace(scheme="https").geturl()
 
         return Configuration.strip_from_url(url)
+
+
+class PathURLResource(_URLResource):
+    """Resource for routes expecting urls from the path."""
+
+    def url_from_path(self):
+        """Get the 'url' parameter from the path.
+
+        :return: The URL as a string
+        :raise HTTPBadRequest: If the URL is missing or empty
+        :raise BadURL: If the URL is malformed
+        """
+
+        url = self._request.path_qs[1:].strip()
+        if not url:
+            raise HTTPBadRequest("Required path part 'url` is missing")
+
+        return self._normalise_url(url)
+
+
+class QueryURLResource(_URLResource):
+    """Resource for routes expecting urls from the query."""
+
+    def url_from_query(self):
+        """Get the 'url' parameter from the query.
+
+        :return: The URL as a string
+        :raise HTTPBadRequest: If the URL is missing or empty
+        :raise BadURL: If the URL is malformed
+        """
+        try:
+            url = self._request.params["url"].strip()
+        except KeyError as err:
+            raise HTTPBadRequest("Required parameter 'url' missing") from err
+
+        if not url:
+            raise HTTPBadRequest("Required parameter 'url' is blank")
+
+        return self._normalise_url(url)

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -1,21 +1,26 @@
 """The views for the Pyramid app."""
-from via.resources import URLResource
+from via.resources import PathURLResource, QueryURLResource
 
 
 def add_routes(config):  # pragma: no cover
     """Add routes to pyramid config."""
 
-    config.add_route("index", "/", factory=URLResource)
+    config.add_route("index", "/", factory=QueryURLResource)
     config.add_route("get_status", "/_status")
-    config.add_route("view_pdf", "/pdf", factory=URLResource)
-    config.add_route("route_by_content", "/route", factory=URLResource)
+    config.add_route("view_pdf", "/pdf", factory=QueryURLResource)
+    config.add_route("route_by_content", "/route", factory=QueryURLResource)
     config.add_route("debug_headers", "/debug/headers")
-    config.add_route("proxy_google_drive_file", "/google_drive/{file_id}/proxied.pdf")
+    config.add_route(
+        "proxy_google_drive_file",
+        "/google_drive/{file_id}/proxied.pdf",
+        factory=QueryURLResource,
+    )
     config.add_route(
         "proxy_google_drive_file:resource_key",
         "/google_drive/{file_id}/{resource_key}/proxied.pdf",
+        factory=QueryURLResource,
     )
-    config.add_route("proxy", "/{url:.*}", factory=URLResource)
+    config.add_route("proxy", "/{url:.*}", factory=PathURLResource)
 
 
 def includeme(config):  # pragma: no cover

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -10,6 +10,7 @@ from via.exceptions import (
     UpstreamServiceError,
     UpstreamTimeout,
 )
+from via.resources import get_original_url
 
 EXCEPTION_MAP = {
     BadURL: {
@@ -144,7 +145,7 @@ def _get_error_body(exc, request):
     return {
         "status_code": status_code,
         "exception": exception_meta,
-        "url": {"original": request.GET.get("url", None), "retry": request.url},
+        "url": {"original": get_original_url(request.context), "retry": request.url},
         "static_url": request.static_url,
     }
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/via/issues/547

Prior to this PR the error handling only displays the correct URL for views which expect a URL in the query parameter. This didn't work for proxying end-point.

This PR:

 * Uses resources to declare whether each view expects:
    * A URL in the path: `PathURLResource`
    * A URL in the query: `QueryURLResource` 
    * No URL at all: no resource
 * Uses the context type to retrieve the correct URL in the error handler

