### PR TITLE
Ensure `build/` dir exists before attempting to watch files in it

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'fs';
+
 import {
   buildCSS,
   buildJS,
@@ -28,6 +30,8 @@ gulp.task('watch-css', () => {
 });
 
 gulp.task('watch-manifest', () => {
+  // Ensure build dir exists, otherwise `gulp.watch` may not work.
+  mkdirSync('build', { recursive: true });
   gulp.watch('build/**/*.{css,js,map}', generateManifest);
 });
 


### PR DESCRIPTION
We encountered an issue where the `build/manifest.json` task was never generated if the `build/` dir did not exist prior to running `make dev`. It seems that `gulp.watch` fails if a watched dir does not exist. Create the dir explicitly first to resolve this.

This fix will need to be replicated in other repos that use h-assets, or we could move the file-watching code into a function in `@hypothesis/frontend-build` which handles this for us.

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1683278304439579