### PR TITLE
Set play/pause button label explicitly

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -50,6 +50,7 @@ export default function VideoPlayerApp({
             classes="text-xl"
             onClick={() => setPlaying(playing => !playing)}
             data-testid="play-button"
+            title={playing ? 'Pause' : 'Play'}
           >
             {playing ? '⏸' : '⏵'}
           </Button>

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -54,14 +54,18 @@ describe('VideoPlayerApp', () => {
     let player = wrapper.find('YouTubeVideoPlayer');
     assert.isFalse(player.prop('play'));
 
-    const playButton = wrapper.find('button[data-testid="play-button"]');
+    let playButton = wrapper.find('button[data-testid="play-button"]');
     assert.equal(playButton.text(), '⏵');
+    assert.equal(playButton.prop('title'), 'Play');
 
     playButton.simulate('click');
 
     player = wrapper.find('YouTubeVideoPlayer');
     assert.isTrue(player.prop('play'));
+
+    playButton = wrapper.find('button[data-testid="play-button"]');
     assert.equal(playButton.text(), '⏸');
+    assert.equal(playButton.prop('title'), 'Pause');
   });
 
   it('updates play/pause button when player is paused', () => {


### PR DESCRIPTION
This ensures assistive technology can present a proper description for the button. The Unicode symbols that are currently used as "icons" for this button are read as eg. "right-pointing arrow" rather than "play".

<img width="588" alt="Play-pause buttons" src="https://github.com/hypothesis/via/assets/2458/6303f928-5215-4d98-a18d-a44391531e8e">

