### PR TITLE
Allow `via.*` query params to `view_video()`

### DIFF
--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,3 +1,4 @@
+import marshmallow
 from h_vialib import Configuration
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
@@ -9,8 +10,10 @@ from via.services import YouTubeService
 
 
 @view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
-@use_kwargs({"url": fields.Url(required=True)}, location="query")
-def youtube(request, url):
+@use_kwargs(
+    {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
+)
+def youtube(request, url, **kwargs):
     youtube_service = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:
@@ -21,7 +24,7 @@ def youtube(request, url):
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
 
-    _, client_config = Configuration.extract_from_params(request.params)
+    _, client_config = Configuration.extract_from_params(kwargs)
 
     return {
         "client_embed_url": request.registry.settings["client_embed_url"],


### PR DESCRIPTION
The URLs that h-vialib generates to the `view_video()` view include various `via.*` query params for configuring the client. Fix the view's new webargs schema to allow these `via.*` query params rather than raising a `ValidationError`.

This actually allows *any* unknown query params to be passed to the view in the `kwargs` argument, not just `via.*` params. But all the view does with `kwargs` is pass them to h-vialib's `extract_from_params()` method which only returns known params:

https://github.com/hypothesis/h-vialib/blob/e3d518e382d944024772dca7b3ee7a8b53be5767/src/h_vialib/configuration.py#L38C1-L48
