### PR TITLE
Use full YouTube URLs not video IDs in the `/video` route

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -102,7 +102,9 @@ markupsafe==1.1.1
     #   jinja2
     #   pyramid-jinja2
 marshmallow==3.19.0
-    # via -r requirements/prod.txt
+    # via
+    #   -r requirements/prod.txt
+    #   webargs
 matplotlib-inline==0.1.3
     # via ipython
 netaddr==0.8.0
@@ -120,6 +122,7 @@ packaging==21.3
     #   -r requirements/prod.txt
     #   build
     #   marshmallow
+    #   webargs
 parso==0.8.2
     # via jedi
 pastedeploy==2.1.1
@@ -255,6 +258,8 @@ venusian==3.0.0
     #   pyramid
 wcwidth==0.2.5
     # via prompt-toolkit
+webargs==8.2.0
+    # via -r requirements/prod.txt
 webob==1.8.6
     # via
     #   -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -98,7 +98,9 @@ markupsafe==1.1.1
     #   jinja2
     #   pyramid-jinja2
 marshmallow==3.19.0
-    # via -r requirements/prod.txt
+    # via
+    #   -r requirements/prod.txt
+    #   webargs
 netaddr==0.8.0
     # via
     #   -r requirements/prod.txt
@@ -115,6 +117,7 @@ packaging==21.3
     #   build
     #   marshmallow
     #   pytest
+    #   webargs
 pastedeploy==2.1.1
     # via
     #   -r requirements/prod.txt
@@ -232,6 +235,8 @@ venusian==3.0.0
     #   pyramid
 waitress==2.1.2
     # via webtest
+webargs==8.2.0
+    # via -r requirements/prod.txt
 webob==1.8.6
     # via
     #   -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -163,6 +163,7 @@ marshmallow==3.19.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   webargs
 mccabe==0.6.1
     # via pylint
 netaddr==0.8.0
@@ -186,6 +187,7 @@ packaging==21.3
     #   build
     #   marshmallow
     #   pytest
+    #   webargs
 pastedeploy==2.1.1
     # via
     #   -r requirements/functests.txt
@@ -372,6 +374,10 @@ waitress==2.1.2
     # via
     #   -r requirements/functests.txt
     #   webtest
+webargs==8.2.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 webob==1.8.6
     # via
     #   -r requirements/functests.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -14,3 +14,4 @@ requests
 whitenoise
 google-auth-oauthlib
 marshmallow
+webargs

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -53,7 +53,9 @@ markupsafe==1.1.1
     #   jinja2
     #   pyramid-jinja2
 marshmallow==3.19.0
-    # via -r requirements/prod.in
+    # via
+    #   -r requirements/prod.in
+    #   webargs
 netaddr==0.8.0
     # via checkmatelib
 newrelic==8.8.0
@@ -61,7 +63,9 @@ newrelic==8.8.0
 oauthlib==3.2.2
     # via requests-oauthlib
 packaging==21.3
-    # via marshmallow
+    # via
+    #   marshmallow
+    #   webargs
 pastedeploy==2.1.1
     # via plaster-pastedeploy
 plaster==1.0
@@ -128,6 +132,8 @@ urllib3==1.26.15
     #   sentry-sdk
 venusian==3.0.0
     # via pyramid
+webargs==8.2.0
+    # via -r requirements/prod.in
 webob==1.8.6
     # via
     #   h-vialib

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -100,7 +100,9 @@ markupsafe==1.1.1
     #   jinja2
     #   pyramid-jinja2
 marshmallow==3.19.0
-    # via -r requirements/prod.txt
+    # via
+    #   -r requirements/prod.txt
+    #   webargs
 netaddr==0.8.0
     # via
     #   -r requirements/prod.txt
@@ -117,6 +119,7 @@ packaging==21.3
     #   build
     #   marshmallow
     #   pytest
+    #   webargs
 pastedeploy==2.1.1
     # via
     #   -r requirements/prod.txt
@@ -233,6 +236,8 @@ venusian==3.0.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
+webargs==8.2.0
+    # via -r requirements/prod.txt
 webob==1.8.6
     # via
     #   -r requirements/prod.txt

--- a/tests/unit/via/views/conftest.py
+++ b/tests/unit/via/views/conftest.py
@@ -1,0 +1,2 @@
+# Import this so that our webargs customization is registered in the view tests.
+import via.views.webargs  # pylint: disable=unused-import

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -3,13 +3,14 @@ from unittest.mock import sentinel
 import pytest
 from pyramid.httpexceptions import HTTPUnauthorized
 
+from via.exceptions import BadURL
 from via.views.view_video import view_video
 
 
 @pytest.mark.usefixtures("youtube_service")
 class TestViewVideo:
-    def test_it(self, pyramid_request, Configuration):
-        pyramid_request.matchdict["id"] = "abcdef"
+    def test_it(self, pyramid_request, Configuration, youtube_service):
+        youtube_service.get_video_id.return_value = sentinel.video_id
 
         response = view_video(pyramid_request)
 
@@ -30,7 +31,18 @@ class TestViewVideo:
                 },
             ],
         }
-        assert response["video_id"] == "abcdef"
+        assert response["video_id"] == sentinel.video_id
+
+    def test_it_errors_if_the_url_is_invalid(self, pyramid_request, youtube_service):
+        # YouTubeService returns None if it can't extract the YouTube video ID
+        # from the URL, which happens if the URL doesn't match a YouTube video
+        # URL format that YouTubeService supports.
+        youtube_service.get_video_id.return_value = None
+
+        with pytest.raises(BadURL) as exc_info:
+            view_video(pyramid_request)
+
+        assert str(exc_info.value).startswith("Unsupported video URL")
 
     def test_it_with_YouTube_transcripts_disabled(
         self, pyramid_request, youtube_service
@@ -49,3 +61,8 @@ class TestViewVideo:
         )
 
         return Configuration
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params["url"] = sentinel.url
+        return pyramid_request

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,39 +1,56 @@
 from unittest.mock import sentinel
 
 import pytest
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 from pyramid.httpexceptions import HTTPUnauthorized
 
 from via.exceptions import BadURL
 from via.views.view_video import view_video
 
+# webargs's kwargs injection into view functions falsely triggers Pylint's
+# no-value-for-parameter all the time so just disable it file-wide.
+# pylint: disable=no-value-for-parameter
+
 
 @pytest.mark.usefixtures("youtube_service")
 class TestViewVideo:
-    def test_it(self, pyramid_request, Configuration, youtube_service):
-        youtube_service.get_video_id.return_value = sentinel.video_id
+    def test_it(self, pyramid_request, Configuration, youtube_service, video_url):
+        youtube_service.get_video_id.return_value = sentinel.youtube_video_id
 
         response = view_video(pyramid_request)
 
-        assert response["client_embed_url"] == "http://hypothes.is/embed.js"
-        assert (
-            response["client_config"]
-            == Configuration.extract_from_params.return_value[1]
-        )
-        assert response["transcript"] == {
-            "segments": [
-                {
-                    "time": 0,
-                    "text": "First segment of transcript",
-                },
-                {
-                    "time": 30,
-                    "text": "Second segment of transcript",
-                },
-            ],
+        youtube_service.get_video_id.assert_called_once_with(video_url)
+        assert response == {
+            "client_embed_url": "http://hypothes.is/embed.js",
+            "client_config": Configuration.extract_from_params.return_value[1],
+            "transcript": {
+                "segments": [
+                    {
+                        "time": 0,
+                        "text": "First segment of transcript",
+                    },
+                    {
+                        "time": 30,
+                        "text": "Second segment of transcript",
+                    },
+                ],
+            },
+            "video_id": sentinel.youtube_video_id,
         }
-        assert response["video_id"] == sentinel.video_id
 
-    def test_it_errors_if_the_url_is_invalid(self, pyramid_request, youtube_service):
+    def test_it_errors_if_the_url_is_invalid(self, pyramid_request):
+        pyramid_request.params["url"] = "not_a_valid_url"
+
+        with pytest.raises(MarshmallowValidationError) as exc_info:
+            view_video(pyramid_request)
+
+        assert exc_info.value.normalized_messages() == {
+            "query": {"url": ["Not a valid URL."]}
+        }
+
+    def test_it_errors_if_the_url_is_not_a_YouTube_url(
+        self, pyramid_request, youtube_service
+    ):
         # YouTubeService returns None if it can't extract the YouTube video ID
         # from the URL, which happens if the URL doesn't match a YouTube video
         # URL format that YouTubeService supports.
@@ -63,6 +80,10 @@ class TestViewVideo:
         return Configuration
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.params["url"] = sentinel.url
+    def video_url(self):
+        return "https://example.com/watch?v=VIDEO_ID"
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, video_url):
+        pyramid_request.params["url"] = video_url
         return pyramid_request

--- a/tests/unit/via/views/webargs_test.py
+++ b/tests/unit/via/views/webargs_test.py
@@ -1,0 +1,14 @@
+import pytest
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
+
+from via.views.webargs import handle_error
+
+
+def test_handle_error():
+    validation_error = MarshmallowValidationError("Test error")
+
+    with pytest.raises(MarshmallowValidationError) as exc_info:
+        handle_error(validation_error)
+
+    assert exc_info.value.status_int == 400
+    assert exc_info.value == validation_error

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -9,7 +9,7 @@ def add_routes(config):  # pragma: no cover
     config.add_route("index", "/", factory=QueryURLResource)
     config.add_route("get_status", "/_status")
     config.add_route("view_pdf", "/pdf", factory=QueryURLResource)
-    config.add_route("view_video", "/video/{id}")
+    config.add_route("view_video", "/video", factory=QueryURLResource)
     config.add_route("route_by_content", "/route", factory=QueryURLResource)
     config.add_route("debug_headers", "/debug/headers")
     config.add_route(

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -1,6 +1,7 @@
 """Error views to handle when things go wrong in the app."""
 
 import h_pyramid_sentry
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 from pyramid.httpexceptions import HTTPClientError, HTTPNotFound
 from pyramid.view import exception_view_config
 
@@ -48,6 +49,12 @@ EXCEPTION_MAP = {
             "The URL you asked for is not part of this service.",
             "Please check the URL you have entered.",
         ],
+        "stage": "request",
+        "retryable": False,
+    },
+    MarshmallowValidationError: {
+        "title": "Invalid request",
+        "long_description": ["We can't process the request because it's invalid."],
         "stage": "request",
         "retryable": False,
     },

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -2,6 +2,7 @@ from h_vialib import Configuration
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
 
+from via.exceptions import BadURL
 from via.services import YouTubeService
 
 
@@ -12,9 +13,15 @@ def view_video(request):
     if not youtube_service.enabled:
         raise HTTPUnauthorized()
 
+    video_url = request.params["url"]
+
+    video_id = youtube_service.get_video_id(video_url)
+
+    if not video_id:
+        raise BadURL(f"Unsupported video URL: {video_url}", url=video_url)
+
     _, client_config = Configuration.extract_from_params(request.params)
 
-    video_id = request.matchdict["id"]
     transcript = {
         "segments": [
             {

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,24 +1,25 @@
 from h_vialib import Configuration
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
+from webargs import fields
+from webargs.pyramidparser import use_kwargs
 
 from via.exceptions import BadURL
 from via.services import YouTubeService
 
 
 @view_config(renderer="via:templates/view_video.html.jinja2", route_name="view_video")
-def view_video(request):
+@use_kwargs({"url": fields.Url(required=True)}, location="query")
+def view_video(request, url):
     youtube_service = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:
         raise HTTPUnauthorized()
 
-    video_url = request.params["url"]
-
-    video_id = youtube_service.get_video_id(video_url)
+    video_id = youtube_service.get_video_id(url)
 
     if not video_id:
-        raise BadURL(f"Unsupported video URL: {video_url}", url=video_url)
+        raise BadURL(f"Unsupported video URL: {url}", url=url)
 
     _, client_config = Configuration.extract_from_params(request.params)
 

--- a/via/views/webargs.py
+++ b/via/views/webargs.py
@@ -1,0 +1,28 @@
+"""Integrate webargs (https://webargs.readthedocs.io/) with Via."""
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
+from webargs.pyramidparser import parser
+
+
+@parser.error_handler
+def handle_error(error: MarshmallowValidationError, *_args, **_kwargs):
+    """Handle a validation error from webargs's Pyramid parser.
+
+    webargs's Pyramid parser has a default error handling method that returns a
+    JSON error response and swallows the original Marshmallow ValidationError.
+
+    We don't want that behavior for Via so override webarg's Pyramid parser's
+    default error handler with our own.
+
+    See:
+
+    https://webargs.readthedocs.io/en/latest/quickstart.html#error-handling
+
+    :raises MarshmallowValidationError: whenever called
+
+    """
+    # Make the HTTP status for Marshmallow validation error responses be 400.
+    error.status_int = 400
+
+    # Re-raise the original Marshmallow validation error so that our exception
+    # views have direct access to it.
+    raise error


### PR DESCRIPTION
[Slack thread](https://hypothes-is.slack.com/archives/C054CG5PH5M/p1686231916609859), [another Slack thread](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1686563922909299).

Change Via's `/video` endpoint to accept full YouTube URLs in a `url` query param instead of accepting just YouTube video IDs in a URL path part.

This changes the format of Via's `/video` URLs from `/video/YOUTUBE_VIDEO_ID` to `/video?url=YOUTUBE_VIDEO_URL`.

This change is needed because the `/video` endpoint may need the full YouTube URL not just the video ID:

* The `/video` endpoint may need to pass the full YouTube URL to Checkmate to check whether the video has been blocked
* The `/video` endpoint may need the full YouTube URL for unforeseen functionality reasons. For example we may find out in future that our video player needs to handle YouTube `/live/` URLs differently from `/watch` ones

This commit also adds **webargs** validation for Via views and makes `/video` show an error page if the `url` query param is missing or is not a valid YouTube URL.

Testing
=======

I've used HTTP status **400** for the error pages rather than webargs's default of 422 because 400 is that Via was already using for other "bad URL" error pages.

No `url` query param: <http://localhost:9083/video>, status is 400
--------------------

![image](https://github.com/hypothesis/via/assets/22498/661947a6-80e2-405c-85fd-2341985d97ba)

`url` query param isn't a valid URL: <http://localhost:9083/video?url=foo>, status is 400
-----------------------------------

![image](https://github.com/hypothesis/via/assets/22498/dcfcb9ca-0edf-4d4c-ab46-c6d80dfe6158)

`url` query param isn't a YouTube URL: <http://localhost:9083/video?url=https://example.com>, status is 400
-------------------------------------

![image](https://github.com/hypothesis/via/assets/22498/256a8031-ef8b-4148-8437-59092b29762b)

`url` query param is a valid YouTube URL: <http://localhost:9083/video?url=https://www.youtube.com/watch?v=jfKfPfyJRdk>
----------------------------------------

![image](https://github.com/hypothesis/via/assets/22498/89ab6eac-da38-404f-9c63-4542ba9adb6f)