### PR TITLE
Mock transcript data in the same shape as the real one

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -19,12 +19,14 @@ class TestViewVideo:
         assert response["transcript"] == {
             "segments": [
                 {
-                    "time": 0,
                     "text": "First segment of transcript",
+                    "start": 0.12,
+                    "duration": 5.219,
                 },
                 {
-                    "time": 30,
                     "text": "Second segment of transcript",
+                    "start": 3.0,
+                    "duration": 3.48,
                 },
             ],
         }

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -13,12 +13,14 @@ def view_video(request):
     transcript = {
         "segments": [
             {
-                "time": 0,
                 "text": "First segment of transcript",
+                "start": 0.12,
+                "duration": 5.219,
             },
             {
-                "time": 30,
                 "text": "Second segment of transcript",
+                "start": 3.0,
+                "duration": 3.48,
             },
         ],
     }


### PR DESCRIPTION
We could try shape it into that other format in the backend if you prefer but this other format seems to have more information.