### PR TITLE
Swap to the new end-point for JSTOR which returns S3 content

### DIFF
--- a/tests/unit/via/services/jstor_test.py
+++ b/tests/unit/via/services/jstor_test.py
@@ -1,12 +1,11 @@
-import base64
 from unittest.mock import sentinel
 
 import pytest
-from faker import Faker
 from freezegun import freeze_time
 
+from via.exceptions import UpstreamServiceError
 from via.requests_tools.headers import add_request_headers
-from via.services.jstor import JSTORAPI, decode_base64_stream, factory
+from via.services.jstor import JSTORAPI, factory
 
 
 class TestJSTORAPI:
@@ -29,14 +28,15 @@ class TestJSTORAPI:
     @pytest.mark.parametrize(
         "url,expected",
         [
-            ("jstor://ARTICLE_ID", "http://jstor.example.com/pdf/10.2307/ARTICLE_ID"),
-            ("jstor://PREFIX/SUFFIX", "http://jstor.example.com/pdf/PREFIX/SUFFIX"),
+            (
+                "jstor://ARTICLE_ID",
+                "http://jstor.example.com/pdf-url/10.2307/ARTICLE_ID",
+            ),
+            ("jstor://PREFIX/SUFFIX", "http://jstor.example.com/pdf-url/PREFIX/SUFFIX"),
         ],
     )
     @freeze_time("2022-01-14")
-    def test_stream_pdf(
-        self, svc, decode_base64_stream, jwt, http_service, url, expected
-    ):
+    def test_stream_pdf(self, svc, jwt, http_service, url, expected):
         jwt.encode.return_value = "TOKEN"
 
         stream = svc.stream_pdf(url=url, site_code=sentinel.site_code)
@@ -46,14 +46,22 @@ class TestJSTORAPI:
             sentinel.secret,
             algorithm="HS256",
         )
-        http_service.stream.assert_called_once_with(
-            expected,
-            headers=add_request_headers(
-                {"Accept": "application/pdf", "Authorization": "Bearer TOKEN"}
-            ),
+
+        http_service.request.assert_called_once_with(
+            method="GET",
+            url=expected,
+            headers=add_request_headers({"Authorization": "Bearer TOKEN"}),
         )
-        decode_base64_stream.assert_called_once_with(http_service.stream.return_value)
-        assert stream == decode_base64_stream.return_value
+        http_service.stream.assert_called_once_with(
+            url=http_service.request.return_value.text
+        )
+        assert stream == http_service.stream.return_value
+
+    def test_stream_pdf_with_bad_return_value_from_s3(self, svc, http_service):
+        http_service.request.return_value.text = "NOT A URL"
+
+        with pytest.raises(UpstreamServiceError):
+            svc.stream_pdf(url="jstor://ANY", site_code=sentinel.site_code)
 
     @pytest.fixture
     def svc(self, http_service):
@@ -64,53 +72,8 @@ class TestJSTORAPI:
         )
 
     @pytest.fixture(autouse=True)
-    def decode_base64_stream(self, patch):
-        return patch("via.services.jstor.decode_base64_stream")
-
-    @pytest.fixture(autouse=True)
     def jwt(self, patch):
         return patch("via.services.jstor.jwt")
-
-
-class TestDecodeBase64Stream:
-    def test_it(self, content_string, base64_stream):
-        content_iter = decode_base64_stream(base64_stream)
-
-        decoded_content = b"".join(content_iter).decode("utf-8")
-        assert decoded_content == content_string
-
-    def test_it_with_non_padded_strings(self):
-        # Non padded strings could leave us with left overs when we are
-        # finished iterating.
-        string = "Hello"
-        b64 = base64.b64encode(string.encode("utf-8")).rstrip(b"=")
-        assert len(b64) % 4, "Sanity check we are not divisible by 4"
-
-        content_iter = decode_base64_stream([b64])
-
-        decoded_content = b"".join(content_iter).decode("utf-8")
-        assert decoded_content == string
-
-    @pytest.fixture
-    def content_string(self):
-        random_text = Faker().paragraph(nb_sentences=100)
-        # Replace lots of chars with the UTF-8 snowman to prove we can handle
-        # high valued chars as well as ASCII
-        random_text = random_text.replace("e", "☃")
-
-        return random_text
-
-    @pytest.fixture
-    def base64_stream(self, content_string):
-        # We can't yield directly from this method as pytest will think we
-        # are creating a context manager like situation. So use a sub-function
-        def _chunk(raw_bytes, chunk_size=129):
-            for i in range(len(raw_bytes) // chunk_size + 1):
-                # Yield random empty bits to test our handling of that
-                yield b""
-                yield raw_bytes[i * chunk_size : (i + 1) * chunk_size]
-
-        return _chunk(base64.b64encode(content_string.encode("utf-8")))
 
 
 class TestFactory:

--- a/via/services/jstor.py
+++ b/via/services/jstor.py
@@ -1,8 +1,8 @@
-import base64
 from datetime import datetime, timedelta
 
 from jose import jwt
 
+from via.exceptions import UpstreamServiceError
 from via.requests_tools.headers import add_request_headers
 from via.services import HTTPService
 
@@ -35,27 +35,31 @@ class JSTORAPI:
 
         :param url: The URL to stream
         :param site_code: The code we use to authenticate ourselves to JSTOR
+        :raises UpstreamServiceError: If we get bad data back from the service
         """
 
+        # Get a signed S3 URL from JSTOR which expires after 10 minutes, and
+        # start a new request to stream that content
+        return self._http.stream(url=self._get_signed_s3_url(url, site_code))
+
+    def _get_signed_s3_url(self, url, site_code):
         doi = url.replace("jstor://", "")
         if "/" not in doi:
             doi = f"{self.DEFAULT_DOI_PREFIX}/{doi}"
 
         token = self._get_access_token(site_code)
+        s3_url = self._http.request(
+            method="GET",
+            url=f"{self._api_url}/pdf-url/{doi}",
+            headers=add_request_headers({"Authorization": f"Bearer {token}"}),
+        ).text
 
-        stream = self._http.stream(
-            url=f"{self._api_url}/pdf/{doi}",
-            headers=add_request_headers(
-                {"Accept": "application/pdf", "Authorization": f"Bearer {token}"}
-            ),
-        )
+        if not s3_url.startswith("https://"):
+            raise UpstreamServiceError(
+                f"Expected to get an S3 URL but got: {s3_url} instead"
+            )
 
-        # Currently, JSTOR is sending us a stream of base 64 encoded data. This
-        # isn't intentional and may change if they can fix it. For the time
-        # being we need to decode this on the fly. This is both because it
-        # gives the user a better time to first byte, but also because the
-        # machinery that consumes this expects a stream, not a string.
-        return decode_base64_stream(stream)
+        return s3_url
 
     def _get_access_token(self, site_code):
         return jwt.encode(
@@ -66,40 +70,6 @@ class JSTORAPI:
             self._secret,
             algorithm="HS256",
         )
-
-
-def decode_base64_stream(b64_stream):
-    """Get a stream of decoded bytes from an input stream of base 64 bytes."""
-
-    unprocessed = b""
-
-    for chunk in b64_stream:
-        # Take a chunk, but remove new lines which aren't part of the b64 data
-        unprocessed += chunk.replace(b"\n", b"")
-
-        # Every 4 bytes of Base 64 encode 3 octets exactly; any more or less
-        # will potentially encode a partial octet. Therefore, we need to split
-        # on exactly 4 bytes:
-        # +-----------+-----------+-----------+-----------+
-        # |    T      |     W     |     F     |     u     | 4 bytes of 64 input
-        # |0 1 0 0 1 1|0 1|0 1 1 0|0 0 0 1|0 1|1 0 1 1 1 0|
-        # |       M       |       a       |       n       | 3 output octets
-        # +---------------+---------------+---------------+
-        safe_len = 4 * (len(unprocessed) // 4)
-
-        # We'll take that many off of the front of the unprocessed bytes
-        to_process, unprocessed = unprocessed[:safe_len], unprocessed[safe_len:]
-
-        # It could be we got a very small chunk, and there aren't enough bytes
-        # to process
-        if to_process:
-            yield base64.b64decode(to_process)
-
-    # Clear up any remaining and add extra padding to ensure we can decode
-    # regardless of the length. The b64 module doesn't care if there is too
-    # much padding, but it might care about too little
-    if unprocessed:
-        yield base64.b64decode(unprocessed + b"====")
 
 
 def factory(_context, request):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/private-issues/issues/110

I'm not sure this is any faster for us, as two calls are worse than one, but it does remove all the Base64 stuff. This also leaves the
possibility of doing the translation to give the URL before we pass to the view, which might remove some more code. This has been done here:

 * https://github.com/hypothesis/via/pull/741

### What's changed?

 * Previously JSTOR's API returned Base64 encoded data to us, which means we have to decode it in a custom view in Via
 * Now the same API returns an S3 URL which we can then stream normally

## Testing notes

 * Get the latest dev data (after https://github.com/hypothesis/devdata/pull/52)
 * All the usual `make dev` magic to stand everything up
 * Make sure your dev tools are open with the cache disabled
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/2968
 * You should see a document, nothing externally should be any different