### PR TITLE
Replace `h-checkmatelib` with just `checkmatelib`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,6 +32,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 cryptography==3.4.7
@@ -58,8 +60,6 @@ google-auth-oauthlib==0.5.2
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 h-vialib==1.0.19
@@ -75,7 +75,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 ipdb==0.13.9
     # via -r requirements/dev.in
 ipython==7.31.1
@@ -93,8 +93,8 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
+    #   checkmatelib
     #   docker-compose
-    #   h-checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -107,7 +107,7 @@ matplotlib-inline==0.1.3
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.1
@@ -201,9 +201,9 @@ pyyaml==5.4.1
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
+    #   checkmatelib
     #   docker
     #   docker-compose
-    #   h-checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -26,6 +26,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 google-auth==2.0.1
@@ -35,8 +37,6 @@ google-auth==2.0.1
 google-auth-oauthlib==0.5.2
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
-    # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
     # via -r requirements/requirements.txt
 h-matchers==1.2.15
     # via -r requirements/functests.in
@@ -57,7 +57,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
@@ -67,7 +67,7 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -78,7 +78,7 @@ marshmallow==3.17.1
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.1
@@ -154,7 +154,7 @@ pytest==7.1.2
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -36,6 +36,10 @@ charset-normalizer==2.0.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
+checkmatelib==1.0.15
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
 click==8.1.3
     # via
     #   -r requirements/tests.txt
@@ -60,10 +64,6 @@ google-auth-oauthlib==0.5.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
 gunicorn==20.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-h-checkmatelib==1.0.14
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -93,7 +93,7 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via
     #   -r requirements/tests.txt
@@ -109,7 +109,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
@@ -128,7 +128,7 @@ netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via
     #   -r requirements/requirements.txt
@@ -244,7 +244,7 @@ requests==2.28.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 gunicorn
-h-checkmatelib
+checkmatelib
 h-pyramid-sentry
 h-vialib
 importlib_resources

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,13 +14,13 @@ certifi==2020.12.5
     #   sentry-sdk
 charset-normalizer==2.0.1
     # via requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.in
 google-auth==2.0.1
     # via google-auth-oauthlib
 google-auth-oauthlib==0.5.2
     # via -r requirements/requirements.in
 gunicorn==20.1.0
-    # via -r requirements/requirements.in
-h-checkmatelib==1.0.14
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in
@@ -33,11 +33,11 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.in
-    #   h-checkmatelib
+    #   checkmatelib
 jinja2==2.11.3
     # via pyramid-jinja2
 jsonschema==3.2.0
-    # via h-checkmatelib
+    # via checkmatelib
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -45,7 +45,7 @@ markupsafe==1.1.1
 marshmallow==3.17.1
     # via -r requirements/requirements.in
 netaddr==0.8.0
-    # via h-checkmatelib
+    # via checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.in
 oauthlib==3.1.1
@@ -91,7 +91,7 @@ pyrsistent==0.17.3
 requests==2.28.1
     # via
     #   -r requirements/requirements.in
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via google-auth-oauthlib

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -26,6 +26,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 coverage==6.4.4
@@ -41,8 +43,6 @@ google-auth==2.0.1
 google-auth-oauthlib==0.5.2
     # via -r requirements/requirements.txt
 gunicorn==20.1.0
-    # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
     # via -r requirements/requirements.txt
 h-matchers==1.2.15
     # via -r requirements/tests.in
@@ -63,7 +63,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
@@ -73,7 +73,7 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -84,7 +84,7 @@ marshmallow==3.17.1
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.1
@@ -162,7 +162,7 @@ python-dateutil==2.8.1
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via


### PR DESCRIPTION
`h-checkmatelib` has been renamed to just `checkmatelib`:

hypothesis/checkmatelib#24

This commit is the result of replace `h-checkmatelib` with `checkmatelib` in `requirements.in` and then running `make requirements`.
