### PR TITLE
Work around Firefox issue that prevented annotating across segments

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -128,7 +128,22 @@ function TranscriptSegment({
       data-is-current={isCurrent}
       data-testid="segment"
     >
-      <button className="pr-5 hover:underline" onClick={onSelect}>
+      <button
+        className={classnames(
+          'pr-5 hover:underline',
+
+          // Workaround for a Firefox issue that prevented annotating across
+          // multiple segments [1]. Buttons have a default `user-select: none`
+          // style in FF and selections that include elements with this style
+          // are split into multiple ranges. The Hypothesis client in turn only
+          // uses the first range from a selection (see [2]).
+          //
+          // [1] https://github.com/hypothesis/via/issues/930
+          // [2] https://github.com/hypothesis/client/issues/5485
+          'select-text'
+        )}
+        onClick={onSelect}
+      >
         {formatTimestamp(time)}
       </button>
       <p


### PR DESCRIPTION
The video player uses `<button>` elements for timestamps, and these have a default `user-select: none` style. This causes selections spanning multiple segments, which include these buttons, to be split into multiple ranges in Firefox. This FF behavior is not compliant with the Selection API spec, and the Hypothesis client currently doesn't handle it.

If a general solution is implemented in the client in future, we can remove this workaround.

Fixes https://github.com/hypothesis/via/issues/930