### PR TITLE
Add `YOUTUBE_TRANSCRIPTS` feature flag

### DIFF
--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -6,3 +6,4 @@ dev: VIA_SECRET = not_a_secret
 dev: CHECKMATE_API_KEY = dev_api_key
 dev: ENABLE_FRONT_PAGE = {env:ENABLE_FRONT_PAGE:true}
 dev: DATA_DIRECTORY = .devdata/
+dev: YOUTUBE_TRANSCRIPTS = {env:YOUTUBE_TRANSCRIPTS:true}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def pyramid_settings():
         "enable_front_page": True,
         "data_directory": "tests/data_directory",
         "dev": False,
+        "youtube_transcripts": True,
     }
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -8,6 +8,7 @@ from via.services import (
     PDFURLBuilder,
     SecureLinkService,
     ViaClientService,
+    YouTubeService,
 )
 
 
@@ -45,3 +46,8 @@ def http_service(mock_service):
 @pytest.fixture
 def pdf_url_builder_service(mock_service):
     return mock_service(PDFURLBuilder)
+
+
+@pytest.fixture
+def youtube_service(mock_service):
+    return mock_service(YouTubeService)

--- a/tests/unit/via/services/youtube_service_test.py
+++ b/tests/unit/via/services/youtube_service_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from via.services.youtube import YouTubeService, factory
+
+
+class TestYouTubeService:
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_enabled(self, enabled):
+        assert YouTubeService(enabled=enabled).enabled == enabled
+
+
+class TestFactory:
+    def test_it(self, YouTubeService, youtube_service, pyramid_request):
+        returned = factory(sentinel.context, pyramid_request)
+
+        YouTubeService.assert_called_once_with(
+            pyramid_request.registry.settings["youtube_transcripts"]
+        )
+        assert returned == youtube_service
+
+    @pytest.fixture(autouse=True)
+    def YouTubeService(self, patch):
+        return patch("via.services.youtube.YouTubeService")
+
+    @pytest.fixture
+    def youtube_service(self, YouTubeService):
+        return YouTubeService.return_value

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,10 +1,12 @@
 from unittest.mock import sentinel
 
 import pytest
+from pyramid.httpexceptions import HTTPUnauthorized
 
 from via.views.view_video import view_video
 
 
+@pytest.mark.usefixtures("youtube_service")
 class TestViewVideo:
     def test_it(self, pyramid_request, Configuration):
         pyramid_request.matchdict["id"] = "abcdef"
@@ -29,6 +31,14 @@ class TestViewVideo:
             ],
         }
         assert response["video_id"] == "abcdef"
+
+    def test_it_with_YouTube_transcripts_disabled(
+        self, pyramid_request, youtube_service
+    ):
+        youtube_service.enabled = False
+
+        with pytest.raises(HTTPUnauthorized):
+            view_video(pyramid_request)
 
     @pytest.fixture
     def Configuration(self, patch):

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ setenv =
     dev: CHECKMATE_API_KEY = dev_api_key
     dev: ENABLE_FRONT_PAGE = {env:ENABLE_FRONT_PAGE:true}
     dev: DATA_DIRECTORY = .devdata/
+    dev: YOUTUBE_TRANSCRIPTS = {env:YOUTUBE_TRANSCRIPTS:true}
 passenv =
     HOME
     PYTEST_ADDOPTS

--- a/via/app.py
+++ b/via/app.py
@@ -27,6 +27,7 @@ PARAMETERS = {
     "data_directory": {"required": True, "formatter": Path},
     "signed_urls_required": {"formatter": asbool},
     "enable_front_page": {"formatter": asbool},
+    "youtube_transcripts": {"formatter": asbool},
 }
 
 

--- a/via/services/__init__.py
+++ b/via/services/__init__.py
@@ -9,6 +9,7 @@ from via.services.http import HTTPService
 from via.services.pdf_url import PDFURLBuilder
 from via.services.secure_link import SecureLinkService, has_secure_url_token
 from via.services.via_client import ViaClientService
+from via.services.youtube import YouTubeService
 
 
 def includeme(config):  # pragma: no cover
@@ -27,6 +28,10 @@ def includeme(config):  # pragma: no cover
     config.register_service_factory("via.services.http.factory", iface=HTTPService)
 
     config.register_service_factory("via.services.pdf_url.factory", iface=PDFURLBuilder)
+
+    config.register_service_factory(
+        "via.services.youtube.factory", iface=YouTubeService
+    )
 
 
 def create_google_api(settings):

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -1,0 +1,11 @@
+class YouTubeService:
+    def __init__(self, enabled: bool):
+        self._enabled = enabled
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+
+def factory(_context, request):
+    return YouTubeService(enabled=request.registry.settings["youtube_transcripts"])

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,9 +1,17 @@
 from h_vialib import Configuration
+from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
+
+from via.services import YouTubeService
 
 
 @view_config(renderer="via:templates/view_video.html.jinja2", route_name="view_video")
 def view_video(request):
+    youtube_service = request.find_service(YouTubeService)
+
+    if not youtube_service.enabled:
+        raise HTTPUnauthorized()
+
     _, client_config = Configuration.extract_from_params(request.params)
 
     video_id = request.matchdict["id"]


### PR DESCRIPTION
The new YouTube transcripts feature is currently enabled on public Via.
For example:

https://via.hypothes.is/video/-EB5NhI2RQQ

Add a `YOUTUBE_TRANSCRIPTS` feature flag environment variable that
disables the feature by turning `/video/{id}` URLs into
**401 Unauthorized** responses if the `YOUTUBE_TRANSCRIPTS` envvar is
not set to `true`.

Enable the feature flag by default in dev and in the tests but allow it
to be disabled by default in production.

Add a new `YouTubeService` that reads the new envvar. This service will
later be extended with more YouTube-related functionality.

Make the `view_video()` view depend on the new `YouTubeService` and
return a **401 Unauthorized** if `YouTubeService.enabled` is `False`.
