### PR TITLE
Display bucket bar alongside transcript

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -56,7 +56,7 @@ function isScrollToRangeEvent(e: Event): e is ScrollToRangeEvent {
 export default function VideoPlayerApp({
   videoId,
   clientSrc,
-  clientConfig,
+  clientConfig: baseClientConfig,
   transcript,
 }: VideoPlayerAppProps) {
   // Current play time of the video, in seconds since the start.
@@ -167,6 +167,14 @@ export default function VideoPlayerApp({
       console.warn('Failed to copy transcript', err);
     }
   };
+
+  const bucketContainerId = 'bucket-container';
+  const clientConfig = useMemo(() => {
+    return {
+      ...baseClientConfig,
+      bucketBarContainer: '#' + bucketContainerId,
+    };
+  }, [baseClientConfig]);
 
   return (
     <div
@@ -320,14 +328,37 @@ export default function VideoPlayerApp({
               <SyncIcon />
             </Button>
           </div>
-          <Transcript
-            autoScroll={autoScroll}
-            transcript={transcript}
-            controlsRef={transcriptControls}
-            currentTime={timestamp}
-            filter={trimmedFilter}
-            onSelectSegment={segment => setTimestamp(segment.start)}
-          />
+          <div
+            className={classnames(
+              'relative',
+
+              // Override flex-basis for transcript. Otherwise this container will
+              // be sized to accomodate all transcript elements.
+              'min-h-0'
+            )}
+          >
+            <Transcript
+              autoScroll={autoScroll}
+              transcript={transcript}
+              controlsRef={transcriptControls}
+              currentTime={timestamp}
+              filter={trimmedFilter}
+              onSelectSegment={segment => setTimestamp(segment.start)}
+            />
+            <div
+              id={bucketContainerId}
+              className={classnames(
+                // Position bucket bar along right edge of transcript, with a
+                // small gap to avoid buckets touching the border.
+                //
+                // The bucket bar width is currently copied from the client.
+                'absolute right-1 top-0 bottom-0 w-[23px]',
+
+                // Make the bucket bar fill this container.
+                'flex flex-column'
+              )}
+            />
+          </div>
           <div data-testid="transcript-footer" className="px-2 py-4">
             <Checkbox
               checked={autoScroll}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -172,7 +172,7 @@ export default function VideoPlayerApp({
   const clientConfig = useMemo(() => {
     return {
       ...baseClientConfig,
-      bucketBarContainer: '#' + bucketContainerId,
+      bucketContainerSelector: '#' + bucketContainerId,
     };
   }, [baseClientConfig]);
 

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -332,9 +332,12 @@ export default function VideoPlayerApp({
             className={classnames(
               'relative',
 
-              // Override flex-basis for transcript. Otherwise this container will
-              // be sized to accomodate all transcript elements.
-              'min-h-0'
+              // Override flex-basis for transcript. Otherwise this container
+              // will be sized to accomodate all transcript elements.
+              'min-h-0',
+
+              // Make the bucket bar fill this container.
+              'flex flex-col'
             )}
           >
             <Transcript

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -401,7 +401,7 @@ describe('VideoPlayerApp', () => {
     const mergedConfig = wrapper.find('HypothesisClient').prop('config');
     assert.deepEqual(mergedConfig, {
       openSidebar: true,
-      bucketBarContainer: '#bucket-container',
+      bucketContainerSelector: '#bucket-container',
     });
   });
 

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -395,6 +395,16 @@ describe('VideoPlayerApp', () => {
     assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
   });
 
+  it('configures bucket bar container for client', () => {
+    const clientConfig = { openSidebar: true };
+    const wrapper = createVideoPlayer({ clientConfig });
+    const mergedConfig = wrapper.find('HypothesisClient').prop('config');
+    assert.deepEqual(mergedConfig, {
+      openSidebar: true,
+      bucketBarContainer: '#bucket-container',
+    });
+  });
+
   describe('keyboard shortcuts', () => {
     let wrappers;
 


### PR DESCRIPTION
Use the Hypothesis client's `bucketBarContainer` config to position the bucket bar alongside the transcript, instead of the left edge of the client's sidebar.

**For the changes to work, you'll need to check out https://github.com/hypothesis/client/pull/5524**. Without the client changes, this PR has no visible effect for end users and the bucket bar is displayed along the edge of the sidebar as before.

Fixes https://github.com/hypothesis/via/issues/952.

**Before:**

<img width="598" src="https://user-images.githubusercontent.com/2458/242860129-409f9055-69e0-4aba-8aaf-ae2be2491e24.png">

**After:**

<img width="598" alt="Transcript buckets" src="https://github.com/hypothesis/via/assets/2458/ba9b5786-8efd-4496-a154-df58a45a2eb2">
