### PR TITLE
Handle request objects without contexts, which can happen apparently

### DIFF
--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -89,6 +89,18 @@ class TestOtherExceptions:
             "retry": sentinel.request_url,
         }
 
+    def test_it_doesnt_read_the_url_if_the_request_has_no_context(
+        self, pyramid_request, get_original_url
+    ):
+        # It seems we can get in the situation where Pyramid does not provide
+        # a context attribute at all on the object
+        delattr(pyramid_request, "context")
+
+        values = other_exceptions(ValueError(), pyramid_request)
+
+        get_original_url.assert_not_called()
+        assert values["url"]["original"] is None
+
     @pytest.mark.parametrize(
         "exception_class,should_report",
         (

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -145,7 +145,12 @@ def _get_error_body(exc, request):
     return {
         "status_code": status_code,
         "exception": exception_meta,
-        "url": {"original": get_original_url(request.context), "retry": request.url},
+        "url": {
+            "original": get_original_url(request.context)
+            if hasattr(request, "context")
+            else None,
+            "retry": request.url,
+        },
         "static_url": request.static_url,
     }
 


### PR DESCRIPTION
For: https://sentry.io/organizations/hypothesis/issues/2653839684/?project=5921964&query=is%3Aunresolved

Apparently we can get in the situation where the request object has no context attribute. I expected it to be `None` sometimes, but not absent.