### PR TITLE
Clear transcript filter when scrolling a highlight into view

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,5 +1,5 @@
 import { Button, Input } from '@hypothesis/frontend-shared';
-import { useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import type { TranscriptData } from '../utils/transcript';
 import HypothesisClient from './HypothesisClient';
@@ -13,6 +13,22 @@ export type VideoPlayerAppProps = {
   clientConfig: object;
   transcript: TranscriptData;
 };
+
+/**
+ * Type of "scrolltorange" event emitted by the client when it is about to
+ * scroll a highlight into view.
+ */
+type ScrollToRangeEvent = CustomEvent<Range> & {
+  waitUntil(ready: Promise<void>): void;
+};
+
+function isScrollToRangeEvent(e: Event): e is ScrollToRangeEvent {
+  return (
+    e instanceof CustomEvent &&
+    'waitUntil' in e &&
+    typeof e.waitUntil === 'function'
+  );
+}
 
 /**
  * Video annotation application.
@@ -32,6 +48,42 @@ export default function VideoPlayerApp({
   const transcriptControls = useRef<TranscriptControls | null>(null);
 
   const [filter, setFilter] = useState('');
+  const trimmedFilter = useMemo(() => filter.trim(), [filter]);
+
+  // Listen for the event the Hypothesis client dispatches before it scrolls
+  // a highlight into view. If a filter is currently active, clear it first
+  // to ensure the highlight is visible.
+  const pendingRender = useRef<() => void>();
+  useEffect(() => {
+    if (trimmedFilter.length === 0) {
+      return () => {};
+    }
+
+    const listener = (e: Event) => {
+      setFilter('');
+
+      if (!isScrollToRangeEvent(e)) {
+        return;
+      }
+
+      // Make the client wait for the transcript to re-render after the clearing
+      // the filter, before it attempts to scroll the highlight into view.
+      const renderDone = new Promise<void>(
+        resolve => (pendingRender.current = resolve)
+      );
+      e.waitUntil(renderDone);
+    };
+    document.body.addEventListener('scrolltorange', listener);
+    return () => {
+      document.body.removeEventListener('scrolltorange', listener);
+    };
+  }, [trimmedFilter]);
+
+  // Notify Hypothesis client on next render after clearing a filter.
+  if (pendingRender.current) {
+    pendingRender.current();
+    pendingRender.current = undefined;
+  }
 
   return (
     <div className="w-full flex flex-row m-2">
@@ -61,19 +113,18 @@ export default function VideoPlayerApp({
           </Button>
           <div className="flex-grow" />
           <Input
-            aria-label="Filter transcript"
+            aria-label="Transcript filter"
             data-testid="filter-input"
-            onInput={e =>
-              setFilter((e.target as HTMLInputElement).value.trim())
-            }
+            onInput={e => setFilter((e.target as HTMLInputElement).value)}
             placeholder="Search..."
+            value={filter}
           />
         </div>
         <Transcript
           transcript={transcript}
           controlsRef={transcriptControls}
           currentTime={timestamp}
-          filter={filter}
+          filter={trimmedFilter}
           onSelectSegment={segment => setTimestamp(segment.start)}
         />
       </div>


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/5484**

The client's normal logic for scrolling a highlight into view does not work if the transcript segment is hidden due to a search filter being active. Listen for the `scrolltorange` event that the client emits before it scrolls a highlight into view and respond by clearing the filter.

We currently also then have to scroll the highlight into view ourselves, rather than let the client do it, because the client can currently only scroll to highlights that are visible immediately after the `scrolltorange` event is dispatched.

**Testing:**

Make sure you have https://github.com/hypothesis/client/pull/5484 checked out.

1. Go to http://localhost:9083/video/x8TO-nrUtSI
2. Annotate some text in the middle of the transcript
3. Enter a filter query in the search bar which does not match the text annotated in step (2)
4. Click the annotation card in the sidebar for the annotation created in step 2

In step 4, clicking the annotation card should cause the filter entered in step 3 to be cleared and the transcript should be scrolled to the location of the highlight.