### PR TITLE
Fix scrolling to annotation, in video player, when there is no filter

### DIFF
--- a/via/static/scripts/video_player/utils/next-render.ts
+++ b/via/static/scripts/video_player/utils/next-render.ts
@@ -1,0 +1,44 @@
+import { useRef } from 'preact/hooks';
+
+export type NextRender = {
+  /** Return a promise which resolves after the next render of the current component. */
+  wait(): Promise<void>;
+};
+
+/**
+ * Hook which enables waiting until the next re-render of the current component
+ * completes.
+ *
+ * A simple timeout could be used instead, but this hook is designed to be
+ * robust to whatever approach is used to schedule renders (next microtask, next
+ * animation frame etc.) in the current environment.
+ */
+export function useNextRender(): NextRender {
+  const resolveNextRender = useRef<{
+    promise: Promise<void>;
+    resolve: () => void;
+  }>();
+
+  // Preact renders synchronously, so we can resolve the promise now and
+  // the DOM will be updated by the time any code waiting on the promise runs.
+  //
+  // If this wasn't the case, we'd have to use `useLayoutEffect` instead.
+  if (resolveNextRender.current) {
+    resolveNextRender.current.resolve();
+    resolveNextRender.current = undefined;
+  }
+
+  const controller = useRef({
+    wait() {
+      if (!resolveNextRender.current) {
+        let resolve = () => {}; // Dummy initializer to avoid TS error.
+        const promise = new Promise<void>(r => {
+          resolve = r;
+        });
+        resolveNextRender.current = { promise, resolve };
+      }
+      return resolveNextRender.current.promise;
+    },
+  });
+  return controller.current;
+}

--- a/via/static/scripts/video_player/utils/test/next-render-test.js
+++ b/via/static/scripts/video_player/utils/test/next-render-test.js
@@ -1,0 +1,48 @@
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+import { useNextRender } from '../next-render';
+
+describe('useNextRender', () => {
+  it('resolves promise after next render', async () => {
+    const container = document.createElement('div');
+    let nextRenderPromise;
+
+    function Widget() {
+      const [count, setCount] = useState(0);
+      const nextRender = useNextRender();
+      const onClick = () => {
+        setCount(c => c + 1);
+        nextRenderPromise = nextRender.wait();
+      };
+      return (
+        <button type="button" onClick={onClick}>
+          {count}
+        </button>
+      );
+    }
+
+    render(<Widget />, container);
+
+    const button = container.querySelector('button');
+    assert.equal(button.textContent, '0');
+
+    button.click();
+    const nextRender1 = nextRenderPromise;
+    await nextRender1;
+    assert.equal(button.textContent, '1');
+
+    // `nextRender.wait()` after a render create a new promise. Subsequent calls
+    // should return the same promise until the re-render completes.
+    button.click();
+    const nextRender2 = nextRenderPromise;
+    assert.notStrictEqual(nextRender1, nextRender2);
+    button.click();
+
+    const nextRender3 = nextRenderPromise;
+    assert.strictEqual(nextRender3, nextRender2);
+
+    await nextRender2;
+    assert.equal(button.textContent, '3');
+  });
+});


### PR DESCRIPTION
Fix an issue where clicking an annotation card did not scroll the transcript if
there was no filter.

This happened because the player always instructed Hypothesis to wait until the
next render before scrolling. If there was no filter and the video was paused,
no re-render happened and so Hypothesis would wait indefinitely until some other
user action caused a re-render. The fix is to only make the client wait if
there is a filter to clear.

- The first commit extracts the logic for waiting for the next render into a shared `useNextRender` hook, and also fixes an issue where it could fail to resolve if called multiple times before the next render happened
- The second commit changes `VideoPlayerApp` to use this hook, and avoiding waiting if there is no filter

**Testing:**

1. Go to a video, eg. http://localhost:9083/video/x8TO-nrUtSI
2. Create an annotation
3. Scroll the transcript so the highlight is off-screen
4. Click on the annotation card. On `main` the transcript won't scroll unless there is a filter. On this branch it should always scroll.