### PR TITLE
Change to HTTPS for the devdata clone URL

### DIFF
--- a/bin/devdata.py
+++ b/bin/devdata.py
@@ -12,7 +12,9 @@ def _get_devdata():
     with TemporaryDirectory() as tmp_dir_name:
         git_dir = os.path.join(tmp_dir_name, "devdata")
 
-        check_call(["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir])
+        check_call(
+            ["git", "clone", "https://github.com/hypothesis/devdata.git", git_dir]
+        )
 
         # Copy devdata files into place.
         for source, target in (


### PR DESCRIPTION
The easiest way to set up Git->GitHub.com authentication nowadays is by
installing [GitHub CLI](https://cli.github.com/), running
[gh auth login](https://cli.github.com/manual/gh_auth_login), and
answering "Yes" (the default) when it asks "Authenticate Git with your
GitHub credentials?". By default this will set up authentication for
HTTPS git clone URLs but not SSH ones so `make devdata` will fail with
an authentication error because it tries to clone the private devdata
repo using the SSH clone URL.

Fix this by changing the devdata clone URL to the HTTPS one.
