### PR TITLE
Don't check JSTOR URLs against Checkmate

### DIFF
--- a/tests/unit/via/services/jstor_test.py
+++ b/tests/unit/via/services/jstor_test.py
@@ -16,10 +16,10 @@ class TestJSTORAPI:
         assert svc.enabled == expected
 
     @pytest.mark.parametrize(
-        "url,is_jstor", (("jstor://anything", True), ("http://other", False))
+        "url,is_jstor", (("jstor://anything", True), ("http://example.com", False))
     )
-    def test_is_jstor_url(self, svc, url, is_jstor):
-        assert svc.is_jstor_url(url) == is_jstor
+    def test_is_jstor_url(self, url, is_jstor):
+        assert JSTORAPI.is_jstor_url(url) == is_jstor
 
     @pytest.mark.parametrize(
         "url,expected",

--- a/via/checkmate.py
+++ b/via/checkmate.py
@@ -3,6 +3,7 @@ from checkmatelib import CheckmateClient, CheckmateException
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 
 from via.exceptions import BadURL
+from via.services import JSTORAPI
 
 
 class ViaCheckmateClient(CheckmateClient):
@@ -23,6 +24,10 @@ class ViaCheckmateClient(CheckmateClient):
         :raises HTTPTemporaryRedirect: If the URL is blocked
         :raises BadURL: For malformed or private URLs
         """
+        if JSTORAPI.is_jstor_url(url):
+            # Nothing much we can do to check JSTOR urls
+            return
+
         try:
             blocked = self.check_url(
                 url,


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/via/issues/734

This really makes me wonder if we aren't creating a pile of pain for ourselves here by encoding these as `jstor://` URLs in the first place? I wonder if we should have left them as the original types which would have some level of graceful degradation for people without JSTOR setup.

What we could have done is include another parameter, or expand the type hints we pass to Via.

In any case, this takes a fairly blunt way of achieving this.

## Testing notes

 * `make devdata` In both LMS and Via
 * Enable JSTOR as described here: https://github.com/hypothesis/lms/pull/3918 (minus the site code)
 * Create a JSTOR assignment with:  https://www.jstor.org/stable/resrep25332.5
 * On master you should see a domain warning
 * In this branch you don't (it still fails though)