### PR TITLE
Adapt video application layout based on size of app container element

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'preact/hooks';
 
+import { useAppLayout } from '../hooks/use-app-layout';
 import { useNextRender } from '../utils/next-render';
 import type { TranscriptData } from '../utils/transcript';
 import { formatTranscript } from '../utils/transcript';
@@ -65,6 +66,8 @@ export default function VideoPlayerApp({
   const [filter, setFilter] = useState('');
   const trimmedFilter = useMemo(() => filter.trim(), [filter]);
   const filterInputRef = useRef<HTMLInputElement>();
+  const appContainerRef = useRef<HTMLDivElement | null>(null);
+  const appSize = useAppLayout(appContainerRef);
 
   // Listen for the event the Hypothesis client dispatches before it scrolls
   // a highlight into view.
@@ -157,15 +160,26 @@ export default function VideoPlayerApp({
     }
   };
 
+  const multicolumn = appSize !== 'sm';
+
   return (
-    <div className="w-full flex">
+    <div
+      data-app-size={appSize}
+      data-multicolumn={multicolumn}
+      className={classnames('w-full flex', {
+        'flex-col min-h-0 h-[100vh]': !multicolumn,
+        'flex-row': multicolumn,
+      })}
+      ref={appContainerRef}
+    >
       <div
         className={classnames(
           // This column will grow in width per the parent flex container and
           // allow the contained media (video) to scale with available space.
           // The column flex layout established here ensures this container fills
           // the full height of the parent flex container
-          'grow flex flex-col p-3'
+          'flex flex-col p-3',
+          { grow: multicolumn }
         )}
       >
         <YouTubeVideoPlayer
@@ -179,11 +193,18 @@ export default function VideoPlayerApp({
       <div
         className={classnames(
           // Full-height column with a width allowing comfortable line lengths
-          'h-[100vh] w-[450px] flex flex-col',
-          'bg-grey-0 border-x',
-          // TODO: This is a stopgap measure to prevent controls from being
-          // interfered with (overlaid) by sidebar controls and toolbar
-          'mr-[30px]'
+          'flex flex-col',
+          {
+            'w-[480px]': appSize === '2xl',
+            'w-[450px]': appSize === 'xl',
+            'w-[410px]': appSize === 'lg',
+            'w-[380px]': appSize === 'md',
+            // TODO: This is a stopgap measure to prevent controls from being
+            // interfered with (overlaid) by sidebar controls and toolbar
+            'mr-[30px] h-[100vh]': multicolumn,
+            'min-h-0 grow': !multicolumn,
+          },
+          'bg-grey-0 border-x'
         )}
       >
         <div

--- a/via/static/scripts/video_player/hooks/use-app-layout.ts
+++ b/via/static/scripts/video_player/hooks/use-app-layout.ts
@@ -1,0 +1,53 @@
+import type { RefObject } from 'preact';
+import { useCallback, useLayoutEffect, useState } from 'preact/hooks';
+
+type AppSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/**
+ * Watch for resizes on `element` and invoke `onSizeChanged` callback
+ */
+export function observeElementSize(
+  element: Element,
+  onSizeChanged: (width: number, height: number) => void
+): () => void {
+  const observer = new ResizeObserver(() =>
+    onSizeChanged(element.clientWidth, element.clientHeight)
+  );
+  observer.observe(element);
+  return () => observer.disconnect();
+}
+
+/**
+ * Return a string representing the relative size of `appContainer`
+ */
+export function useAppLayout(appContainer: RefObject<HTMLDivElement | null>) {
+  const [appSize, setAppSize] = useState<AppSize>('sm');
+
+  const updateWidth = useCallback(() => {
+    const containerWidth = appContainer.current?.clientWidth;
+    if (!containerWidth) {
+      return;
+    }
+
+    let containerSize: AppSize = 'sm';
+    if (containerWidth > 1376) {
+      containerSize = '2xl';
+    } else if (containerWidth > 1024) {
+      containerSize = 'xl';
+    } else if (containerWidth > 875) {
+      containerSize = 'lg';
+    } else if (containerWidth > 768) {
+      containerSize = 'md';
+    }
+
+    setAppSize(containerSize);
+  }, [appContainer]);
+
+  useLayoutEffect(() => {
+    const cleanup = observeElementSize(appContainer.current!, updateWidth);
+    updateWidth();
+    return cleanup;
+  }, [updateWidth, appContainer]);
+
+  return appSize;
+}


### PR DESCRIPTION
This draft PR demonstrates a mechanism for adapting the layout of the video-annotation app based on the available size of the app's containing element. We cannot use media queries here because the viewport may be considerably wider than the app element when the sidebar side-by-side mode is activated. Container queries would be just the ticket but are not yet widely enough supported.

The concept I'd like to evaluate is the encapsulation of a certain amount of this logic in a hook (called `useLayoutHook` here), which internally uses a `ResizeObserver`. This hook returns a relative width value (e.g. 'sm', 'xl') that the consuming component can use to style itself. The breakpoint values in `useAppLayout` are a best guess first swag but shouldn't be construed final recommendations.

There some design challenges yet to sort out that I'm deferring until after we have a bucket-bar-on-transcript feature sorted and landed.

### Testing

On this branch, view the video player app. Resize your browser winder[^1] and open and close the sidebar at different sizes.

The layout stays multicolumn until an aggressively narrow amount of space is available[^2], and then will fall down to single-column. The transcript column width is adjusted at certain breakpoints to make this more possible. 


[^1]: This was a typo but I'm leaving it because I like the idea of cowgirl-me saying "Resize yer browser wind-er".

[^2]: The design "brief" implies that we should use a multi-column layout when it is at all possible. 