### PR TITLE
Detect files blocked by Google Drive as malicous

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ day-to-day.
  * **408 (error)** - We timed out trying to make a connection to Google 
  * **409 (error)** - We had a conventional error like a connection error
  * **417 (error)** - We got an unexpected response from Google
+ * **423 (error)** - Google has blocked the file as malicous
  * **429 (error)** - We have been rate limited by Google
 
 Updating the PDF viewer

--- a/tests/unit/via/services/fixtures/google_403_malicious.json
+++ b/tests/unit/via/services/fixtures/google_403_malicious.json
@@ -1,0 +1,13 @@
+{
+    "error": {
+        "errors": [
+            {
+                "domain": "global",
+                "reason": "cannotDownloadAbusiveFile",
+                "message": "This file has been identified as malware or spam and cannot be downloaded."
+            }
+        ],
+        "code": 403,
+        "message": "This file has been identified as malware or spam and cannot be downloaded."
+    }
+}

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -176,6 +176,14 @@ class TestGoogleDriveAPI:
                 GoogleDriveServiceError,
                 403,
             ),
+            (
+                {
+                    "status_code": 403,
+                    "json_data": load_fixture("google_403_malicious.json"),
+                },
+                GoogleDriveServiceError,
+                423,
+            ),
         ),
     )
     def test_iter_file_catches_specific_google_exceptions(

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -72,6 +72,17 @@ def translate_google_error(error):
             requests_err=error,
         )
 
+    if status_code == 403 and google_reason == "cannotDownloadAbusiveFile":
+        # This file is blocked because Google thinks it is malware of some kind
+        return GoogleDriveServiceError(
+            "Google has identified this file as malicious and has denied "
+            "access to it",
+            # 423 - Locked
+            # 'The resource that is being accessed is locked' - kinda?
+            status_int=423,
+            requests_err=error,
+        )
+
     return None
 
 


### PR DESCRIPTION
See: 

 * https://hypothes-is.slack.com/archives/C4K6M7P5E/p1657657579981149

When Google denies access to a particular file because it thinks it's malicious, we currently emit a 417 indicating a general failure. This catches this special case and allocates a new HTTP code for it.

### Review notes

There are two commits:

 * The first implements this directly and is should be easy to see
 * The second refactors the layout of the function to avoid a lint message