### PR TITLE
Use the new deploy.yml workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,50 +22,56 @@ jobs:
       Application: ${{ github.event.repository.name }}
     secrets: inherit
 
-  qa-via:
+  QA:
     needs: create-image
-    name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA
+      github_environment_url: https://qa-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
-  qa-lms-via:
+  QA_Edu:
+    name: QA (Edu)
     needs: create-image
-    name: lms-via
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: lms-via
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA (Edu)
+      github_environment_url: https://qa-lms-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
-  prod-via:
-    needs: [create-image, qa-via]
-    name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+  Production:
+    needs: [create-image, QA]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production
+      github_environment_url: https://via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
-  prod-lms-via:
-    needs: [create-image, qa-lms-via]
-    name: lms-via
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+  Production_Edu:
+    name: Production (Edu)
+    needs: [create-image, QA_Edu]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: lms-via
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production (Edu)
+      github_environment_url: https://lms-via.hypothes.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Use the new `deploy.yml` workflow from
hypothesis/workflows#2, specify a different
GitHub environment name for each Elastic Beanstalk environment, and also
specify a URL for each environment.
