### PR TITLE
Fix stopping Via's NGINX process in dev

### DIFF
--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -4,7 +4,8 @@
       "command": "gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini"
     },
     "nginx": {
-      "command": "docker compose run --rm --service-ports nginx-proxy"
+      "command": "docker compose run --rm --service-ports nginx-proxy",
+      "stopsignal": "TERM"
     },
     "assets": {
       "command": "node_modules/.bin/gulp watch"

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -13,7 +13,7 @@ stopasgroup=true
 command=docker compose run --rm --service-ports nginx-proxy
 stdout_events_enabled=true
 stderr_events_enabled=true
-stopsignal=KILL
+stopsignal=TERM
 stopasgroup=true
 
 [program:assets]


### PR DESCRIPTION
Problem: run `make dev` then kill it with <kbd>Ctrl</kbd> + <kbd>c</kbd>
then run `make dev` again. You'll see this error from the `nginx` process:

    Bind for 127.0.0.1:9083 failed: port is already allocated

This happens because the `nginx` process from the first run of
`make dev` is still running. This commit attempts to fix this by
configuring Supervisor to stop NGINX using the `TERM` signal instead
of `KILL` so that Docker has time to stop NGINX properly.
