### PR TITLE
Make PyLint fail on any message

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,11 @@ load-plugins=pylint.extensions.bad_builtin,
              pylint.extensions.overlapping_exceptions,
              pylint.extensions.redefined_variable_type,
 
+# Fail if there are *any* messages from PyLint.
+# The letters refer to PyLint's message categories, see
+# https://pylint.pycqa.org/en/latest/messages/messages_introduction.html
+fail-on=C,E,F,I,R,W
+
 [MESSAGES CONTROL]
 enable=
     bad-inline-option,

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -10,6 +10,11 @@ load-plugins=pylint.extensions.bad_builtin,
              pylint.extensions.overlapping_exceptions,
              pylint.extensions.redefined_variable_type,
 
+# Fail if there are *any* messages from PyLint.
+# The letters refer to PyLint's message categories, see
+# https://pylint.pycqa.org/en/latest/messages/messages_introduction.html
+fail-on=C,E,F,I,R,W
+
 [MESSAGES CONTROL]
 disable=bad-continuation,
         invalid-name,


### PR DESCRIPTION
Make PyLint fail if it prints any messages (even just informational ones).