### PR TITLE
Add streaming Base64 decoding in the JSTOR service

### DIFF
--- a/tests/unit/via/services/jstor_test.py
+++ b/tests/unit/via/services/jstor_test.py
@@ -16,10 +16,10 @@ class TestJSTORAPI:
         assert svc.enabled == expected
 
     @pytest.mark.parametrize(
-        "url,is_jstor", (("jstor://anything", True), ("http://other", False))
+        "url,is_jstor", (("jstor://anything", True), ("http://example.com", False))
     )
-    def test_is_jstor_url(self, svc, url, is_jstor):
-        assert svc.is_jstor_url(url) == is_jstor
+    def test_is_jstor_url(self, url, is_jstor):
+        assert JSTORAPI.is_jstor_url(url) == is_jstor
 
     @pytest.mark.parametrize(
         "url,expected",

--- a/via/checkmate.py
+++ b/via/checkmate.py
@@ -3,6 +3,7 @@ from checkmatelib import CheckmateClient, CheckmateException
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 
 from via.exceptions import BadURL
+from via.services import JSTORAPI
 
 
 class ViaCheckmateClient(CheckmateClient):
@@ -23,6 +24,10 @@ class ViaCheckmateClient(CheckmateClient):
         :raises HTTPTemporaryRedirect: If the URL is blocked
         :raises BadURL: For malformed or private URLs
         """
+        if JSTORAPI.is_jstor_url(url):
+            # Nothing much we can do to check JSTOR urls
+            return
+
         try:
             blocked = self.check_url(
                 url,

--- a/via/services/jstor.py
+++ b/via/services/jstor.py
@@ -1,3 +1,5 @@
+import base64
+
 from via.requests_tools.headers import add_request_headers
 from via.services import HTTPService
 
@@ -36,9 +38,50 @@ class JSTORAPI:
             doi = f"{self.DEFAULT_DOI_PREFIX}/{doi}"
 
         url = f"{self._api_url}/{doi}?ip={jstor_ip}"
-        return self._http.stream(
+        stream = self._http.stream(
             url, headers=add_request_headers({"Accept": "application/pdf"})
         )
+
+        # Currently, JSTOR is sending us a stream of base 64 encoded data. This
+        # isn't intentional and may change if they can fix it. For the time
+        # being we need to decode this on the fly. This is both because it
+        # gives the user a better time to first byte, but also because the
+        # machinery that consumes this expects a stream, not a string.
+        return decode_base64_stream(stream)
+
+
+def decode_base64_stream(b64_stream):
+    """Get a stream of decoded bytes from an input stream of base 64 bytes."""
+
+    unprocessed = b""
+
+    for chunk in b64_stream:
+        # Take a chunk, but remove new lines which aren't part of the b64 data
+        unprocessed += chunk.replace(b"\n", b"")
+
+        # Every 4 bytes of Base 64 encode 3 octets exactly; any more or less
+        # will potentially encode a partial octet. Therefore, we need to split
+        # on exactly 4 bytes:
+        # +-----------+-----------+-----------+-----------+
+        # |    T      |     W     |     F     |     u     | 4 bytes of 64 input
+        # |0 1 0 0 1 1|0 1|0 1 1 0|0 0 0 1|0 1|1 0 1 1 1 0|
+        # |       M       |       a       |       n       | 3 output octets
+        # +---------------+---------------+---------------+
+        safe_len = 4 * (len(unprocessed) // 4)
+
+        # We'll take that many off of the front of the unprocessed bytes
+        to_process, unprocessed = unprocessed[:safe_len], unprocessed[safe_len:]
+
+        # It could be we got a very small chunk, and there aren't enough bytes
+        # to process
+        if to_process:
+            yield base64.b64decode(to_process)
+
+    # Clear up any remaining and add extra padding to ensure we can decode
+    # regardless of the length. The b64 module doesn't care if there is too
+    # much padding, but it might care about too little
+    if unprocessed:
+        yield base64.b64decode(unprocessed + b"====")
 
 
 def factory(_context, request):


### PR DESCRIPTION
Currently JSTOR returns us Base64 encoded PDFs, whether we like it or not. This isn't intentional and they are going to try and fix it, but in the mean time we need to deal with it.

One option is to download the entire PDF, decode it, and then send it to the user. This is bad for a number of reasons:

 * The time to first byte for the user is worse than streaming
 * We have to hold the entire document in memory to decode it
 * Our system is heavily setup to expect a stream, not a string (for the reasons above)

This PR adds streaming base 64 decoding of the PDF content.

## Testing notes

 * `make devdata` In both LMS and Via
 * Enable JSTOR as described here: https://github.com/hypothesis/lms/pull/3918 (minus the site code)
 * Create a JSTOR assignment with any value: e.g. https://www.jstor.org/stable/resrep25332.5
 * On master you should see a broken PDF with malformed content
 * In this branch it should work