### PR TITLE
JSTOR pdf proxing based on a new jstor:// schema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def pyramid_settings():
         "checkmate_allow_all": False,
         "enable_front_page": True,
         "data_directory": "tests/data_directory",
+        "jstor_pdf_url": None,
     }
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from via.services import (
+    JSTORAPI,
     GoogleDriveAPI,
     HTTPService,
     PDFURLBuilder,
@@ -45,3 +46,8 @@ def http_service(mock_service):
 @pytest.fixture
 def pdf_url_builder_service(mock_service):
     return mock_service(PDFURLBuilder)
+
+
+@pytest.fixture
+def jstor_api(mock_service):
+    return mock_service(JSTORAPI)

--- a/tests/unit/via/services/jstor_test.py
+++ b/tests/unit/via/services/jstor_test.py
@@ -1,0 +1,37 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from via.requests_tools.headers import add_request_headers
+from via.services.jstor import JSTORAPI, factory
+
+
+class TestJSTORAPI:
+    @pytest.mark.parametrize(
+        "url,expected", [(None, False), ("http://jstor-api.com", True)]
+    )
+    def test_enabled(self, url, expected):
+        assert JSTORAPI(sentinel.http, url).enabled == expected
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("jstor://ARTICLE_ID", "http://jstor-api.com/10.2307/ARTICLE_ID?ip=IP"),
+            ("jstor://PREFIX/SUFFIX", "http://jstor-api.com/PREFIX/SUFFIX?ip=IP"),
+        ],
+    )
+    def test_pdf_stream(self, http_service, url, expected):
+        stream = JSTORAPI(http_service, "http://jstor-api.com").jstor_pdf_stream(
+            url, "IP"
+        )
+
+        http_service.stream.assert_called_once_with(
+            expected, headers=add_request_headers({"Accept": "application/pdf"})
+        )
+        assert stream == http_service.stream.return_value
+
+
+class TestFactory:
+    @pytest.mark.usefixtures("http_service")
+    def test_it(self, pyramid_request):
+        assert isinstance(factory(sentinel.context, pyramid_request), JSTORAPI)

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -2,10 +2,15 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
-from pyramid.httpexceptions import HTTPNoContent
+from pyramid.httpexceptions import HTTPNoContent, HTTPUnauthorized
 
 from via.resources import QueryURLResource
-from via.views.view_pdf import proxy_google_drive_file, proxy_onedrive_pdf, view_pdf
+from via.views.view_pdf import (
+    proxy_google_drive_file,
+    proxy_jstor_pdf,
+    proxy_onedrive_pdf,
+    view_pdf,
+)
 
 
 @pytest.mark.usefixtures(
@@ -138,6 +143,34 @@ class TestProxyOneDrivePDF:
         response = call_view("https://one-drive.com", view=proxy_onedrive_pdf)
 
         assert isinstance(response, HTTPNoContent)
+
+
+@pytest.mark.usefixtures("secure_link_service", "pdf_url_builder_service")
+class TestJSTORPDF:
+    @pytest.mark.usefixtures("http_service")
+    def test_it(self, call_view, jstor_api, pyramid_request):
+        response = call_view(
+            "jstor://DOI", view=proxy_jstor_pdf, params={"jstor.ip": "1.1.1.1"}
+        )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Disposition"] == "inline"
+        assert response.headers["Content-Type"] == "application/pdf"
+        assert (
+            response.headers["Cache-Control"]
+            == "public, max-age=43200, stale-while-revalidate=86400"
+        )
+        jstor_api.jstor_pdf_stream.assert_called_once_with(
+            "jstor://DOI", pyramid_request.params["jstor.ip"]
+        )
+
+    def test_when_not_enabled(self, call_view, jstor_api):
+        jstor_api.enabled = False
+
+        with pytest.raises(HTTPUnauthorized):
+            call_view(
+                "jstor://DOI", view=proxy_jstor_pdf, params={"jstor.ip": "1.1.1.1"}
+            )
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: SIGNED_URLS_REQUIRED
+    dev: JSTOR_PDF_URL
 deps =
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt

--- a/via/app.py
+++ b/via/app.py
@@ -26,6 +26,7 @@ PARAMETERS = {
     "data_directory": {"required": True, "formatter": Path},
     "signed_urls_required": {"formatter": asbool},
     "enable_front_page": {"formatter": asbool},
+    "jstor_pdf_url": {},
 }
 
 

--- a/via/services/__init__.py
+++ b/via/services/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from via.exceptions import ConfigurationError
 from via.services.google_drive import GoogleDriveAPI
 from via.services.http import HTTPService
+from via.services.jstor import JSTORAPI
 from via.services.pdf_url import PDFURLBuilder
 from via.services.secure_link import SecureLinkService, has_secure_url_token
 from via.services.via_client import ViaClientService
@@ -27,6 +28,7 @@ def includeme(config):  # pragma: no cover
     config.register_service_factory("via.services.http.factory", iface=HTTPService)
 
     config.register_service_factory("via.services.pdf_url.factory", iface=PDFURLBuilder)
+    config.register_service_factory("via.services.jstor.factory", iface=JSTORAPI)
 
 
 def create_google_api(settings):

--- a/via/services/jstor.py
+++ b/via/services/jstor.py
@@ -1,0 +1,32 @@
+from via.requests_tools.headers import add_request_headers
+from via.services import HTTPService
+
+
+class JSTORAPI:
+    DEFAULT_DOI_PREFIX = "10.2307"
+    """Main DOI prefix. Used for real DOIs and non registered pseudo-DOIs with the same format"""
+
+    def __init__(self, http_service: HTTPService, url):
+        self._jstor_pdf_url = url
+        self._http = http_service
+
+    @property
+    def enabled(self):
+        return bool(self._jstor_pdf_url)
+
+    def jstor_pdf_stream(self, jstor_url: str, jstor_ip: str):
+        doi = jstor_url.replace("jstor://", "")
+        if not "/" in doi:
+            doi = f"{self.DEFAULT_DOI_PREFIX}/{doi}"
+
+        url = f"{self._jstor_pdf_url}/{doi}?ip={jstor_ip}"
+        return self._http.stream(
+            url, headers=add_request_headers({"Accept": "application/pdf"})
+        )
+
+
+def factory(_context, request):
+    return JSTORAPI(
+        http_service=request.find_service(HTTPService),
+        url=request.registry.settings.get("jstor_pdf_url", None),
+    )

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -26,6 +26,12 @@ def add_routes(config):  # pragma: no cover
         factory=QueryURLResource,
     )
 
+    config.add_route(
+        "proxy_jstor_pdf",
+        "/jstor/proxied.pdf",
+        factory=QueryURLResource,
+    )
+
     config.add_route("proxy", "/{url:.*}", factory=PathURLResource)
 
 


### PR DESCRIPTION
Here we rely on a `jstor://` URL coming from LMS


## Testing



- `export JSTOR_PDF_URL=<>`
- Configure a new URL assignment with `jstor://10.1086/508573` and launch it.

Tested with both: 

https://www.jstor.org/stable/1234 
https://www.jstor.org/stable/10.1086/508573


### When not configured

Remove any configured PDF_URL

```unset JSTOR_PDF_URL```

- Launch the assignment, you'll get a 401 in the `http://localhost:9083/jstor/proxied.pdf?url=jstor%3A%2F%2F10.1086%2F508573\u0026jstor.ip=3.141.59.26` endpoint.



