### PR TITLE
Use undocumented `onVideoProgress` event to detect video progress changes

### DIFF
--- a/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
@@ -92,6 +92,8 @@ export default function YouTubeVideoPlayer({
 
   const playerController = useRef<YT.Player>();
 
+  // Capture last-seen values of props so we can invoke callbacks without
+  // re-running effects when they change.
   const onPlayingChangedCallback = useRef<(playing: boolean) => void>();
   onPlayingChangedCallback.current = onPlayingChanged;
 


### PR DESCRIPTION
Instead of polling the player every second to get the current timestamp, use the undocumented `onVideoProgress` event that the player emits as it plays. This event has the advantage of being emitted immediately when the user manually seeks the video, whereas the previous approach only synced the transcript once the video had played for a second after beeing seeked.

I [filed an issue with YouTube](https://issuetracker.google.com/issues/283097094) to confirm that this API is something we can continue to rely on. If it ever gets removed, we'll have to go back to polling. There are some major sites (eg. [Khan Academy](https://www.khanacademy.org/math/linear-algebra/matrix-transformations/linear-transformations/v/a-more-formal-understanding-of-functions)) that use YouTube's player and need the same functionality, so I don't think this is too risky.

**Testing:**

1. Go to http://localhost:9083/video/KxxuA3faFW8
2. Start playing the video
3. Pause the video and seek to a different location using the progress bar inside the player

On main, the transcript will not update to reflect the new position until after the video starts playing again. On this branch it will update immediately.