### PR TITLE
Copy tailwind config into frontend build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:19.8.1-alpine as frontend-build
 
 ENV NODE_ENV production
-COPY .babelrc rollup.config.mjs gulpfile.mjs package.json yarn.lock ./
+COPY .babelrc rollup.config.mjs gulpfile.mjs package.json tailwind.config.mjs yarn.lock ./
 COPY via/static ./via/static
 
 RUN yarn install --frozen-lockfile


### PR DESCRIPTION
This is needed to build CSS assets. This fixes the build failure encountered [here](https://github.com/hypothesis/via/actions/runs/4861425765/jobs/8666476856).