### PR TITLE
Exclude timestamps from selected text in transcripts

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -118,6 +118,8 @@ function TranscriptSegment({
     };
   }, [highlight, matches]);
 
+  const timestamp = formatTimestamp(time);
+
   return (
     <li
       className={classnames('flex flex-row p-1 hover:text-black', {
@@ -129,8 +131,10 @@ function TranscriptSegment({
       data-testid="segment"
     >
       <button
+        aria-label={timestamp}
+        onClick={onSelect}
         className={classnames(
-          'pr-5 hover:underline',
+          'pr-2 mr-3 hover:underline',
 
           // Workaround for a Firefox issue that prevented annotating across
           // multiple segments [1]. Buttons have a default `user-select: none`
@@ -140,18 +144,33 @@ function TranscriptSegment({
           //
           // [1] https://github.com/hypothesis/via/issues/930
           // [2] https://github.com/hypothesis/client/issues/5485
-          'select-text'
+          'select-text',
+
+          // The timestamp is rendered using a CSS ::before pseudo-element
+          // so that it does not appear in the selection captured by the Hypothesis
+          // client, when creating an annotation that spans multiple segments.
+          //
+          // We use a combination of padding and margin to create the space
+          // between the timestamp and transcript. The padding region enlarges
+          // the clickable area of the timestamp button. The margin region enlarges
+          // the area in which a user can start a selection of the transcript text.
+          // Without it selecting the left edge of the transcript is fiddly.
+          'before:content-[attr(data-timestamp)]'
         )}
-        onClick={onSelect}
-      >
-        {formatTimestamp(time)}
-      </button>
+        data-timestamp={timestamp}
+      />
       <p
         className="basis-64 grow"
         data-testid="transcript-text"
         ref={contentRef}
       >
         {text}
+        {
+          // Add a trailing space at the end of each segment to avoid the last
+          // word of a segment being joined with the first word of the next
+          // segment in annotation quotes.
+          ' '
+        }
       </p>
     </li>
   );

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -28,13 +28,13 @@ describe('Transcript', () => {
     const segments = wrapper.find('[data-testid="segment"]');
     assert.equal(segments.length, 3);
 
-    assert.equal(segments.at(0).text(), '0:05Hello and welcome');
+    assert.equal(segments.at(0).text(), 'Hello and welcome ');
     assert.isTrue(segments.at(0).prop('data-is-current'));
 
-    assert.equal(segments.at(1).text(), '0:10To this video about');
+    assert.equal(segments.at(1).text(), 'To this video about ');
     assert.isFalse(segments.at(1).prop('data-is-current'));
 
-    assert.equal(segments.at(2).text(), '0:20how to use Hypothesis');
+    assert.equal(segments.at(2).text(), 'how to use Hypothesis ');
     assert.isFalse(segments.at(2).prop('data-is-current'));
   });
 


### PR DESCRIPTION
This PR solves the problem of segment timestamps appearing in the middle of annotation quotes. The Hypothesis client creates quotes from the text content of the selected range (effectively `window.getSelection().getRangeAt(0).toString()`). Since timestamp "buttons" appear at the start of each segment in DOM layout order, this resulted in the timestamps appearing in the quotes, as well as the user-visible selection.

The approach taken here is to render formatted timestamps using a `::before` pseudo-element rather than the text content of timestamp `<button>`s. This way the timestamp text doesn't appear in the selected range's text, and hence doesn't get a selection background color or appear in annotation quotes or highlights.

An alternative approach would be to introduce some general mechanism in the client for excluding certain elements from the selection. For example maybe we could exclude all elements with a `user-select: none` style from the quote, or exclude elements with a certain `data-` attribute. We'd have to be careful about the impact of this on the wider web though.

**Testing:**

1. Go to http://localhost:9083/video/x8TO-nrUtSI
2. Make a selection that spans multiple lines of the transcript. The selection background should not include the timestamps.
3. Annotate the selected text. The timestamps at the start of each segment should not appear in the annotation quote in the sidebar or be highlighted.

<img width="585" alt="Exclude timestamps from selection" src="https://github.com/hypothesis/via/assets/2458/4e1701c2-d6ed-4536-89de-5ce85c6fd6ea">
