### PR TITLE
Add Sync button for scrolling transcript to current segment

### DIFF
--- a/via/static/scripts/test-util/mock-imported-components.ts
+++ b/via/static/scripts/test-util/mock-imported-components.ts
@@ -1,0 +1,80 @@
+import type { FunctionComponent } from 'preact';
+
+/**
+ * Return true if an imported `value` "looks like" a Preact function component.
+ *
+ * This check can have false positives (ie. match values which are not really components).
+ * That's OK because typical usage in a test is to first mock all components with
+ * `$imports.$mock(mockImportedComponents())` and then mock other things with
+ * `$imports.$mock(...)`. The more specific mocks will override the generic
+ * component mocks.
+ */
+function isComponent(value: unknown) {
+  return (
+    typeof value === 'function' &&
+    value.name.match(/^[A-Z]/) &&
+    // Check that function is not an ES class. Note this only works with real
+    // ES classes and may not work with ones transpiled to ES5.
+    !value.toString().match(/^class\b/)
+  );
+}
+
+/**
+ * Return the display name of a component, minus the names of any wrappers
+ * (eg. `withServices(OriginalName)` becomes `OriginalName`).
+ *
+ * @param component - A Preact component
+ */
+function getDisplayName(component: FunctionComponent): string {
+  let displayName =
+    component.displayName || component.name || 'UnknownComponent';
+
+  const wrappedComponentMatch = displayName.match(/\([A-Z][A-Za-z0-9]+\)/);
+  if (wrappedComponentMatch) {
+    displayName = wrappedComponentMatch[0].slice(1, -1);
+  }
+
+  return displayName;
+}
+
+/**
+ * Helper for use with `babel-plugin-mockable-imports` that mocks components
+ * imported by a file. This will only mock components that are local to the
+ * package; it will not mock external components. This is to aid in catching
+ * integration issues, at the slight cost of unit isolation.
+ *
+ * Mocked components will have the same display name as the original component,
+ * minus any wrappers (eg. `Widget` and `withServices(Widget)` both become
+ * `Widget`). They will render only their children, as if they were just a
+ * `Fragment`.
+ *
+ * @example
+ *   import ComponentUnderTest, { $imports } from '../component-under-test';
+ *
+ *   beforeEach(() => {
+ *     $imports.$mock(mockImportedComponents());
+ *
+ *     // Add additional mocks or overrides here.
+ *   });
+ *
+ *   afterEach(() => {
+ *     $imports.$restore();
+ *   });
+ *
+ * @return A function that can be passed to `$imports.$mock`.
+ */
+export function mockImportedComponents() {
+  return (source: string, symbol: string, value: unknown) => {
+    if (!isComponent(value) || !source.startsWith('.')) {
+      return null;
+    }
+
+    const mock = (props: any) => props.children;
+
+    // Make it possible to do `wrapper.find('ComponentName')` where `wrapper`
+    // is an Enzyme wrapper.
+    mock.displayName = getDisplayName(value as FunctionComponent);
+
+    return mock;
+  };
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@hypothesis/frontend-shared';
-import { useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 
 import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
-import type { TranscriptData } from './Transcript';
+import type { TranscriptControls, TranscriptData } from './Transcript';
 import YouTubeVideoPlayer from './YouTubeVideoPlayer';
 
 export type VideoPlayerAppProps = {
@@ -28,6 +28,7 @@ export default function VideoPlayerApp({
   // Current play time of the video, in seconds since the start.
   const [timestamp, setTimestamp] = useState(0);
   const [playing, setPlaying] = useState(false);
+  const transcriptControls = useRef<TranscriptControls | null>(null);
 
   return (
     <div className="w-full flex flex-row m-2">
@@ -41,7 +42,7 @@ export default function VideoPlayerApp({
         />
       </div>
       <div className="w-2/5 h-[80vh] bg-grey-0 border border-grey-3">
-        <div className="p-1 bg-grey-1 border-b border-grey-3">
+        <div className="p-1 bg-grey-1 border-b border-grey-3 flex flex-row">
           <Button
             classes="text-xl"
             onClick={() => setPlaying(playing => !playing)}
@@ -49,9 +50,16 @@ export default function VideoPlayerApp({
           >
             {playing ? '⏸' : '⏵'}
           </Button>
+          <Button
+            onClick={() => transcriptControls.current!.scrollToCurrentSegment()}
+            data-testid="sync-button"
+          >
+            Sync
+          </Button>
         </div>
         <Transcript
           transcript={transcript}
+          controlsRef={transcriptControls}
           currentTime={timestamp}
           onSelectSegment={segment => setTimestamp(segment.time)}
         />

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -103,4 +103,26 @@ describe('Transcript', () => {
       wrapper.unmount();
     }
   });
+
+  it("scrolls transcript when controller's `scrollToCurrentSegment` method is called", () => {
+    const controlsRef = { current: null };
+    const wrapper = mount(
+      <Transcript
+        controlsRef={controlsRef}
+        transcript={transcript}
+        currentTime={5}
+      />
+    );
+    const scrollContainer = wrapper.find('div[data-testid="scroll-container"]');
+    const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+
+    assert.ok(controlsRef.current);
+    controlsRef.current.scrollToCurrentSegment();
+
+    assert.calledWith(scrollTo, {
+      left: 0,
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
 });

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -100,4 +100,22 @@ describe('VideoPlayerApp', () => {
     const player = wrapper.find('YouTubeVideoPlayer');
     assert.equal(player.prop('time'), transcriptData.segments[1].time);
   });
+
+  it('scrolls current transcript segment into view when "Sync" button is clicked', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    const transcriptController = wrapper.find('Transcript').prop('controlsRef');
+    assert.ok(transcriptController.current);
+    sinon.spy(transcriptController.current, 'scrollToCurrentSegment');
+
+    wrapper.find('button[data-testid="sync-button"]').simulate('click');
+
+    assert.calledOnce(transcriptController.current.scrollToCurrentSegment);
+  });
 });

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -1,7 +1,9 @@
 import { mount } from 'enzyme';
+import { useImperativeHandle } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 
-import VideoPlayerApp from '../VideoPlayerApp';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import VideoPlayerApp, { $imports } from '../VideoPlayerApp';
 
 describe('VideoPlayerApp', () => {
   const transcriptData = {
@@ -16,6 +18,29 @@ describe('VideoPlayerApp', () => {
       },
     ],
   };
+
+  function FakeTranscript({ controlsRef }) {
+    useImperativeHandle(
+      controlsRef,
+      () => ({
+        scrollToCurrentSegment: sinon.stub(),
+      }),
+      []
+    );
+    return <div />;
+  }
+  FakeTranscript.displayName = 'Transcript';
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      './Transcript': FakeTranscript,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
 
   it('plays and pauses video', () => {
     const wrapper = mount(
@@ -112,7 +137,6 @@ describe('VideoPlayerApp', () => {
     );
     const transcriptController = wrapper.find('Transcript').prop('controlsRef');
     assert.ok(transcriptController.current);
-    sinon.spy(transcriptController.current, 'scrollToCurrentSegment');
 
     wrapper.find('button[data-testid="sync-button"]').simulate('click');
 

--- a/via/static/scripts/video_player/utils/test/youtube-test.js
+++ b/via/static/scripts/video_player/utils/test/youtube-test.js
@@ -10,7 +10,7 @@ describe('loadYouTubeIFrameAPI', () => {
       ready: callback => setTimeout(() => callback(), 0),
       Player: sinon.stub(),
     };
-    return window.PT;
+    return window.YT;
   }
 
   it('adds YouTube IFrame API script to page', async () => {


### PR DESCRIPTION
This provides a way for the user to scroll the transcript back to the current segment, if they have manually scrolled it to a different location while the video is paused.

[Docdrop's video player](https://docdrop.org/video/G99TR_9KF4E/) and the mocks at https://hypothesis-video-transcriptions.netlify.app/ have the same toolbar button. A known issue in this PR is that the button doesn't have an icon like it does in these prototypes. That will come later.

**Testing:**

1. Go to http://localhost:9083/video/KxxuA3faFW8
2. Scroll the transcript list manually until the current segment is no longer in view
3. Click the "Sync" button in the toolbar. The current segment should be scrolled back into view.

<img width="1171" alt="Sync button" src="https://github.com/hypothesis/via/assets/2458/f66ced28-da15-47ff-92ca-ec91ab6f1f51">
