### PR TITLE
Change Via's `/video` endpoint to `/video/youtube`

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -5,7 +5,7 @@ from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 from pyramid.httpexceptions import HTTPUnauthorized
 
 from via.exceptions import BadURL
-from via.views.view_video import view_video
+from via.views.view_video import youtube
 
 # webargs's kwargs injection into view functions falsely triggers Pylint's
 # no-value-for-parameter all the time so just disable it file-wide.
@@ -17,7 +17,7 @@ class TestViewVideo:
     def test_it(self, pyramid_request, Configuration, youtube_service, video_url):
         youtube_service.get_video_id.return_value = sentinel.youtube_video_id
 
-        response = view_video(pyramid_request)
+        response = youtube(pyramid_request)
 
         youtube_service.get_video_id.assert_called_once_with(video_url)
         assert response == {
@@ -42,7 +42,7 @@ class TestViewVideo:
         pyramid_request.params["url"] = "not_a_valid_url"
 
         with pytest.raises(MarshmallowValidationError) as exc_info:
-            view_video(pyramid_request)
+            youtube(pyramid_request)
 
         assert exc_info.value.normalized_messages() == {
             "query": {"url": ["Not a valid URL."]}
@@ -57,7 +57,7 @@ class TestViewVideo:
         youtube_service.get_video_id.return_value = None
 
         with pytest.raises(BadURL) as exc_info:
-            view_video(pyramid_request)
+            youtube(pyramid_request)
 
         assert str(exc_info.value).startswith("Unsupported video URL")
 
@@ -67,7 +67,7 @@ class TestViewVideo:
         youtube_service.enabled = False
 
         with pytest.raises(HTTPUnauthorized):
-            view_video(pyramid_request)
+            youtube(pyramid_request)
 
     @pytest.fixture
     def Configuration(self, patch):

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -9,7 +9,7 @@ def add_routes(config):  # pragma: no cover
     config.add_route("index", "/", factory=QueryURLResource)
     config.add_route("get_status", "/_status")
     config.add_route("view_pdf", "/pdf", factory=QueryURLResource)
-    config.add_route("view_video", "/video", factory=QueryURLResource)
+    config.add_route("youtube", "/video/youtube", factory=QueryURLResource)
     config.add_route("route_by_content", "/route", factory=QueryURLResource)
     config.add_route("debug_headers", "/debug/headers")
     config.add_route(

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -8,9 +8,9 @@ from via.exceptions import BadURL
 from via.services import YouTubeService
 
 
-@view_config(renderer="via:templates/view_video.html.jinja2", route_name="view_video")
+@view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
 @use_kwargs({"url": fields.Url(required=True)}, location="query")
-def view_video(request, url):
+def youtube(request, url):
     youtube_service = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:


### PR DESCRIPTION
The reason for this is that we may want to have different query params
for different video platforms. For example lets say we have a `foo`
param that's required for YouTube videos but not allowed for Vimeo
videos. If the endpoint is `/video?url=YOUTUBE_OR_VIMEO_URL` then the
`foo` param is either required or not allowed depending on the value of
the `url` param. This could make validation difficult. It'll be easier
if `/video/youtube` and `/video/vimeo` are two different endpoints that
can easily be validated differently.
