### PR TITLE
Diagnostic "fix" for errors proxying single slash URLs

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -62,7 +62,7 @@ http {
         # Not to be confused with NGINX's builtin $proxy_host variable!
         #
         # ?proxy_path: The path part of the URL-to-be-proxied, e.g. "/bar/gar.pdf"
-        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?://)(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
+        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?)://(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
 
@@ -128,8 +128,8 @@ http {
             # "!~*" triggers *negative* case-insensitive regex matching. The
             # `if` will match if $upstream_http_location does *not* match the
             # given regex.
-            if ($upstream_http_location !~* "^https?://.*") {
-                set $saved_redirect_location '$proxy_scheme$proxy_hostname$upstream_http_location';
+            if ($upstream_http_location !~* "^https?:/.*") {
+                set $saved_redirect_location '$proxy_scheme://$proxy_hostname$upstream_http_location';
             }
 
             # Follow the redirect internally, now proxying to the URL given in

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -62,7 +62,7 @@ http {
         # Not to be confused with NGINX's builtin $proxy_host variable!
         #
         # ?proxy_path: The path part of the URL-to-be-proxied, e.g. "/bar/gar.pdf"
-        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?)://(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
+        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?)://?(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
 


### PR DESCRIPTION
This is an attempt to rule in or out the fact we are receiving URLs with single slashes after the scheme. If we are, then this might also help them work again while we track down what's going on.

This has two commits:

 * The first should be functionally identical and everything should work the same
 * The second should allow single slash URLs