### PR TITLE
Add button to copy transcript in video player

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Input } from '@hypothesis/frontend-shared';
+import { Button, Checkbox, CopyIcon, Input } from '@hypothesis/frontend-shared';
 import {
   useCallback,
   useEffect,
@@ -8,6 +8,7 @@ import {
 } from 'preact/hooks';
 
 import type { TranscriptData } from '../utils/transcript';
+import { formatTranscript } from '../utils/transcript';
 import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
@@ -137,6 +138,16 @@ export default function VideoPlayerApp({
     };
   }, [syncTranscript]);
 
+  const copyTranscript = async () => {
+    const formattedTranscript = formatTranscript(transcript.segments);
+    try {
+      await navigator.clipboard.writeText(formattedTranscript);
+    } catch (err) {
+      // TODO: Replace this with a toast message in the UI.
+      console.warn('Failed to copy transcript', err);
+    }
+  };
+
   return (
     <div className="w-full flex flex-row m-2">
       <div className="mr-2">
@@ -181,6 +192,13 @@ export default function VideoPlayerApp({
               )}
             </Button>
             <div className="flex-grow" />
+            <Button
+              onClick={copyTranscript}
+              data-testid="copy-button"
+              title="Copy transcript"
+            >
+              <CopyIcon />
+            </Button>
             <Button
               onClick={syncTranscript}
               data-testid="sync-button"

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -97,6 +97,67 @@ describe('VideoPlayerApp', () => {
     assert.equal(playButton.text().trim(), 'Play');
   });
 
+  it('copies transcript to clipboard when "Copy" button is pressed', async () => {
+    const fakeClipboard = {
+      writeText: sinon.stub().resolves(),
+    };
+    const clipboardStub = sinon
+      .stub(navigator, 'clipboard')
+      .get(() => fakeClipboard);
+
+    try {
+      const wrapper = mount(
+        <VideoPlayerApp
+          videoId="1234"
+          clientSrc="https://dummy.hypothes.is/embed.js"
+          clientConfig={{}}
+          transcript={transcriptData}
+        />
+      );
+
+      await wrapper.find('button[data-testid="copy-button"]').prop('onClick')();
+
+      assert.calledWith(fakeClipboard.writeText, 'Hello\nWorld');
+    } finally {
+      clipboardStub.restore();
+    }
+  });
+
+  it('logs a warning if accessing clipboard fails', async () => {
+    const copyError = new Error('Not allowed');
+    const fakeClipboard = {
+      writeText: sinon.stub().rejects(copyError),
+    };
+    const clipboardStub = sinon
+      .stub(navigator, 'clipboard')
+      .get(() => fakeClipboard);
+    const warnStub = sinon.stub(console, 'warn');
+
+    try {
+      const wrapper = mount(
+        <VideoPlayerApp
+          videoId="1234"
+          clientSrc="https://dummy.hypothes.is/embed.js"
+          clientConfig={{}}
+          transcript={transcriptData}
+        />
+      );
+
+      try {
+        await wrapper
+          .find('button[data-testid="copy-button"]')
+          .prop('onClick')();
+      } catch {
+        /* ignored */
+      }
+
+      assert.calledWith(console.warn, 'Failed to copy transcript', copyError);
+    } finally {
+      clipboardStub.restore();
+      warnStub.restore();
+    }
+  });
+
   it('syncs timestamp from player to transcript', () => {
     const wrapper = mount(
       <VideoPlayerApp

--- a/via/static/scripts/video_player/utils/test/transcript-test.js
+++ b/via/static/scripts/video_player/utils/test/transcript-test.js
@@ -1,5 +1,5 @@
 import { sampleTranscript } from '../../sample-transcript';
-import { filterTranscript } from '../transcript';
+import { filterTranscript, formatTranscript } from '../transcript';
 
 describe('filterTranscript', () => {
   it('returns matching segments and offsets', () => {
@@ -16,5 +16,20 @@ describe('filterTranscript', () => {
         assert.equal(text.slice(start, end).toLowerCase(), query.toLowerCase());
       }
     }
+  });
+});
+
+describe('formatTranscript', () => {
+  it('concatenates text from segments', () => {
+    const shortTranscript = sampleTranscript.slice(0, 3);
+    const formatted = formatTranscript(shortTranscript);
+    assert.equal(
+      formatted,
+      `
+[Music]
+how many of you remember the first time
+you saw a playstation 1 game if you were
+`.trim()
+    );
   });
 });

--- a/via/static/scripts/video_player/utils/transcript.ts
+++ b/via/static/scripts/video_player/utils/transcript.ts
@@ -65,3 +65,10 @@ export function filterTranscript(
   }
   return result;
 }
+
+/**
+ * Format a transcript as plain text.
+ */
+export function formatTranscript(transcript: Segment[]): string {
+  return transcript.map(seg => seg.text).join('\n');
+}


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/via/pull/944**~~

Add a button to the video player toolbar to copy the video's transcript to the clipboard. This is based on the design in https://hypothesis-video-transcriptions.netlify.app and similar functionality in Docdrop's video player.

The implementation uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#browser_compatibility). Support for [_writing_](https://caniuse.com/async-clipboard) using this API is now supported widely enough that I think we can rely on it. Support for _reading_ is more limited according to caniuse.

Error handling is rather rudimentary. If the browser decides to reject the clipboard write for any reason, we just log a console warning. Ideally we'd show a toast message or something else instead so the user is aware the write failed.

**Preview:**

<img width="589" alt="Copy transcript button" src="https://github.com/hypothesis/via/assets/2458/6c583d56-92cf-4334-b402-c8749909b65e">
