### PR TITLE
Use Marshmallow to validate Google Drive error bodies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -96,6 +96,8 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pyramid-jinja2
+marshmallow==3.13.0
+    # via -r requirements/requirements.txt
 newrelic==7.2.1.168
     # via -r requirements/requirements.txt
 oauthlib==3.1.1

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -69,6 +69,8 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pyramid-jinja2
+marshmallow==3.13.0
+    # via -r requirements/requirements.txt
 newrelic==7.2.1.168
     # via -r requirements/requirements.txt
 oauthlib==3.1.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -108,6 +108,10 @@ markupsafe==1.1.1
     #   -r requirements/tests.txt
     #   jinja2
     #   pyramid-jinja2
+marshmallow==3.13.0
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
 mccabe==0.6.1
     # via pylint
 newrelic==7.2.1.168

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,3 +12,4 @@ pyramid-services
 requests
 whitenoise
 google-auth-oauthlib
+marshmallow

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -42,6 +42,8 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   pyramid-jinja2
+marshmallow==3.13.0
+    # via -r requirements/requirements.in
 newrelic==7.2.1.168
     # via -r requirements/requirements.in
 oauthlib==3.1.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -75,6 +75,8 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pyramid-jinja2
+marshmallow==3.13.0
+    # via -r requirements/requirements.txt
 newrelic==7.2.1.168
     # via -r requirements/requirements.txt
 oauthlib==3.1.1


### PR DESCRIPTION
Use Marshmallow instead of plain Python code to validate the JSON bodies of error responses from Google Drive.

The downside of this is that it's more code: the Marshmallow schema is more lines of code than it takes to parse this manually in Python.

It also requires knowledge of Marshmallow to understand the schema.

The benefits include:

* It separates validating the JSON body from taking different actions based on the contents of the valid JSON body. A single more complex function is split into two simpler ones.

* The Marshmallow schema has its own direct unit tests. This just allows us to be more thorough about testing the validation and makes bugs less likely.

* The `translate_google_error()` function can now just call the validation schema and then go ahead and assume that the data is as expected without worrying about crashing

You could get the same benefits without Marshmallow by just writing a separate plain Python function to do the validation. But I think Marshmallow is worthwhile here. It does require you to learn Marshmallow but you already have to learn that anyway because we use it elsewhere. And once you know Marshmallow I think it makes it easier to write the validation code. It's actually pretty tricky to write this kind of validation code in plain Python and not make any mistakes. To illustrate, here's a plain Python function that passes all the same tests as the Marshmallow schema does. It's actually about the same number of lines of code as the Marshmallow schema. But I think it's much trickier to write:

```python
def validate_google_error(error):
    try:
        json_data = error.response.json()
    except JSONDecodeError as err:
        raise ValueError() from err

    if not isinstance(json_data.get("error"), dict):
        raise ValueError()

    if not isinstance(json_data["error"].get("errors"), list):
        raise ValueError()

    if not json_data["error"]["errors"]:
        raise ValueError()

    for key in ("message", "reason"):
        try:
            value = json_data["error"]["errors"][0].get(key)
        except AttributeError as err:
            raise ValueError() from err

        if not (isinstance(value, str) or value is None):
            raise ValueError()

    return json_data
```

^ I think there would be ways to get the above Python function shorter.