### PR TITLE
Don't crash on unexpected JSON formats from Google

### DIFF
--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -160,6 +160,8 @@ class TestGoogleDriveAPI:
             param({"status_code": 503}, id="unexpected status code"),
             param({"json_data": None}, id="no json"),
             param({"json_data": {"hello": 1}}, id="unexpected json"),
+            param({"json_data": {"error": {"errors": 23}}}, id="unexpected json"),
+            param({"json_data": {"error": {"errors": [23]}}}, id="unexpected json"),
             param({"raw_data": "{... broken}"}, id="malformed json"),
         ),
     )


### PR DESCRIPTION
Don't crash if Google Drive sends us an error response with a JSON body whose `"errors"` list is not a list or whose `"errors"[0]` dict is not a dict.

FYI: this is why we use Marshmallow to parse responses in LMS. Python code like this that parses JSON responses gets complex (`translate_google_error()` is now tripping a PyLint `too-many-return-statements` and is close to tripping PyLint's `too-complex`) and error-prone (an attempt was clearly made to parse the response robustly but the code nonetheless contained at least two crashers). LMS once had exactly the same problem: in lots of places it had Python code to parse Canvas responses and there were dozens of bugs in this code.

The solution in LMS was to use Marshmallow to parse responses before using them. For example [`OAuthTokenResponseSchema`](https://github.com/hypothesis/lms/blob/2e2113e425fd4b5f9d46fe655bf0aad917eb8545/lms/validation/authentication/_oauth.py#L136-L146) parses OAuth token responses and then `OAuthHTTPService` simply [uses the schema to validate a response](https://github.com/hypothesis/lms/blob/eb27a4e5e562b558579e8adf069662ab2a06e01c/lms/services/oauth_http.py#L118-L126) and then assumes that `validated_data` is a dict containing the expected keys, value types, etc. `OAuthHTTPService` doesn't even catch the `ValidationError` that `OAuthTokenResponseSchema` might throw: there's an exception view for those.

(Part of the reason for the choice of Marshmallow was that it can parse any part of any type of request or response. E.g. query params, XML, form submissions, etc. Not just JSON bodies.)