### PR TITLE
Adapt video-app controls for different app widths

### DIFF
--- a/via/static/scripts/video_player/hooks/use-app-layout.ts
+++ b/via/static/scripts/video_player/hooks/use-app-layout.ts
@@ -20,6 +20,7 @@ export function useAppLayout(
 
   const updateWidth = useCallback(() => {
     const containerWidth = appContainer.current?.clientWidth;
+    /* istanbul ignore next */
     if (!containerWidth) {
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,9 +1343,9 @@
     glob "^7.2.0"
 
 "@hypothesis/frontend-shared@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.1.1.tgz#c3bd46f162e20c9c5612dd66f3fa4bb2e911f674"
-  integrity sha512-GGk6eb8pRNuqLN+QtQHQn+CC2ab7m5+a6cye0MSWkvuEclh8wLSxEHQk8/74xN9BJeWRWPbBNEswxKui8kph/A==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.3.0.tgz#4b5b5190edab671747a1506316647bd0f5c61862"
+  integrity sha512-vM8BeeLgHJiW4iOi25ZDVFfzM/LE4YGMMT/stWhFIycTJ+g6oujkyDtn1Xu+ZN2GolBtY3Jx3bovvLCVFcW+PA==
   dependencies:
     highlight.js "^11.6.0"
     wouter-preact "^2.10.0-alpha.1"
@@ -7061,9 +7061,9 @@ workerpool@6.2.1:
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wouter-preact@^2.10.0-alpha.1:
-  version "2.10.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/wouter-preact/-/wouter-preact-2.10.0-alpha.1.tgz#213394a210d1566f8bd5bfc794909b10cafb09b2"
-  integrity sha512-V6K8YBIURy9PHbF1e2P0gCuhCy0Oe0GbD1EZ1VxEWLU/rtBZ7IwkTj+6QVJ236NFbCklDuwL68PiUg44sSgq/w==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/wouter-preact/-/wouter-preact-2.11.0.tgz#587b12381a5b582be19cd2dcc77e9b6837fe5437"
+  integrity sha512-0eGcl9kI1lk/85/6uri46s5rP+j92F1US2FHzG1ezwF97l0Mas/1n0q9YmKNX3s1VzMxO+ajYKRfAKbsxn+/sA==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This PR adjusts the styling and layout of controls in the video-annotation application for different widths, and polishes the styling of some button controls.

The main goals here were to address some shortcomings in the single-column layout:

* Search bar was too far from transcript content (#993)
* We need to give the transcript more vertical space (#994)

Visible changes here are primarily for narrow screens, but transcript-control button styling has also been updated to match our button design patterns.

Before, narrow screens:

<img width="612" alt="Screen Shot 2023-06-15 at 3 18 04 PM" src="https://github.com/hypothesis/via/assets/439947/c04dea00-94b2-410f-960d-f6ba3a71c400">

After, narrow screens:

<img width="627" alt="Screen Shot 2023-06-16 at 2 52 21 PM" src="https://github.com/hypothesis/via/assets/439947/d71832bd-1c04-4b98-898e-de0b1b460dc5">

Note that the semi-transparent sidebar/bucket-bar overlay is a little obnoxious here, especially since it doesn't ever have buckets. I'll track that separately.

After, wider screens (only significant change is button styling):

<img width="1461" alt="Screen Shot 2023-06-16 at 2 53 28 PM" src="https://github.com/hypothesis/via/assets/439947/32caa32f-d25d-4074-9932-7ea3b78a3253">

## What's changed

* The top bar is only rendered in multi-column layouts, saving vertical space when in single-column
* The vertical height of the "footer" is decreased, to give more space to the transcript itself (NB: styling of the auto-scroll control is not done yet)
* Branding and the filter/search input is combined with the transcript controls for single-column layouts. We'll have to keep an eye on things when we add the "scroll to top/bottom" buttons to this set of controls, to make sure the search input is still a usable width.
* Because the "Play/Pause" button is so close to the video element when in single-column view, I have elected not to render it to save room.

We're still in "a bit messy" mode here in terms of DRYing out layout and components, but I've done my best to keep things as sane as possible for the moment.

If this passes muster, it should:

Fix #993 
Fix #994