### PR TITLE
Add a redeploy workflow

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,67 @@
+# Redeploy the currently deployed version of Via, a.k.a "turn if off and on again".
+name: Redeploy
+concurrency:
+  group: ${{ github.event.repository.name }}-deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      QA:
+        type: boolean
+        description: Redeploy QA
+      QA_Edu:
+        type: boolean
+        description: Redeploy QA (Edu)
+      Production:
+        type: boolean
+        description: Redeploy Production
+      Production_Edu:
+        type: boolean
+        description: Redeploy Production (Edu)
+jobs:
+  QA:
+    if: inputs.QA
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: QA
+      github_environment_url: https://qa-via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: qa
+    secrets: inherit
+  QA_Edu:
+    name: QA (Edu)
+    if: inputs.QA_Edu
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: QA (Edu)
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/878
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: qa
+    secrets: inherit
+  Production:
+    if: inputs.Production
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Production
+      github_environment_url: https://via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek
+      aws_region: us-west-1
+      elasticbeanstalk_application: via
+      elasticbeanstalk_environment: prod
+    secrets: inherit
+  Production_Edu:
+    name: Production (Edu)
+    if: inputs.Production_Edu
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: Production (Edu)
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/882
+      aws_region: us-west-1
+      elasticbeanstalk_application: lms-via
+      elasticbeanstalk_environment: prod
+    secrets: inherit


### PR DESCRIPTION
Add an easy-to-use `redeploy.yml` workflow to allow developers to easily redeploy Via from Via's own GitHub Actions page.

Having a `redeploy.yml` workflow in the app repos has a couple of advantages:

* Developers will be used to going to an app's GitHub Actions tab to see its deployments so it's good that they can also redeploy the app from its own GitHub Actions tab rather than having to go to another repo.
* The redeploy workflow is very easy to use: just check the checkboxes for the environment(s) that you want to redeploy and hit run.
* Redeployments will show up with normal deployments in the app's deployment logs (on each app's `/deployments` page). If the redeploy workflow lives in another repo then its deployments won't show up in the app's deployment logs.
* Redeployments use the same concurrency group as normal deployments so a redeployment can't happen at the same time as a normal deployment. If the redeploy workflow is in a separate repo I don't think it's possible to handle the concurrency properly.

A `redeploy.yml` workflow was previously attempted in https://github.com/hypothesis/via/pull/816 but was reverted in https://github.com/hypothesis/via/pull/822. This commit's `redeploy.yml` differs from the previous attempt in a couple of ways:

* A workflow run doesn't have to deploy all environments.

  When triggering a workflow run the user is presented with checkboxes for each environment (QA, QA Edu, Prod, and Prod Edu) so they can choose which environment(s) they want to redeploy.

* There aren't dependencies between the jobs.

  For example if you redeploy all four environments in a single workflow run they'll all redeploy at once. The production environments don't need to wait for the QA environments.