### PR TITLE
Update `h-vialib` to allow passing the `contentPartner` externally

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -62,7 +62,7 @@ h-checkmatelib==1.0.14
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.18
+h-vialib==1.0.19
     # via -r requirements/requirements.txt
 hupper==1.10.2
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -42,7 +42,7 @@ h-matchers==1.2.13
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.18
+h-vialib==1.0.19
     # via -r requirements/requirements.txt
 httpretty==1.1.4
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -72,7 +72,7 @@ h-pyramid-sentry==1.2.3
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-h-vialib==1.0.18
+h-vialib==1.0.19
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ h-checkmatelib==1.0.14
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in
-h-vialib==1.0.18
+h-vialib==1.0.19
     # via -r requirements/requirements.in
 hupper==1.10.2
     # via pyramid

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -50,7 +50,7 @@ h-matchers==1.2.13
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.18
+h-vialib==1.0.19
     # via -r requirements/requirements.txt
 httpretty==1.1.4
     # via -r requirements/tests.in


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/private-issues/issues/110

This is required for the move to LMS being in charge. This means we can accept the `contentPartner` value and it should trigger it to show.

This is needed for:

 * https://github.com/hypothesis/lms/pull/3941