### PR TITLE
Handle URLs with no scheme and a leading dot

### DIFF
--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -14,6 +14,7 @@ NORMALISED_URLS = [
     ("http://example.com?a=1", "http://example.com?a=1"),
     # URLs without a protocol that should have `https://` prefixed
     ("example.com", "https://example.com"),
+    (".example.com", "https://example.com"),
     ("//example.com", "https://example.com"),
     # Leading and trailing whitespace that should be stripped
     (" http://example.com", "http://example.com"),

--- a/via/resources.py
+++ b/via/resources.py
@@ -30,7 +30,7 @@ class _URLResource:
             if not parsed.netloc:
                 # Without a scheme urlparse often assumes the domain is the
                 # path. To prevent this add a fake scheme and try again
-                return cls._normalise_url("https://" + url)
+                return cls._normalise_url("https://" + url.lstrip("."))
 
             url = parsed._replace(scheme="https").geturl()
 


### PR DESCRIPTION
It seems reasonably common for users to type in a URL without a scheme but with a leading dot:

* https://sentry.io/organizations/hypothesis/issues/2648094577/?project=5921964&query=is%3Aunresolved

For example `.tumbler.com`. We add `https://` to the front and create an unparsable URL`https://.tumbler.com`

## Testing notes

* `make dev`
* Goto the landing page http://localhost:9083
* Type in a URL with no scheme and a leading dot
* We should now attempt to go to the URL with the dot stripped
* Previously we would crash