### PR TITLE
Don't pin PyLint in `lint.in`

### DIFF
--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,5 +1,5 @@
 pip-tools
-pylint<2.15
+pylint
 pydocstyle
 -r tests.txt
 -r requirements.txt


### PR DESCRIPTION
We pin all our requirements to exact version numbers in the `requirements/*.txt` files and use Dependabot to keep them up to date. You can tell Dependabot to ignore a particular dependency (or ignore a major or minor version, or to only send patch upgrades for a given dependency, etc) if you don't want one to be upgraded.

Trying to pin a dependency in a `*.in` file doesn't work, Dependabot will just increment the pinned version number. Example:

https://github.com/hypothesis/via/commit/94b8dc216c8e84cf074f8c4d8a97082f117aa54e