### PR TITLE
Ensure border on scrolling transcript doesn't get cut off

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -41,8 +41,8 @@ export default function VideoPlayerApp({
           onTimeChanged={setTimestamp}
         />
       </div>
-      <div className="w-2/5 h-[80vh] bg-grey-0 border border-grey-3">
-        <div className="p-1 bg-grey-1 border-b border-grey-3 flex flex-row">
+      <div className="w-2/5 h-[80vh] flex flex-col bg-grey-0 border">
+        <div className="p-1 bg-grey-1 border-b flex flex-row">
           <Button
             classes="text-xl"
             onClick={() => setPlaying(playing => !playing)}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -41,7 +41,7 @@ export default function VideoPlayerApp({
           onTimeChanged={setTimestamp}
         />
       </div>
-      <div className="w-2/5 h-[80vh] flex flex-col bg-grey-0 border">
+      <div className="w-2/5 h-[90vh] flex flex-col bg-grey-0 border">
         <div className="p-1 bg-grey-1 border-b flex flex-row">
           <Button
             classes="text-xl"


### PR DESCRIPTION
Contain element with height of 80vh with a flex-column layout. This will prevent the bottom of the border on the transcript from disappearing.

Oh! It does occur to me to ask what the purpose is of constraining that element to 80vh, but we can tackle that separately!

Before:

<img width="875" alt="image" src="https://github.com/hypothesis/via/assets/439947/ea59eceb-e05c-42fc-aff8-615457552150">


After:

<img width="881" alt="image" src="https://github.com/hypothesis/via/assets/439947/fb9f83af-6168-458b-bcb3-c604759931ce">


Also, just for style elimination: default border color should be `grey-3` without having to set; I removed the border-color styles there because they were right in front of me :).