### PR TITLE
Improve transcript display and sync with current video timestamp

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -66,7 +66,7 @@ function TranscriptSegment({
       data-is-current={isCurrent}
       data-testid="segment"
     >
-      <button className="pr-5 hover:underline" onClick={() => onSelect()}>
+      <button className="pr-5 hover:underline" onClick={onSelect}>
         {formatTimestamp(time)}
       </button>
       <p className="basis-64 grow" data-testid="transcript-text">

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -67,7 +67,7 @@ function TranscriptSegment({
       data-is-current={isCurrent}
       data-testid="segment"
     >
-      <button className="w-20 hover:underline" onClick={() => onSelect()}>
+      <button className="pr-5 hover:underline" onClick={() => onSelect()}>
         {formatTimestamp(time)}
       </button>
       <p className="basis-64 grow" data-testid="transcript-text">

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -1,3 +1,13 @@
+import {
+  Scroll,
+  ScrollContainer,
+  ScrollContent,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { useEffect, useRef } from 'preact/hooks';
+
+import { formatTimestamp } from '../utils/time';
+
 export type Segment = {
   /**
    * True if this segment corresponds to the section of the video that is
@@ -27,43 +37,141 @@ export type TranscriptProps = {
    * the start of the video.
    */
   currentTime: number;
+
+  /**
+   * Callback invoked when the user selects a segment from the transcript.
+   */
+  onSelectSegment?: (segment: Segment) => void;
 };
 
 type TranscriptSegmentProps = {
   isCurrent: boolean;
+  onSelect: () => void;
   time: number;
   text: string;
 };
 
-function TranscriptSegment({ time, text }: TranscriptSegmentProps) {
-  // TODO - Use appropriate semantic elements here
+function TranscriptSegment({
+  isCurrent,
+  onSelect,
+  time,
+  text,
+}: TranscriptSegmentProps) {
   return (
-    <div>
-      <div>{time}</div>
-      <p>{text}</p>
-    </div>
+    <li
+      className={classnames(
+        'flex flex-row p-1 hover:text-black',
+        isCurrent && 'bg-grey-2',
+        !isCurrent && 'text-grey-6'
+      )}
+      data-is-current={isCurrent}
+      data-testid="segment"
+    >
+      <button className="w-20 hover:underline" onClick={() => onSelect()}>
+        {formatTimestamp(time)}
+      </button>
+      <p className="basis-64 grow" data-testid="transcript-text">
+        {text}
+      </p>
+    </li>
   );
+}
+
+/**
+ * Return the offset of `element` from the top of a positioned ancestor `parent`.
+ *
+ * @param parent - Positioned ancestor of `element`
+ */
+function offsetRelativeTo(element: HTMLElement, parent: HTMLElement): number {
+  let offset = 0;
+  while (element !== parent && parent.contains(element)) {
+    offset += element.offsetTop;
+    element = element.offsetParent as HTMLElement;
+  }
+  return offset;
 }
 
 export default function Transcript({
   currentTime,
+  onSelectSegment,
   transcript,
 }: TranscriptProps) {
-  // TODO - Use appropriate semantic elements here
+  const scrollRef = useRef<HTMLElement | null>(null);
+
+  const currentIndex = transcript.segments.findIndex(
+    (segment, index) =>
+      currentTime >= segment.time &&
+      (index === transcript.segments.length - 1 ||
+        currentTime < transcript.segments[index + 1].time)
+  );
+
+  useEffect(() => {
+    const scrollContainer = scrollRef.current!;
+    const currentSegment = scrollContainer.querySelector(
+      '[data-is-current=true]'
+    ) as HTMLElement | null;
+    if (!currentSegment) {
+      return;
+    }
+
+    // Don't scroll the transcript container while the user is making a
+    // selection inside it, as this will likely cause the wrong text to be
+    // selected.
+    const selection = window.getSelection();
+    const selectedRange = selection?.rangeCount
+      ? selection.getRangeAt(0)
+      : null;
+    if (
+      selectedRange &&
+      !selectedRange.collapsed &&
+      scrollContainer.contains(selectedRange.startContainer)
+    ) {
+      return;
+    }
+
+    // Scroll container such that the middle of the current segment is centered
+    // in the container. Note that we don't use `currentSegment.scrollIntoView`
+    // here because that may scroll the whole document, which we don't want.
+    const currentSegmentOffset = offsetRelativeTo(
+      currentSegment,
+      scrollContainer
+    );
+    const scrollTarget =
+      currentSegmentOffset +
+      currentSegment.clientHeight / 2 -
+      scrollContainer.clientHeight / 2;
+
+    scrollContainer.scrollTo({
+      left: 0,
+      top: scrollTarget,
+      behavior: 'smooth',
+    });
+  }, [currentIndex, transcript]);
+
   return (
-    <div>
-      {transcript.segments.map((segment, index) => (
-        <TranscriptSegment
-          key={index}
-          isCurrent={
-            currentTime >= segment.time &&
-            (index === transcript.segments.length - 1 ||
-              currentTime < transcript.segments[index + 1].time)
-          }
-          time={segment.time}
-          text={segment.text}
-        />
-      ))}
-    </div>
+    <ScrollContainer borderless>
+      <Scroll
+        classes={
+          // Make element positioned for use with `offsetRelativeTo`.
+          'relative'
+        }
+        data-testid="scroll-container"
+        elementRef={scrollRef}
+      >
+        <ScrollContent>
+          <ul>
+            {transcript.segments.map((segment, index) => (
+              <TranscriptSegment
+                key={index}
+                isCurrent={index === currentIndex}
+                onSelect={() => onSelectSegment?.(segment)}
+                time={segment.time}
+                text={segment.text}
+              />
+            ))}
+          </ul>
+        </ScrollContent>
+      </Scroll>
+    </ScrollContainer>
   );
 }

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -59,11 +59,10 @@ function TranscriptSegment({
 }: TranscriptSegmentProps) {
   return (
     <li
-      className={classnames(
-        'flex flex-row p-1 hover:text-black',
-        isCurrent && 'bg-grey-2',
-        !isCurrent && 'text-grey-6'
-      )}
+      className={classnames('flex flex-row p-1 hover:text-black', {
+        'bg-grey-2': isCurrent,
+        'text-grey-6': !isCurrent,
+      })}
       data-is-current={isCurrent}
       data-testid="segment"
     >

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,4 +1,4 @@
-import { Button, Input } from '@hypothesis/frontend-shared';
+import { Button } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
 import HypothesisClient from './HypothesisClient';
@@ -30,24 +30,32 @@ export default function VideoPlayerApp({
   const [playing, setPlaying] = useState(false);
 
   return (
-    <div className="w-full">
-      <YouTubeVideoPlayer
-        videoId={videoId}
-        play={playing}
-        time={timestamp}
-        onPlayingChanged={setPlaying}
-        onTimeChanged={setTimestamp}
-      />
-      <Button onClick={() => setPlaying(playing => !playing)}>
-        {playing ? 'Pause' : 'Play'}
-      </Button>
-      <Input
-        value={timestamp}
-        onChange={e =>
-          setTimestamp(parseInt((e.target as HTMLInputElement).value))
-        }
-      />
-      <Transcript transcript={transcript} currentTime={timestamp} />
+    <div className="w-full flex flex-row m-2">
+      <div className="mr-2">
+        <YouTubeVideoPlayer
+          videoId={videoId}
+          play={playing}
+          time={timestamp}
+          onPlayingChanged={setPlaying}
+          onTimeChanged={setTimestamp}
+        />
+      </div>
+      <div className="w-2/5 h-[80vh] bg-grey-0 border border-grey-3">
+        <div className="p-1 bg-grey-1 border-b border-grey-3">
+          <Button
+            classes="text-xl"
+            onClick={() => setPlaying(playing => !playing)}
+            data-testid="play-button"
+          >
+            {playing ? '⏸' : '⏵'}
+          </Button>
+        </div>
+        <Transcript
+          transcript={transcript}
+          currentTime={timestamp}
+          onSelectSegment={segment => setTimestamp(segment.time)}
+        />
+      </div>
       <HypothesisClient src={clientSrc} config={clientConfig} />
     </div>
   );

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -1,0 +1,106 @@
+import { mount } from 'enzyme';
+
+import Transcript from '../Transcript';
+
+describe('Transcript', () => {
+  const transcript = {
+    segments: [
+      {
+        time: 5,
+        text: 'Hello and welcome',
+      },
+      {
+        time: 10,
+        text: 'To this video about',
+      },
+      {
+        time: 20,
+        text: 'how to use Hypothesis',
+      },
+    ],
+  };
+
+  it('renders segments', () => {
+    const wrapper = mount(
+      <Transcript transcript={transcript} currentTime={5} />
+    );
+    const segments = wrapper.find('[data-testid="segment"]');
+    assert.equal(segments.length, 3);
+
+    assert.equal(segments.at(0).text(), '0:05Hello and welcome');
+    assert.isTrue(segments.at(0).prop('data-is-current'));
+
+    assert.equal(segments.at(1).text(), '0:10To this video about');
+    assert.isFalse(segments.at(1).prop('data-is-current'));
+
+    assert.equal(segments.at(2).text(), '0:20how to use Hypothesis');
+    assert.isFalse(segments.at(2).prop('data-is-current'));
+  });
+
+  it('renders segments if none is current', () => {
+    const wrapper = mount(
+      <Transcript transcript={transcript} currentTime={0} />
+    );
+    const segments = wrapper.find('[data-testid="segment"]');
+    assert.isFalse(segments.at(0).prop('data-is-current'));
+  });
+
+  it('invokes callback when segment is clicked', () => {
+    const selectSegment = sinon.stub();
+    const wrapper = mount(
+      <Transcript
+        transcript={transcript}
+        currentTime={5}
+        onSelectSegment={selectSegment}
+      />
+    );
+    const timestamp = wrapper
+      .find('[data-testid="segment"]')
+      .at(1)
+      .find('button');
+
+    timestamp.simulate('click');
+
+    assert.calledWith(selectSegment, transcript.segments[1]);
+  });
+
+  it('scrolls current segment into view', () => {
+    const wrapper = mount(
+      <Transcript transcript={transcript} currentTime={5} />
+    );
+    const scrollContainer = wrapper.find('div[data-testid="scroll-container"]');
+    const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+
+    wrapper.setProps({ currentTime: 10 });
+
+    assert.calledWith(scrollTo, {
+      left: 0,
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('does not scroll transcript while user is selecting text', () => {
+    const wrapper = mount(
+      <Transcript transcript={transcript} currentTime={5} />,
+      {
+        attachTo: document.body,
+      }
+    );
+    try {
+      const scrollContainer = wrapper.find(
+        'div[data-testid="scroll-container"]'
+      );
+      const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+
+      const segment = wrapper.find('[data-testid="segment"]').at(1);
+      window.getSelection().selectAllChildren(segment.getDOMNode());
+
+      wrapper.setProps({ currentTime: 10 });
+
+      assert.notCalled(scrollTo);
+    } finally {
+      wrapper.unmount();
+    }
+  });
+});

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -1,0 +1,103 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import VideoPlayerApp from '../VideoPlayerApp';
+
+describe('VideoPlayerApp', () => {
+  const transcriptData = {
+    segments: [
+      {
+        time: 0,
+        text: 'Hello',
+      },
+      {
+        time: 5,
+        text: 'World',
+      },
+    ],
+  };
+
+  it('plays and pauses video', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    let player = wrapper.find('YouTubeVideoPlayer');
+    assert.isFalse(player.prop('play'));
+
+    const playButton = wrapper.find('button[data-testid="play-button"]');
+    assert.equal(playButton.text(), '⏵');
+
+    playButton.simulate('click');
+
+    player = wrapper.find('YouTubeVideoPlayer');
+    assert.isTrue(player.prop('play'));
+    assert.equal(playButton.text(), '⏸');
+  });
+
+  it('updates play/pause button when player is paused', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    act(() => {
+      wrapper.find('YouTubeVideoPlayer').prop('onPlayingChanged')(true);
+    });
+    wrapper.update();
+
+    const playButton = wrapper.find('button[data-testid="play-button"]');
+    assert.equal(playButton.text(), '⏸');
+
+    act(() => {
+      wrapper.find('YouTubeVideoPlayer').prop('onPlayingChanged')(false);
+    });
+    wrapper.update();
+    assert.equal(playButton.text(), '⏵');
+  });
+
+  it('syncs timestamp from player to transcript', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    act(() => {
+      wrapper.find('YouTubeVideoPlayer').prop('onTimeChanged')(20);
+    });
+    wrapper.update();
+
+    const transcript = wrapper.find('Transcript');
+    assert.equal(transcript.prop('currentTime'), 20);
+  });
+
+  it('updates player time when transcript segment is selected', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    act(() => {
+      wrapper.find('Transcript').prop('onSelectSegment')(
+        transcriptData.segments[1]
+      );
+    });
+    wrapper.update();
+
+    const player = wrapper.find('YouTubeVideoPlayer');
+    assert.equal(player.prop('time'), transcriptData.segments[1].time);
+  });
+});

--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -3,6 +3,7 @@ import { render } from 'preact';
 // Enable debugging checks and devtools. Removed in prod builds by Rollup config.
 import 'preact/debug';
 
+import type { TranscriptData } from './components/Transcript';
 import VideoPlayerApp from './components/VideoPlayerApp';
 import { readConfig } from './config';
 
@@ -15,9 +16,22 @@ export function init() {
   const {
     client_config: clientConfig,
     client_src: clientSrc,
-    transcript,
+
+    // Ignored until backend is able to provide real transcript data.
+    // transcript,
+
     video_id: videoId,
   } = readConfig();
+
+  // Generate fake transcript for testing.
+  const transcript: TranscriptData = { segments: [] };
+  for (let i = 0; i < 20; i++) {
+    transcript.segments.push({
+      isCurrent: false,
+      time: i * 15,
+      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    });
+  }
 
   render(
     <VideoPlayerApp

--- a/via/static/scripts/video_player/utils/test/time-test.js
+++ b/via/static/scripts/video_player/utils/test/time-test.js
@@ -1,0 +1,24 @@
+import { formatTimestamp } from '../time';
+
+describe('formatTimestamp', () => {
+  it('formats durations under one hour as m:ss', () => {
+    assert.equal(formatTimestamp(30), '0:30');
+    assert.equal(formatTimestamp(96), '1:36');
+    assert.equal(formatTimestamp(96.35), '1:36');
+    assert.equal(formatTimestamp(620), '10:20');
+    assert.equal(formatTimestamp(59 * 60 + 59), '59:59');
+  });
+
+  it('formats durations over one hour as h:mm:ss', () => {
+    assert.equal(formatTimestamp(60 * 60), '1:00:00');
+    assert.equal(formatTimestamp(60 * 60 + 123), '1:02:03');
+    assert.equal(formatTimestamp(10 * 60 * 60), '10:00:00');
+    assert.equal(formatTimestamp(100 * 60 * 60), '100:00:00');
+  });
+
+  it('formats invalid timestamps', () => {
+    assert.equal(formatTimestamp(NaN), '');
+    assert.equal(formatTimestamp(-1), '');
+    assert.equal(formatTimestamp(Infinity), '');
+  });
+});

--- a/via/static/scripts/video_player/utils/time.ts
+++ b/via/static/scripts/video_player/utils/time.ts
@@ -1,0 +1,27 @@
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+/**
+ * Format a video timestamp.
+ *
+ * The timestamp is formatted as `m:ss` for times < 1 hour or `h:mm:ss` for
+ * times over 1 hour. This matches how transcript timestamps are formatted on
+ * youtube.com.
+ *
+ * @param time - Time in seconds since the start of the video
+ */
+export function formatTimestamp(time: number): string {
+  if (!isFinite(time) || time < 0) {
+    return '';
+  }
+  const totalSeconds = Math.floor(time);
+  const hours = Math.floor(totalSeconds / (60 * 60));
+  const mins = Math.floor(totalSeconds / 60) % 60;
+  const secs = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${pad(mins)}:${pad(secs)}`;
+  } else {
+    return `${mins}:${pad(secs)}`;
+  }
+}


### PR DESCRIPTION
This PR starts work on getting the transcript to display alongside of the video in a scrollable container, per current designs, highlight and scroll to the segment matching the current timestamp, and navigate the video when clicking on timestamps in the transcript.

Please consider the visual design and UX details preliminary. The main focus is to get the transcript scrolling, syncing and timestamps in. Also the timestamps in the transcript appear in the annotation quotes / selected text at present. We'll probably want to remove those in future.

**Changes:**

 - Add dummy transcript data that will allow testing of transcript annotation, scrolling and syncing
 - Align the video, transcript and client in a three-column vertical layout, and make the transcript container scrollable.
 - Format timestamps in the transcript in `m:ss` or `h:mm:ss` strings. This format is intentionally more compact than what docdrop.org uses and matches youtube.com
 - Highlight the segment of the transcript that corresponds to the current video timestamp, and smoothly scroll it into view if needed.
 - Increase the contrast of hovered non-current transcript text segments, to make text selection easier.
 - Support navigating the video by clicking on timestamps in the transcript. We intentionally do not scroll when clicking the transcript text, as I felt that was disruptive to watching the video. This is something we might change.

**Testing:**

1. Go to http://localhost:9083/video/KxxuA3faFW8
2. Click on the video to start playing. The playing/paused state should be reflected in the control bar above the transcript
3. Click on the Play/Pause button in the control bar. The video should play/pause.
4. As the video plays, the transcript segment corresponding to the current video time should be highlighted.
5. Move the video playback to a different point. The segment highlighting should update, _but only when the video starts playing from the new position_ (this is due to limitations of the player API).
6. Click on a timestamp in a segment. The video player should move to that timestamp.
7. As the video plays, the transcript container should scroll so that the current segment is centered in the container, unless there is a text selection in the container, to avoid disrupting the user while selecting text to annotate or copy.

**Preview:**

<img width="1229" alt="Screenshot 2023-05-15 at 11 08 03" src="https://github.com/hypothesis/via/assets/2458/88dcd9f5-cbf7-4f71-b5a9-bb007da66053">
