### PR TITLE
Use better GitHub environment URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA
-      github_environment_url: https://qa-via.hypothes.is/
+      github_environment_url: https://qa-via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek
       aws_region: us-west-1
       elasticbeanstalk_application: via
       elasticbeanstalk_environment: qa
@@ -42,7 +42,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA (Edu)
-      github_environment_url: https://qa-lms-via.hypothes.is/
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/878
       aws_region: us-west-1
       elasticbeanstalk_application: lms-via
       elasticbeanstalk_environment: qa
@@ -55,7 +55,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production
-      github_environment_url: https://via.hypothes.is/
+      github_environment_url: https://via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek
       aws_region: us-west-1
       elasticbeanstalk_application: via
       elasticbeanstalk_environment: prod
@@ -69,7 +69,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production (Edu)
-      github_environment_url: https://lms-via.hypothes.is/
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/882
       aws_region: us-west-1
       elasticbeanstalk_application: lms-via
       elasticbeanstalk_environment: prod


### PR DESCRIPTION
Replace the QA and production environment URLs with direct links to
proxy PDFs in Via, and replace the Via (Edu) QA and production
environment URLs with links to PDF assignments in our test Canvas
instance (you can't use Via (Edu) directly, you have to go through the
LMS app).