### PR TITLE
Attempt to correct single slash URLs

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -62,7 +62,10 @@ http {
         # Not to be confused with NGINX's builtin $proxy_host variable!
         #
         # ?proxy_path: The path part of the URL-to-be-proxied, e.g. "/bar/gar.pdf"
-        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?://)(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
+
+        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?://?)(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
+            rewrite ^/proxy/static/[^/]+/[^/]+/(https?):/([^/].*)$ $1://$2 break;
+
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
 


### PR DESCRIPTION
This attempts to fix URLs back to having two slashes internally if they don't already. Might not work with redirects?

### Testing notes

 * Start dev
 * Visit http://localhost:9083
 * Paste in https://africau.edu/images/default/sample.pdf?token=foo
 * This should work
 * Grab the URL for the PDF from F12
 * Like: http://localhost:9083/proxy/static/3w1NcLjPDQ5KDj4htPSxtg/1636111800/https://africau.edu/images/default/sample.pdf?token=foo
 * Remove the slash
 * Like: http://localhost:9083/proxy/static/3w1NcLjPDQ5KDj4htPSxtg/1636111800/https:/africau.edu/images/default/sample.pdf?token=foo
 * Should still work