### PR TITLE
Add `pyramid-sanity` to Via to catch UTF-8 and other errors

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -153,12 +153,15 @@ pyramid==2.0
     #   pyramid-exclog
     #   pyramid-ipython
     #   pyramid-jinja2
+    #   pyramid-sanity
     #   pyramid-services
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-ipython==0.2
     # via -r requirements/dev.in
 pyramid-jinja2==2.8
+    # via -r requirements/requirements.txt
+pyramid-sanity==1.0.2
     # via -r requirements/requirements.txt
 pyramid-services==2.2
     # via -r requirements/requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -115,10 +115,13 @@ pyramid==2.0
     #   h-pyramid-sentry
     #   pyramid-exclog
     #   pyramid-jinja2
+    #   pyramid-sanity
     #   pyramid-services
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
+    # via -r requirements/requirements.txt
+pyramid-sanity==1.0.2
     # via -r requirements/requirements.txt
 pyramid-services==2.2
     # via -r requirements/requirements.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -180,12 +180,17 @@ pyramid==2.0
     #   h-pyramid-sentry
     #   pyramid-exclog
     #   pyramid-jinja2
+    #   pyramid-sanity
     #   pyramid-services
 pyramid-exclog==1.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
 pyramid-jinja2==2.8
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+pyramid-sanity==1.0.2
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,6 +7,7 @@ newrelic
 pyramid
 pyramid-exclog
 pyramid-jinja2
+pyramid-sanity
 pyramid-services
 requests
 whitenoise

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -68,10 +68,13 @@ pyramid==2.0
     #   h-pyramid-sentry
     #   pyramid-exclog
     #   pyramid-jinja2
+    #   pyramid-sanity
     #   pyramid-services
 pyramid-exclog==1.0
     # via -r requirements/requirements.in
 pyramid-jinja2==2.8
+    # via -r requirements/requirements.in
+pyramid-sanity==1.0.2
     # via -r requirements/requirements.in
 pyramid-services==2.2
     # via -r requirements/requirements.in

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -121,10 +121,13 @@ pyramid==2.0
     #   h-pyramid-sentry
     #   pyramid-exclog
     #   pyramid-jinja2
+    #   pyramid-sanity
     #   pyramid-services
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
+    # via -r requirements/requirements.txt
+pyramid-sanity==1.0.2
     # via -r requirements/requirements.txt
 pyramid-services==2.2
     # via -r requirements/requirements.txt

--- a/via/app.py
+++ b/via/app.py
@@ -80,6 +80,9 @@ def create_app(_=None, **settings):
 
     config.add_tween("via.tweens.robots_tween_factory")
 
+    # Add this as near to the end of your config as possible:
+    config.include("pyramid_sanity")
+
     app = WhiteNoise(
         config.make_wsgi_app(),
         index_file=True,


### PR DESCRIPTION
For many UTF-8 errors like this: https://sentry.io/organizations/hypothesis/issues/2635391672/?project=5921964&query=is%3Aunresolved

## Testing notes

I'm not going to list everything as it's covered what `pyramid-sanity` fixes here, but here's one which you can try:

 * `make dev`
 * http://localhost:9083/route?q=%FC
 * In this branch you should get a 400
 * In master you get a 500