### PR TITLE
Apply basic layout to video-annotation interface at target baseline viewport

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,4 +1,5 @@
 import { Button, Checkbox, CopyIcon, Input } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import {
   useCallback,
   useEffect,
@@ -158,7 +159,15 @@ export default function VideoPlayerApp({
 
   return (
     <div className="w-full flex">
-      <div className="grow flex flex-col p-4">
+      <div
+        className={classnames(
+          // This column will grow in width per the parent flex container and
+          // allow the contained media (video) to scale with available space.
+          // The column flex layout established here ensures this container fills
+          // the full height of the parent flex container
+          'grow flex flex-col p-3'
+        )}
+      >
         <YouTubeVideoPlayer
           videoId={videoId}
           play={playing}
@@ -167,8 +176,25 @@ export default function VideoPlayerApp({
           onTimeChanged={setTimestamp}
         />
       </div>
-      <div className="w-2/5 h-[90vh] flex flex-col bg-grey-0 border">
-        <div className="p-1 bg-grey-1 border-b flex flex-col">
+      <div
+        className={classnames(
+          // Full-height column with a width allowing comfortable line lengths
+          'h-[100vh] w-[50ch] flex flex-col',
+          'bg-grey-0 border-x',
+          // TODO: This is a stopgap measure to prevent controls from being
+          // interfered with (overlaid) by sidebar controls and toolbar
+          'mr-[30px]'
+        )}
+      >
+        <div
+          className={classnames(
+            'p-1 bg-grey-1',
+            // TODO: This is a stopgap measure to prevent the right side of the
+            // search input from being inpinged on by sidebar controls
+            'pr-2'
+          )}
+          data-testid="search-bar"
+        >
           <Input
             aria-label="Transcript filter"
             data-testid="filter-input"
@@ -224,7 +250,7 @@ export default function VideoPlayerApp({
           filter={trimmedFilter}
           onSelectSegment={segment => setTimestamp(segment.start)}
         />
-        <div className="pl-2">
+        <div className="p-2">
           <Checkbox
             checked={autoScroll}
             data-testid="autoscroll-checkbox"
@@ -232,7 +258,7 @@ export default function VideoPlayerApp({
               setAutoScroll((e.target as HTMLInputElement).checked)
             }
           >
-            <div className="p-2 select-none">Auto-scroll</div>
+            <div className="select-none">Auto-scroll</div>
           </Checkbox>
         </div>
       </div>

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -157,8 +157,8 @@ export default function VideoPlayerApp({
   };
 
   return (
-    <div className="w-full flex flex-row m-2">
-      <div className="mr-2">
+    <div className="w-full flex">
+      <div className="grow flex flex-col p-4">
         <YouTubeVideoPlayer
           videoId={videoId}
           play={playing}

--- a/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
@@ -1,3 +1,4 @@
+import { AspectRatio } from '@hypothesis/frontend-shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { loadYouTubeIFrameAPI } from '../utils/youtube';
@@ -166,10 +167,9 @@ export default function YouTubeVideoPlayer({
   }, [time]);
 
   return (
-    <div>
+    <AspectRatio>
       <iframe
         allow="autoplay; fullscreen"
-        className="w-[640px] h-[360px] pb-2"
         title="Video player"
         src={playerURL}
         ref={videoFrame}
@@ -179,6 +179,6 @@ export default function YouTubeVideoPlayer({
           <b>There was an error loading this video. Try reloading the page.</b>
         </p>
       )}
-    </div>
+    </AspectRatio>
   );
 }

--- a/via/static/styles/video_player.css
+++ b/via/static/styles/video_player.css
@@ -3,6 +3,10 @@ CSS entry point for the video player app.
 */
 
 @tailwind base;
+
+html {
+  @apply bg-grey-0;
+}
 @tailwind components;
 @tailwind utilities;
 


### PR DESCRIPTION
This PR applies a very basic layout for the video-annotation application to best suit (in broad strokes) the target baseline viewport of ~1448px as per https://github.com/hypothesis/via/issues/974

A few salient points:

* `AspectRatio` is used here to allow the video content to fill available space while retaining the correct aspect ratio
* The columnar layout is updated such that the column containing the transcript and controls is full height and fixed-width, and always flush against the right
* A subtle background color has been applied to the page. This is just author preference :)

Absolutely nothing here is carved in stone and should be considered iterative, as will be the case with several subsequent design-related PRs.

Many things are not addressed here. This only attempts to satisfy the first item in the UI/design list captured in https://github.com/hypothesis/via/issues/953

Before, 1448px:

<img width="1560" alt="Screen Shot 2023-06-08 at 9 04 25 AM" src="https://github.com/hypothesis/via/assets/439947/6861674f-cf11-42fe-981a-fa21afd903bd">

<img width="1560" alt="Screen Shot 2023-06-08 at 9 04 42 AM" src="https://github.com/hypothesis/via/assets/439947/46bfdbb9-0f51-4f77-a26d-708724e68102">

After, 1448px:

<img width="1560" alt="Screen Shot 2023-06-08 at 9 02 53 AM" src="https://github.com/hypothesis/via/assets/439947/a5204104-5dde-4752-af48-4539d274cf2d">

<img width="1560" alt="Screen Shot 2023-06-08 at 9 02 30 AM" src="https://github.com/hypothesis/via/assets/439947/4c9e600a-8885-4249-a10e-d687fbc2c1f4">


Fixes https://github.com/hypothesis/via/issues/974
Part of #953