### PR TITLE
Remove the unused hardcoded YouTube transcript

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -23,18 +23,6 @@ class TestViewVideo:
         assert response == {
             "client_embed_url": "http://hypothes.is/embed.js",
             "client_config": Configuration.extract_from_params.return_value[1],
-            "transcript": {
-                "segments": [
-                    {
-                        "time": 0,
-                        "text": "First segment of transcript",
-                    },
-                    {
-                        "time": 30,
-                        "text": "Second segment of transcript",
-                    },
-                ],
-            },
             "video_id": sentinel.youtube_video_id,
         }
 

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -23,22 +23,8 @@ def youtube(request, url):
 
     _, client_config = Configuration.extract_from_params(request.params)
 
-    transcript = {
-        "segments": [
-            {
-                "time": 0,
-                "text": "First segment of transcript",
-            },
-            {
-                "time": 30,
-                "text": "Second segment of transcript",
-            },
-        ],
-    }
-
     return {
         "client_embed_url": request.registry.settings["client_embed_url"],
         "client_config": client_config,
-        "transcript": transcript,
         "video_id": video_id,
     }


### PR DESCRIPTION
The frontend doesn't actually use this, and the plan is for real
transcripts to come from a separate API endpoint not from the
`view_video()` view.
