### PR TITLE
Add "Auto-scroll" checkbox to toggle automatic transcript scrolling

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -30,6 +30,12 @@ export type TranscriptControls = {
 };
 
 export type TranscriptProps = {
+  /**
+   * Whether to automatically scroll the transcript as the video plays to keep
+   * the segment corresponding to `currentTime` in view.
+   */
+  autoScroll?: boolean;
+
   transcript: TranscriptData;
 
   /**
@@ -191,6 +197,7 @@ function offsetRelativeTo(element: HTMLElement, parent: HTMLElement): number {
 }
 
 export default function Transcript({
+  autoScroll = true,
   controlsRef,
   currentTime,
   filter = '',
@@ -250,8 +257,10 @@ export default function Transcript({
   }, []);
 
   useEffect(() => {
-    scrollToCurrentSegment();
-  }, [currentIndex, transcript, scrollToCurrentSegment]);
+    if (autoScroll) {
+      scrollToCurrentSegment();
+    }
+  }, [autoScroll, currentIndex, transcript, scrollToCurrentSegment]);
 
   useImperativeHandle(
     controlsRef || { current: null },

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,4 +1,4 @@
-import { Button, Input } from '@hypothesis/frontend-shared';
+import { Button, Checkbox, Input } from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import type { TranscriptData } from '../utils/transcript';
@@ -44,6 +44,11 @@ export default function VideoPlayerApp({
 }: VideoPlayerAppProps) {
   // Current play time of the video, in seconds since the start.
   const [timestamp, setTimestamp] = useState(0);
+
+  // Whether transcript automatically scrolls to stay in sync with video
+  // position.
+  const [autoScroll, setAutoScroll] = useState(true);
+
   const [playing, setPlaying] = useState(false);
   const transcriptControls = useRef<TranscriptControls | null>(null);
 
@@ -122,12 +127,24 @@ export default function VideoPlayerApp({
           />
         </div>
         <Transcript
+          autoScroll={autoScroll}
           transcript={transcript}
           controlsRef={transcriptControls}
           currentTime={timestamp}
           filter={trimmedFilter}
           onSelectSegment={segment => setTimestamp(segment.start)}
         />
+        <div className="pl-2">
+          <Checkbox
+            checked={autoScroll}
+            data-testid="autoscroll-checkbox"
+            onChange={e =>
+              setAutoScroll((e.target as HTMLInputElement).checked)
+            }
+          >
+            <div className="p-2 select-none">Auto-scroll</div>
+          </Checkbox>
+        </div>
       </div>
       <HypothesisClient src={clientSrc} config={clientConfig} />
     </div>

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -81,6 +81,18 @@ describe('Transcript', () => {
     });
   });
 
+  it('does not scroll to current segment if `autoScroll` is disabled', () => {
+    const wrapper = mount(
+      <Transcript autoScroll={false} transcript={transcript} currentTime={5} />
+    );
+    const scrollContainer = wrapper.find('div[data-testid="scroll-container"]');
+    const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+
+    wrapper.setProps({ currentTime: 10 });
+
+    assert.notCalled(scrollTo);
+  });
+
   it('does not scroll transcript while user is selecting text', () => {
     const wrapper = mount(
       <Transcript transcript={transcript} currentTime={5} />,

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -215,4 +215,31 @@ describe('VideoPlayerApp', () => {
     // have the expected even type, the video player should ignore it.
     document.body.dispatchEvent(new Event('scrolltorange'));
   });
+
+  it('toggles automatic scrolling when "Auto-scroll" checkbox is changed', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+
+    const toggleAutoScroll = () => {
+      act(() => {
+        const input = wrapper.find('input[data-testid="autoscroll-checkbox"]');
+
+        input.getDOMNode().checked = !input.getDOMNode().checked;
+        input.simulate('change');
+      });
+      wrapper.update();
+    };
+
+    assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
+    toggleAutoScroll();
+    assert.isFalse(wrapper.find('Transcript').prop('autoScroll'));
+    toggleAutoScroll();
+    assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
+  });
 });


### PR DESCRIPTION
Add a checkbox to control whether the transcript automatically scrolls as the video plays. Turning this off is useful if the user wants to read ahead or back in the transcript while the video is playing.

The focus in this PR is adding the functionality. The location and styling is preliminary.

<img width="481" alt="auto-scroll checkbox" src="https://github.com/hypothesis/via/assets/2458/a90438bf-c64e-4548-829f-fb0b6aff0ecf">

**Testing:**

1. Go to http://localhost:9083/video/x8TO-nrUtSI
2. Auto-scroll should initially be enabled. The transcript should scroll as the video plays.
3. Toggling the checkbox off should prevent the auto-scroll behavior and allow the user to scroll up and down while the video is playing
4. Toggling the checkbox back on should re-enable auto-scrolling and immediately scroll to the current location