### PR TITLE
Handle zero length documents returned from Google Drive.

### DIFF
--- a/tests/unit/via/views/google_drive_test.py
+++ b/tests/unit/via/views/google_drive_test.py
@@ -36,6 +36,13 @@ class TestGetFileContent:
         # And we still get everything if we iterate
         assert list(response.app_iter) == [0, 1, 2]
 
+    def test_it_can_stream_an_empty_iterator(self, pyramid_request, google_drive_api):
+        google_drive_api.iter_file.return_value = iter([])
+
+        response = proxy_google_drive_file(pyramid_request)
+
+        assert list(response.app_iter) == []
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.matchdict.update(

--- a/via/views/google_drive.py
+++ b/via/views/google_drive.py
@@ -42,4 +42,7 @@ def _reify_first(iterable):
     called now. This is so any errors or problems that come from starting the
     process happen immediately, rather than whenever the iterable is evaluated.
     """
-    return chain((next(iterable),), iterable)
+    try:
+        return chain((next(iterable),), iterable)
+    except StopIteration:
+        return []


### PR DESCRIPTION
With zero length documents the first chunk doesn't exist and we immediately get a `StopIteration` exception.

See: 

 * https://github.com/hypothesis/via/issues/635

## Testing notes

 * `make dev`
 * Try and view: http://localhost:9083/https://drive.google.com/uc?id=1d8JdZSYU-fgFuMQpS2Y9YoMtkQTBCAtD&export=download
 * You should now get an error: "Invalid or corrupted PDF file"
 * In master this is "Unexpected server response." (disable caching if you want to try)