### PR TITLE
Ignore the deprecation warnings from Marshmallow for now.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [pytest]
 filterwarnings =
+    # See: https://docs.python.org/3/library/warnings.html#the-warnings-filter
+
     error
+
+    # Required until marshmallow 3.15.0 is released which should fix this. See:
+    # * https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst
+    # * https://github.com/marshmallow-code/marshmallow/pull/1903
+    ignore:^distutils Version classes are deprecated\. Use packaging.version instead\.$:DeprecationWarning:marshmallow:17
 
 xfail_strict=true
 


### PR DESCRIPTION
There's no public fix for this yet. As mentioned in https://github.com/marshmallow-code/marshmallow/pull/1903, a change has resulted in Marshmallow raising a deprecation warning. As we're pretty strict about warnings this has bombed out our build.

## Testing notes

For this to show up you need to remove your `.tox/` directory. Then run `make sure` and you should see failures / it working depending on whether you are in master or this PR.