### PR TITLE
Fix `make dev` building the frontend assets

### DIFF
--- a/frontend.mk
+++ b/frontend.mk
@@ -2,6 +2,8 @@ node_modules/.uptodate: package.json yarn.lock
 	yarn install
 	@touch $@
 
+dev: node_modules/.uptodate
+
 .PHONY: build
 $(call help,make build,"prepare the build files")
 build: python node_modules/.uptodate


### PR DESCRIPTION
If you run `make clean dev` the frontend assets won't be built and Via
page loads will crash. Fix this by making `make dev` depend on
`node_modules/.uptodate`.
