### PR TITLE
Replace `ViaClientService.is_pdf()` with `content_type()`

### DIFF
--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -7,15 +7,15 @@ from via.services.via_client import ViaClientService, factory
 
 class TestViaClientService:
     @pytest.mark.parametrize(
-        "mime_type,is_pdf",
+        "mime_type,expected_content_type",
         [
-            ("application/x-pdf", True),
-            ("application/pdf", True),
-            ("text/html", False),
+            ("application/x-pdf", "pdf"),
+            ("application/pdf", "pdf"),
+            ("text/html", "html"),
         ],
     )
-    def test_is_pdf(self, mime_type, is_pdf, svc):
-        assert svc.is_pdf(mime_type) == is_pdf
+    def test_content_type(self, mime_type, expected_content_type, svc):
+        assert svc.content_type(mime_type) == expected_content_type
 
     @pytest.mark.parametrize(
         "mime_type,expected_content_type",

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -13,12 +13,12 @@ class TestRouteByContent:
     @pytest.mark.parametrize(
         "content_type,status_code,expected_cache_control_header",
         [
-            ("PDF", 200, "public, max-age=300, stale-while-revalidate=86400"),
-            ("HTML", 200, "public, max-age=60, stale-while-revalidate=86400"),
-            ("HTML", 401, "public, max-age=60, stale-while-revalidate=86400"),
-            ("HTML", 404, "public, max-age=60, stale-while-revalidate=86400"),
-            ("HTML", 500, "no-cache"),
-            ("HTML", 501, "no-cache"),
+            ("pdf", 200, "public, max-age=300, stale-while-revalidate=86400"),
+            ("html", 200, "public, max-age=60, stale-while-revalidate=86400"),
+            ("html", 401, "public, max-age=60, stale-while-revalidate=86400"),
+            ("html", 404, "public, max-age=60, stale-while-revalidate=86400"),
+            ("html", 500, "no-cache"),
+            ("html", 501, "no-cache"),
         ],
     )
     def test_it(
@@ -36,7 +36,7 @@ class TestRouteByContent:
             sentinel.mime_type,
             status_code,
         )
-        via_client_service.is_pdf.return_value = content_type == "PDF"
+        via_client_service.content_type.return_value = content_type
 
         response = route_by_content(context, pyramid_request)
 
@@ -45,7 +45,7 @@ class TestRouteByContent:
         url_details_service.get_url_details.assert_called_once_with(
             url, pyramid_request.headers
         )
-        via_client_service.is_pdf.assert_called_once_with(sentinel.mime_type)
+        via_client_service.content_type.assert_called_once_with(sentinel.mime_type)
         via_client_service.url_for.assert_called_once_with(
             url, sentinel.mime_type, {"foo": "bar"}
         )

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -5,19 +5,22 @@ from h_vialib import ViaClient
 class ViaClientService:
     """A wrapper service for h_vialib.ViaClient."""
 
+    _mime_types_content_type = {
+        "application/x-pdf": "pdf",
+        "application/pdf": "pdf",
+    }
+
+    def content_type(self, mime_type):
+        return self._mime_types_content_type.get(mime_type, "html")
+
     def __init__(self, via_client):
         self.via_client = via_client
-
-    @staticmethod
-    def is_pdf(mime_type):
-        """Return True if the given MIME type is a PDF one."""
-        return mime_type in ("application/x-pdf", "application/pdf")
 
     def url_for(self, url, mime_type, params):
         """Return a Via URL for the given `url`."""
         return self.via_client.url_for(
             url,
-            content_type="pdf" if self.is_pdf(mime_type) else "html",
+            content_type=self.content_type(mime_type),
             options=params,
         )
 

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -18,7 +18,7 @@ def route_by_content(context, request):
     )
     via_client_svc = request.find_service(ViaClientService)
 
-    if via_client_svc.is_pdf(mime_type):
+    if via_client_svc.content_type(mime_type) == "pdf":
         caching_headers = _caching_headers(max_age=300)
     else:
         caching_headers = _cache_headers_for_http(status_code)


### PR DESCRIPTION
Replace `ViaClientService.is_pdf()` with a `content_type()` method that
returns either `"pdf"` or `"html"`. This will be more easily extensible
to support more content types in future.
