### PR TITLE
Return a 204 no content when Google Drive files are empty.

### DIFF
--- a/tests/unit/via/views/google_drive_test.py
+++ b/tests/unit/via/views/google_drive_test.py
@@ -1,17 +1,19 @@
 from unittest.mock import sentinel
 
 import pytest
+from pyramid.httpexceptions import HTTPNoContent
 
 from via.views.google_drive import proxy_google_drive_file
 
 
 @pytest.mark.usefixtures("secure_link_service", "google_drive_api")
 class TestGetFileContent:
-    def test_it_adds_headers(
+    def test_status_and_headers(
         self, pyramid_request, secure_link_service, google_drive_api
     ):
         response = proxy_google_drive_file(pyramid_request)
 
+        assert response.status_code == 200
         assert response.headers["Content-Disposition"] == "inline"
         assert response.headers["Content-Type"] == "application/pdf"
         assert (
@@ -41,7 +43,7 @@ class TestGetFileContent:
 
         response = proxy_google_drive_file(pyramid_request)
 
-        assert list(response.app_iter) == []
+        assert isinstance(response, HTTPNoContent)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/via/issues/635

This means we serve a 204 No Content when the google files are empty. This should prevent Cloudflare from caching the response.

### Testing notes

 * `make dev`
 * Visit http://localhost:9082/google_drive/1d8JdZSYU-fgFuMQpS2Y9YoMtkQTBCAtD/proxied.pdf?url=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1d8JdZSYU-fgFuMQpS2Y9YoMtkQTBCAtD%26export%3Ddownload
 * It's hard to see as nothing happens, but look at the dev console and you should see a 204