### PR TITLE
Catch and re-raise Checkmate `BadURL`s to trigger our nice UI

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ google-auth-oauthlib==0.5.1
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.11
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -32,7 +32,7 @@ google-auth-oauthlib==0.5.1
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.11
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-matchers==1.2.13
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -55,7 +55,7 @@ gunicorn==20.1.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-h-checkmatelib==1.0.11
+h-checkmatelib==1.0.12
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ google-auth-oauthlib==0.5.1
     # via -r requirements/requirements.in
 gunicorn==20.1.0
     # via -r requirements/requirements.in
-h-checkmatelib==1.0.11
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -38,7 +38,7 @@ google-auth-oauthlib==0.5.1
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.11
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-matchers==1.2.13
     # via -r requirements/tests.in

--- a/tests/unit/via/checkmate_test.py
+++ b/tests/unit/via/checkmate_test.py
@@ -1,11 +1,13 @@
 from unittest.mock import create_autospec, patch, sentinel
 
 import pytest
+from checkmatelib import BadURL as CheckmateBadURL
 from checkmatelib import CheckmateException
 from checkmatelib.client import BlockResponse
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 
 from via.checkmate import ViaCheckmateClient
+from via.exceptions import BadURL
 
 
 class TestViaCheckmateClient:
@@ -37,6 +39,14 @@ class TestViaCheckmateClient:
             client.raise_if_blocked(sentinel.url)
 
         assert exc.value.location == block_response.presentation_url
+
+    def test_raise_if_blocked_reraises_BadURL(self, client, check_url):
+        check_url.side_effect = CheckmateBadURL
+
+        with pytest.raises(BadURL) as exc:
+            client.raise_if_blocked(sentinel.url)
+
+        assert exc.value.url == sentinel.url
 
     def test_raise_if_blocked_ignores_CheckmateExceptions(self, client, check_url):
         check_url.side_effect = CheckmateException

--- a/via/checkmate.py
+++ b/via/checkmate.py
@@ -1,5 +1,8 @@
+from checkmatelib import BadURL as CheckmateBadURL
 from checkmatelib import CheckmateClient, CheckmateException
 from pyramid.httpexceptions import HTTPTemporaryRedirect
+
+from via.exceptions import BadURL
 
 
 class ViaCheckmateClient(CheckmateClient):
@@ -17,7 +20,8 @@ class ViaCheckmateClient(CheckmateClient):
         Checkmate.
 
         :param url: The URL to check
-        :raise HTTPTemporaryRedirect: If the URL is blocked
+        :raises HTTPTemporaryRedirect: If the URL is blocked
+        :raises BadURL: For malformed or private URLs
         """
         try:
             blocked = self.check_url(
@@ -28,6 +32,9 @@ class ViaCheckmateClient(CheckmateClient):
                     "checkmate_ignore_reasons"
                 ],
             )
+
+        except CheckmateBadURL as exc:
+            raise BadURL(exc, url=url) from exc
 
         except CheckmateException:
             blocked = None

--- a/via/services/http.py
+++ b/via/services/http.py
@@ -29,7 +29,7 @@ class HTTPService:
         # requests and urllib3 connection pooling is used (which means that
         # underlying TCP connections are re-used when making multiple requests
         # to the same host, e.g. pagination).
-        #
+
         # See https://docs.python-requests.org/en/latest/user/advanced/#session-objects
         self._session = session or requests.Session()
         self._error_translator = error_translator
@@ -50,7 +50,7 @@ class HTTPService:
         return self.request("DELETE", *args, **kwargs)
 
     def request(self, method, url, timeout=(10, 10), raise_for_status=True, **kwargs):
-        r"""Send a request with `requests` and return the requests.Response object.
+        r"""Send a request with `requests`.
 
         :param method: The HTTP method to use, one of "GET", "PUT", "POST",
             "PATCH", "DELETE", "OPTIONS" or "HEAD"
@@ -65,12 +65,15 @@ class HTTPService:
             Note that the read_timeout is *not* a time limit on the entire
             response download. It's a time limit on how long to wait *between
             bytes from the server*. The entire download can take much longer.
-        :param raise_for_status: Optionally raise for 4xx & 5xx response statuses.
-        :param \**kwargs: Any other keyword arguments will be passed directly to
-            requests.Session().request():
+        :param raise_for_status: Optionally raise for 4xx & 5xx response
+            statuses.
+        :param \**kwargs: Any other keyword arguments will be passed directly
+            to requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
-        :raise request.exceptions are mapped to via's exception on DEFAULT_ERROR_MAP
-        :raise UnhandledUpstreamException: For any non mapped exception raised by requests
+        :raise request.exceptions are mapped to via's exception on
+            DEFAULT_ERROR_MAP
+        :raise UnhandledUpstreamException: For any non mapped exception raised
+            by requests
         :raise Exception: For any non requests exception raised
         :returns: a request.Response
         """
@@ -88,7 +91,7 @@ class HTTPService:
 
         except Exception as err:
             if mapped_err := self._translate_exception(err):
-                raise mapped_err from err  # pylint: disable=raising-bad-type
+                raise mapped_err from err
 
             raise
 
@@ -100,7 +103,7 @@ class HTTPService:
             yield from self._stream_bytes(response)
         except Exception as err:
             if mapped_err := self._translate_exception(err):
-                raise mapped_err from err  # pylint: disable=raising-bad-type
+                raise mapped_err from err
 
             raise
 
@@ -122,14 +125,14 @@ class HTTPService:
         """Stream content from a `requests.Response` object.
 
         The response must have been called with `stream=True` for this to be
-        effective. This will attempt to smooth over some of the variation of block
-        size to give a smoother output for upstream services calling us.
+        effective. This will attempt to smooth over some of the variation of
+        block size to give a smoother output for upstream services calling us.
         """
         buffer = b""
 
         # The chunk_size appears to be a guide value at best. We often get more
-        # or just about 9 bytes, so we'll do some smoothing for our callers so we
-        # don't incur overhead with very short iterations of content
+        # or just about 9 bytes, so we'll do some smoothing for our callers so
+        # we don't incur overhead with very short iterations of content
         for chunk in response.iter_content(chunk_size=min_chunk_size):
             buffer += chunk
             if len(buffer) >= min_chunk_size:


### PR DESCRIPTION
Needs:

 * https://github.com/hypothesis/checkmatelib/pull/21

This will cause BadURL messages to be presented to the user rather than buried.

## Testing notes

At the moment it's quite hard to get `checkmatelib` to raise, so I'd suggest manually bodging `via/checkmate.py` to raise an error:

```python
    def raise_if_blocked(self, url):
        """Raise a redirect to Checkmate if the URL is blocked.

        This will sensibly apply all ignore reasons and other configuration for
        Checkmate.

        :param url: The URL to check
        :raises HTTPTemporaryRedirect: If the URL is blocked
        :raises BadURL: For malformed or private URLs
        """
        try:
            raise CheckmateBadURL("TERRIBLE NEWS!")

            blocked = self.check_url(
                url,
                allow_all=self._request.registry.settings["checkmate_allow_all"],
                blocked_for=self._request.params.get("via.blocked_for"),
                ...
```

Then you can run `make dev` visit http://localhost:9083/ and attempt to visit any site.

* You should see the error page blaming you for the mistake
* In the details box you should see the string from your error