### PR TITLE
Pause video playback when Hypothesis client scrolls to highlight

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -65,20 +65,22 @@ export default function VideoPlayerApp({
   const filterInputRef = useRef<HTMLInputElement>();
 
   // Listen for the event the Hypothesis client dispatches before it scrolls
-  // a highlight into view. If a filter is currently active, clear it first
-  // to ensure the highlight is visible.
+  // a highlight into view.
+  //
+  // - If a filter is currently active, clear it first to ensure the highlight
+  //   is visible.
+  // - Pause playback to prevent transcript quickly scrolling away from the
+  //   highlight back to the current location, if autoscroll is active.
   const pendingRender = useRef<() => void>();
   useEffect(() => {
-    if (trimmedFilter.length === 0) {
-      return () => {};
-    }
-
     const listener = (e: Event) => {
       setFilter('');
 
       if (!isScrollToRangeEvent(e)) {
         return;
       }
+
+      setPlaying(false);
 
       // Make the client wait for the transcript to re-render after the clearing
       // the filter, before it attempts to scroll the highlight into view.
@@ -91,7 +93,7 @@ export default function VideoPlayerApp({
     return () => {
       document.body.removeEventListener('scrolltorange', listener);
     };
-  }, [trimmedFilter]);
+  }, []);
 
   // Notify Hypothesis client on next render after clearing a filter.
   if (pendingRender.current) {

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -249,12 +249,12 @@ describe('VideoPlayerApp', () => {
 
     // Simulate event emitted by client before it scrolls a highlight, which
     // may be in a hidden segment, into view.
-    const scrollToRangeEvent = new CustomEvent('scrolltorange');
+    const event = new CustomEvent('scrolltorange');
     let ready;
-    scrollToRangeEvent.waitUntil = promise => {
+    event.waitUntil = promise => {
       ready = promise;
     };
-    document.body.dispatchEvent(scrollToRangeEvent);
+    document.body.dispatchEvent(event);
 
     // Wait for VideoPlayerApp to be re-rendered with filter cleared.
     assert.instanceOf(ready, Promise);
@@ -263,6 +263,28 @@ describe('VideoPlayerApp', () => {
     wrapper.update();
     const transcript = wrapper.find('Transcript');
     assert.equal(transcript.prop('filter'), '');
+  });
+
+  it('pauses playback when Hypothesis client scrolls to a highlight', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    wrapper.find('button[data-testid="play-button"]').simulate('click');
+
+    const event = new CustomEvent('scrolltorange');
+    event.waitUntil = () => {}; // Dummy
+    act(() => {
+      document.body.dispatchEvent(event);
+    });
+    wrapper.update();
+
+    const player = wrapper.find('YouTubeVideoPlayer');
+    assert.isFalse(player.prop('play'));
   });
 
   it('ignores "scrolltorange" events with wrong type', () => {


### PR DESCRIPTION
This prevents the video player from immediately scrolling away from the highlight back to wherever it is currently playing.

Fixes https://github.com/hypothesis/via/issues/947

**Testing:**

1. Go to a video (eg. http://localhost:9083/video/x8TO-nrUtSI)
2. Create an annotation somewhere in the transcript that is not near the start
3. Start playing the video. It will soon scroll back up to where the transcript is currently playing
4. Click the annotation card in the sidebar

At step (4), playback should pause and the transcript should scroll to the highlight.

The same behavior ought to happen if you click the up/down-pointing icons at the top/bottom of the bucket bar, but this is not happening due to a [client bug](https://github.com/hypothesis/client/issues/5505).