### PR TITLE
Add initial version of search bar to video player

### DIFF
--- a/via/static/scripts/types/css-custom-highlights.d.ts
+++ b/via/static/scripts/types/css-custom-highlights.d.ts
@@ -1,0 +1,18 @@
+// Types for the CSS Custom Highlight API.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API.
+
+declare class Highlight {
+  constructor(...ranges: Range[]);
+  add(r: Range): void;
+  delete(r: Range): void;
+}
+
+interface HighlightsRegistry {
+  delete(name: string): void;
+  set(name: string, highlight: Highlight): void;
+}
+
+declare namespace CSS {
+  let highlights: HighlightsRegistry;
+}

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -105,8 +105,8 @@ function TranscriptSegment({
       // FIXME - If the Hypothesis client has inserted highlights, these will
       // break up the single text node child into multiple children.
       if (textNode instanceof Text && textNode.length >= end) {
-        range.setStart(contentRef.current!.childNodes[0], start);
-        range.setEnd(contentRef.current!.childNodes[0], end);
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
       }
 
       return range;

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@hypothesis/frontend-shared';
+import { Button, Input } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
 import type { TranscriptData } from '../utils/transcript';
@@ -31,6 +31,8 @@ export default function VideoPlayerApp({
   const [playing, setPlaying] = useState(false);
   const transcriptControls = useRef<TranscriptControls | null>(null);
 
+  const [filter, setFilter] = useState('');
+
   return (
     <div className="w-full flex flex-row m-2">
       <div className="mr-2">
@@ -57,11 +59,21 @@ export default function VideoPlayerApp({
           >
             Sync
           </Button>
+          <div className="flex-grow" />
+          <Input
+            aria-label="Filter transcript"
+            data-testid="filter-input"
+            onInput={e =>
+              setFilter((e.target as HTMLInputElement).value.trim())
+            }
+            placeholder="Search..."
+          />
         </div>
         <Transcript
           transcript={transcript}
           controlsRef={transcriptControls}
           currentTime={timestamp}
+          filter={filter}
           onSelectSegment={segment => setTimestamp(segment.start)}
         />
       </div>

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -142,4 +142,22 @@ describe('VideoPlayerApp', () => {
 
     assert.calledOnce(transcriptController.current.scrollToCurrentSegment);
   });
+
+  it('filters transcript when typing in search field', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    const input = wrapper.find('input[data-testid="filter-input"]');
+
+    input.getDOMNode().value = 'foobar';
+    input.simulate('input');
+
+    const transcript = wrapper.find('Transcript');
+    assert.equal(transcript.prop('filter'), 'foobar');
+  });
 });

--- a/via/static/scripts/video_player/utils/test/transcript-test.js
+++ b/via/static/scripts/video_player/utils/test/transcript-test.js
@@ -1,0 +1,20 @@
+import { sampleTranscript } from '../../sample-transcript';
+import { filterTranscript } from '../transcript';
+
+describe('filterTranscript', () => {
+  it('returns matching segments and offsets', () => {
+    const query = 'Nintendo 64';
+
+    const segmentMatches = filterTranscript(sampleTranscript, query);
+
+    assert.equal(segmentMatches.size, 5);
+    for (const [index, matches] of segmentMatches.entries()) {
+      const text = sampleTranscript[index].text;
+      assert.include(text.toLowerCase(), query.toLowerCase());
+      assert.notEqual(matches.length, 0);
+      for (const { start, end } of matches) {
+        assert.equal(text.slice(start, end).toLowerCase(), query.toLowerCase());
+      }
+    }
+  });
+});

--- a/via/static/scripts/video_player/utils/transcript.ts
+++ b/via/static/scripts/video_player/utils/transcript.ts
@@ -15,3 +15,53 @@ export type Segment = {
 export type TranscriptData = {
   segments: Segment[];
 };
+
+/**
+ * Escape characters in `str` which have a special meaning in a regex pattern.
+ *
+ * Taken from https://stackoverflow.com/a/6969486.
+ */
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+/**
+ * Location of a query match within the text of a segment.
+ */
+export type MatchOffset = {
+  start: number;
+  end: number;
+};
+
+/** Perform a case-insensitive search for `query` in `text`. */
+function findMatches(text: string, query: string): Array<MatchOffset> {
+  const pattern = new RegExp(escapeRegExp(query), 'ig');
+  const matches: MatchOffset[] = [];
+
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    matches.push({ start: match.index, end: match.index + match[0].length });
+  }
+
+  return matches;
+}
+
+/**
+ * Filter a transcript against a user-supplied query.
+ *
+ * Returns a map of indices of matching segments to locations of match within
+ * the segment.
+ */
+export function filterTranscript(
+  transcript: Segment[],
+  query: string
+): Map<number, MatchOffset[]> {
+  const result = new Map<number, MatchOffset[]>();
+  for (const [index, segment] of transcript.entries()) {
+    const matches = findMatches(segment.text, query);
+    if (matches.length > 0) {
+      result.set(index, matches);
+    }
+  }
+  return result;
+}

--- a/via/static/styles/video_player.css
+++ b/via/static/styles/video_player.css
@@ -5,3 +5,7 @@ CSS entry point for the video player app.
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+p::highlight(transcript-filter-match) {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Add an initial version of a search bar to the video player. This filters the transcript to segments whose text matches the current filter. Additionally the current segment is always displayed, so the user can more easily tell where the current video place is relative to the video segments that are visible.

If the browser supports the [CSS Custom Highlights API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) (currently only Chrome), that is used to underline matching spans in segments in a way that doesn't interfere with highlights inserted by the Hypothesis client. In other browsers the matching segments are displayed with no underlines. There is a known issue that these highlights may not display in segments that also have Hypothesis highlights.

<img width="1238" alt="Search bar preview" src="https://github.com/hypothesis/via/assets/2458/b699eca8-923f-495c-8b14-12be919e02d3">
