### PR TITLE
Temporarily switch Via to be a Debian Slim-based container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ FROM python:3.8.15-slim-bullseye
 LABEL maintainer="Hypothes.is Project and contributors"
 
 # Install nginx & supervisor
-RUN apt-get update && apt-get install --yes nginx nginx-extras gettext-base \
-  && pip install --no-cache-dir supervisor \
+RUN apt-get update && apt-get install --yes nginx nginx-extras gettext-base supervisor \
   && apt-get clean
 
 # Create the hypothesis user, group, home directory and package directory.
@@ -33,4 +32,4 @@ COPY . .
 
 USER hypothesis
 
-CMD /usr/bin/envsubst '$${NGINX_SECURE_LINK_SECRET}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/local/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf
+CMD /usr/bin/envsubst '$${NGINX_SECURE_LINK_SECRET}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,17 @@ python:
 	@./bin/install-python
 
 DOCKER_TAG = dev
+
+.PHONY: run-docker
+run-docker:
+	docker run --rm \
+		-v $(PWD)/.devdata/:/via-data/:ro \
+		-e "CHECKMATE_API_KEY=dummy" \
+		-e "CHECKMATE_URL=http://dummy-checkmate-service" \
+		-e "CLIENT_EMBED_URL=http://localhost:5000/embed.js" \
+		-e "DATA_DIRECTORY=/via-data/" \
+		-e "NGINX_SECURE_LINK_SECRET=dummy" \
+		-e "NGINX_SERVER=http://localhost:9083" \
+		-e "VIA_HTML_URL=http://localhost:9085" \
+		-e "VIA_SECRET=dummy" \
+		-p 9083:9083 docker.io/hypothesis/via:dev


### PR DESCRIPTION
This PR works around a limitation in Musl libc's DNS resolver, lack of support for TCP retries, by temporarily switching the base image of Via to be based on Debian Slim (which uses glibc instead of Musl) rather than Alpine Linux. This limitation caused problems when Via tried to connect to certain Sharepoint-hosted domains, and after some experimentation/exploration, I concluded that changing the base image in the short term is probably going to be the least unpleasant/risky solution (aside from deciding not to fix the problem at all).

See https://github.com/hypothesis/product-backlog/issues/1409#issuecomment-1338447951 for a detailed explanation of the issue and possible solutions.

Musl is due to get support for TCP retries in the next release (v1.2.4?), and will hopefully appear in Alpine 3.18. So we should be able to switch Via back to Alpine at that point, for consistency with our other apps. The Alpine-based image is also smaller. The compressed Debian-based one is ~107MB whereas the compressed Alpine-based image is 58MB.

The first commit updates the Docker file. The second adds a `run-docker` command to assist with testing locally.

Fixes https://github.com/hypothesis/product-backlog/issues/1409.

**Testing:**

1. Run h, viahtml and the client locally
2. Check out this branch, and create a local commit that patches `conf/nginx/includes/resolver.conf` to change the DNS resolver from AWS's resolver to 1.1.1.1 or 8.8.8.8
3. Run `make docker`
4. Run `make run-docker`
5. Visit http://localhost:9083/https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf