### PR TITLE
Suppress warning about pkg_resources being deprecated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ filterwarnings =
     # pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
     ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
 
+    # Suppress deprecation warning from dependencies (eg. pyramid) that still use pkg_resources
+    ignore:^pkg_resources is deprecated as an API$:DeprecationWarning:pkg_resources
+
 xfail_strict=true
 
 [tox]


### PR DESCRIPTION
This package is imported by Pyramid and it triggers a warning:

```
DeprecationWarning: pkg_resources is deprecated as an API
```

See also https://github.com/hypothesis/h/pull/7950 and https://hypothes-is.slack.com/archives/C1MA4E9B9/p1682933798408359.