### PR TITLE
Configure client to show JSTOR content banner

### DIFF
--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -47,6 +47,10 @@ class TestViewPDF:
             "https://example.com/foo/bar.pdf?q=s"
         )
 
+    def test_enables_partner_banner(self, call_view, jstor_api):
+        response = call_view("jstor://DOI", params={"jstor.ip": "1.1.1.1"})
+        assert response["hypothesis_config"].get("contentPartner") == "jstor"
+
     @pytest.fixture
     def Configuration(self, patch):
         Configuration = patch("via.views.view_pdf.Configuration")

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -28,6 +28,10 @@ def view_pdf(context, request):
 
     _, h_config = Configuration.extract_from_params(request.params)
 
+    # Show content partner banner in client for JSTOR.
+    if url.startswith("jstor://"):
+        h_config["contentPartner"] = "jstor"
+
     return {
         # The upstream PDF URL that should be associated with any annotations.
         "pdf_url": url,


### PR DESCRIPTION
When serving content from JSTOR using their APIs, configure the client
to show a banner indicating where the content is from and providing a
link to JSTOR.

See also https://github.com/hypothesis/client/pull/4308 and https://github.com/hypothesis/private-issues/issues/99.