### PR TITLE
Add `redeploy.yml`

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,50 @@
+# Redeploy the currently deployed version of Via, a.k.a "turn if off and on again".
+name: Redeploy
+concurrency:
+  group: ${{ github.event.repository.name }}-deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+jobs:
+  QA:
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: QA
+      github_environment_url: https://qa-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: qa
+    secrets: inherit
+  QA (Edu):
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: QA (Edu)
+      github_environment_url: https://qa-lms-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: qa
+    secrets: inherit
+  Production:
+    needs: QA
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Production
+      github_environment_url: https://via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: prod
+    secrets: inherit
+  Production (Edu):
+    needs: QA (Edu)
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Production (Edu)
+      github_environment_url: https://lms-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: prod
+    secrets: inherit


### PR DESCRIPTION
The idea is to have a super easy way to redeploy the current version of an app: by going to that app's Actions tab and running the Redeploy workflow (no arguments).

Having the redeploy workflow live in each app's own repo (instead of in the deployment repo) also means that redeployments will show up in that app's deployment logs (https://github.com/hypothesis/via/deployments) and can share environment and concurrency group protections with the app's deploy workflow (so you can't be both deploying and redeploying the same app at the same time).
