### PR TITLE
Fix `view_video.html.jinja2` template

### DIFF
--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -15,8 +15,7 @@
       {
         "client_config": {{ client_config | tojson }},
         "client_src": "{{ client_embed_url }}",
-        "video_id": "{{ video_id }}",
-        "transcript": {{ transcript | tojson }}
+        "video_id": "{{ video_id }}"
       }
     </script>
 


### PR DESCRIPTION
Commit 21af690390ba0432481885f7048bb06d17a65dbb (https://github.com/hypothesis/via/pull/981) removed `transcript` from the variables that the Python code passes to the `view_video.html.jinja2` template but neglected to remove the template code that tries to read `transcript`, so template rendering is now crashing. Fix this by removing `transcript` from the template as well.
