### PR TITLE
Separate GitHub Actions environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
     with:
       Application: lms-via
-      Environment: qa
+      Environment: qa-lms
       Region: us-west-1
       Operation: deploy
       Version: latest
@@ -64,7 +64,7 @@ jobs:
     uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
     with:
       Application: lms-via
-      Environment: prod
+      Environment: prod-lms
       Region: us-west-1
       Operation: deploy
       Version: latest


### PR DESCRIPTION
**This PR is a draft currently because I'm not sure the change will actually work as written.** I think some changes may be needed to [the shared `eb-update.yml` workflow](https://github.com/hypothesis/workflows/blob/main/.github/workflows/eb-update.yml) to enable the change that I'm trying to make in this PR to work.

* * *

Use two separate GitHub Actions environments named `qa` and `qa-lms` for the `via-qa` and `lms-via-qa` Elastic Beanstalk environments instead of using a single GitHub environment named `qa` for the jobs that deploy to both Elastic Beanstalk environments.

Similarly, use two separate GitHub Actions environments named `prod` and `prod-lms` for the `via-prod` and `lms-via-prod` Elastic Beanstalk environments instead of using a single GitHub environment named `prod` for the jobs that deploy to both Elastic Beanstalk environments.

I think this is the correct way to do this: **there should be a 1:1 mapping from GitHub environments to Elastic Beanstalk environments**. One separate GitHub environment for each Elastic Beanstalk environment. Don't share multiple Elastic Beanstalk environments under a single GitHub environment.

I think creating this 1:1 GitHub environment:Elastic Beanstalk environment mapping will cause various deployment-related GitHub UI and API features that're currently broken to work correctly:

* GitHub lets you associate a single URL with each deployment to an environment and links to that URL in various places where the environment or deployments to the environment appear in GitHub's UI and API.

  For example we'd use https://via.hypothes.is/ as the URL for Via's `prod` environment and https://qa-via.hypothes.is/ for Via's `qa` environment, and so on for the `prod-lms` and `qa-lms` Via environments.

  GitHub's docs about this: <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment>

  We can't make use of this feature when we share a single GitHub environment between multiple Elastic Beanstalk environments: each GitHub environment can only have one deployment URL not multiple.

* The **Environments** section in the right-hand sidebar on each GitHub repo's front page will helpfully list all of that repo's Elastic Beanstalk deployments. For example just `qa` and `prod` for Bouncer, but `qa`, `prod`, `qa-websocket`, `prod-websocket` and `ca-central-1` for h. I think the sidebar will also link each environment to its URL. Very handy for finding each app's QA environment when you need to test it.

  Currently this **Environment** sidebar is unhelpful/uninformative: it just lists the same two `qa` and `prod` environments (not real environments) for each repo and doesn't link them to URLs. It also sometimes incorrectly labels one or the other of the environments as "inactive":

  <img width="411" alt="Screenshot 2022-10-21 at 18 03 49" src="https://user-images.githubusercontent.com/22498/197250300-e6cef670-d0dc-4606-8cf8-d842434896f2.png">

* I think GitHub will also handily link the environments/deployments to their URLs when they appear on Actions workflow pages, on deployment history pages, etc.

* I think the deployment history page will work properly:

  https://github.com/hypothesis/via/deployments/activity_log

  For one thing the section at the top of that page will show all four Elastic Beanstalk environments separately and which PR is currently deployed to each of the four environments. Currently it just lists the `qa` and `prod` environments:

  <img width="754" alt="Screenshot 2022-10-21 at 18 04 45" src="https://user-images.githubusercontent.com/22498/197250442-4cb4e57d-06a4-41d2-b449-fe4f32d4838c.png">

  The information shown here is incorrect. Usually, if all is going well, the same PR will be deployed to both the `via-prod` and `lms-via-prod` Elastic Beanstalk environments. But this won't always be true. For example the job to deploy a PR to `via-prod` might succeed whilst the job to deploy the same PR to `lms-via-prod` fails for some reason. Now two different PRs are deployed to these two different environments. So the above UI needs to present the two different environments separately. It's not valid to state that a given PR is deployed to "prod" because there isn't really a single prod environment.

  The filter menu on that page will also allow us to filter to `qa`, `prod`, `lms-qa` or `lms-prod` deployments individually, instead of just `qa` and `prod`:
   
  <img width="434" alt="Screenshot 2022-10-21 at 18 08 43" src="https://user-images.githubusercontent.com/22498/197251074-849b67ff-5002-4706-aeca-e1cd3d5867b9.png">


  The deployment history will also be correct: currently for a given pull request (for example: `remove-jenkinsfile`, #808) the deployment history page shows two apparently duplicate deployments of the same PR to `qa`, one marked as "active" and the other "inactive", and two apparently duplicate deployments of the same PR to `prod`, again one "active" and one "inactive". The reason there are two deployments to QA and two to prod is that there are two QA Elastic Beanstalk environments (`via-qa` and `lms-via-qa`) and two Elastic Beanstalk prod environments (`via-prod` and `lms-via-prod`) and our GitHub Actions workflow has two jobs that deploy to the two Elastic Beanstalk QA environments (in parallel) and two jobs that deploy to the two Elastic Beanstalk prod environments (also in parallel). But you can't see this in GitHub's deployment history UI: the two deployments to `qa` look exactly the same as each other and the two deployments to `prod` look the same. They look like duplicate entries:

  <img width="532" alt="Screenshot 2022-10-21 at 18 09 41" src="https://user-images.githubusercontent.com/22498/197251204-58cff22c-42b7-49c4-a204-063e54558d7f.png">

  The reason is that we've told GitHub that there is just one `qa` environment and one `prod` environment. So what happens is:

  1. Parallel jobs start deploying to the `via-prod` and `lms-via-prod` Elastic Beanstalk environments. GitHub thinks that these are two parallel jobs deploying the same commit to the same single `prod` environment
  2. The `via-prod` deployment finishes first and GitHub's deployment history briefly marks this deployment as "active"
  3. Then the `lms-via-prod` deployment finishes and since GitHub thinks both jobs are deploying to a single `prod` environment it now marks the `lms-via-prod` deployment as "active" and the `via-prod` one as "inactive". It thinks that the `lms-via-prod` deployment has replaced the `via-prod` deployment in the single `prod` environment.

  What should happen is that both deployments should remain marked as active because they are both currently deployed to two different Elastic Beanstalk environments, and the history should show the two different environment names instead of calling them both `prod`.

GitHub Environment Naming Plan
------------------------------

I've tried to keep the GitHub environment names short, sweet and consistent across repos. As much as possible I'd prefer just `prod` over over something like `via-us-west-1-prod`. Rules:

* Don't include the app name or GitHub repo name in the GitHub environment name since GitHub environments are already namespaced under repos. For example the GitHub environment can just be called `qa` not `via-qa`. This allows for consistent GitHub environment names across repos (for example `qa` and `prod`)

* Don't include the AWS region when it is `us-west-1` as this would force us to name everything `us-west-1-prod` instead of the nice and simple `prod`

* For `ca-central-1` environments we do need to include `ca-central-1` in the GitHub environment name to distinguish them from the same repo's `us-west-1` environments

* We don't have any QA Elastic Beanstalk environments in the `ca-central-1` region, only prod ones. So for `ca-central-1` environments I think the GitHub environment name can just be `ca-central-1`, it doesn't need to be `ca-central-1-prod` (or `prod-ca-central-1`) as there's no need to distinguish between `qa` and `prod`

Here's what I've come up with:

| GitHub Repo | AWS Region   | Elastic Beanstalk Application | Elastic Beanstalk Environment | GitHub Environment |
| ----------- | ------------ | ----------------------------- | ----------------------------- | ------------------ |
| via         | us-west-1    | via                           | via-qa                        | qa                 |
| via         | us-west-1    | via                           | via-prod                      | prod               |
| via         | us-west-1    | lms-via                       | lms-via-qa                    | qa-lms             |
| via         | us-west-1    | lms-via                       | lms-via-prod                  | prod-lms           |
| viahtml     | us-west-1    | viahtml                       | viahtml-qa                    | qa                 |
| viahtml     | us-west-1    | viahtml                       | viahtml-prod                  | prod               |
| viahtml     | us-west-1    | lms-viahtml                   | lms-viahtml-qa                | qa-lms             |
| viahtml     | us-west-1    | lms-viahtml                   | lms-viahtml-prod              | prod-lms           |
| bouncer     | us-west-1    | bouncer                       | bouncer-qa                    | qa                 |
| bouncer     | us-west-1    | bouncer                       | bouncer-prod                  | prod               |
| checkmate   | us-west-1    | checkmate                     | checkmate-qa                  | qa                 |
| checkmate   | us-west-1    | checkmate                     | checkmate-prod                | prod               |
| h           | us-west-1    | h                             | h-qa                          | qa                 |
| h           | us-west-1    | h                             | h                             | prod               |
| h           | us-west-1    | h-websocket                   | h-websocket-qa                | qa-websocket       |
| h           | us-west-1    | h-websocket                   | h-websocket-prod              | prod-websocket     |
| h           | ca-central-1 | h                             | h-prod                        | ca-central-1       |
| h-periodic  | us-west-1    | h-periodic                    | h-periodic-qa                 | qa                 |
| h-periodic  | us-west-1    | h-periodic                    | h-periodic-prod               | prod               |
| h-periodic  | ca-central-1 | h-periodic                    | h-periodic-prod               | ca-central-1       |
| lms         | us-west-1    | lms                           | lms-qa                        | qa                 |
| lms         | us-west-1    | lms                           | lms-prod                      | prod               |
| lms         | ca-central-1 | lms                           | lms-prod                      | ca-central-1       |
