### PR TITLE
Revert "Add Checkmate to `view_video()`"

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import sentinel
 
 import pytest
-from checkmatelib import BadURL as CheckmateBadURL
 from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 from pyramid.httpexceptions import HTTPUnauthorized
 
@@ -16,6 +15,8 @@ from via.views.view_video import youtube
 @pytest.mark.usefixtures("youtube_service")
 class TestViewVideo:
     def test_it(self, pyramid_request, Configuration, youtube_service, video_url):
+        youtube_service.get_video_id.return_value = sentinel.youtube_video_id
+
         response = youtube(pyramid_request)
 
         youtube_service.get_video_id.assert_called_once_with(video_url)
@@ -27,16 +28,6 @@ class TestViewVideo:
             "client_config": Configuration.extract_from_params.return_value[1],
             "video_id": sentinel.youtube_video_id,
         }
-
-    def test_it_raises_if_the_url_is_blocked_by_checkmate(
-        self, pyramid_request, video_url
-    ):
-        pyramid_request.checkmate.raise_if_blocked.side_effect = CheckmateBadURL
-
-        with pytest.raises(CheckmateBadURL):
-            youtube(pyramid_request)
-
-        pyramid_request.checkmate.raise_if_blocked.assert_called_once_with(video_url)
 
     def test_it_errors_if_the_url_is_invalid(self, pyramid_request):
         pyramid_request.params["url"] = "not_a_valid_url"
@@ -79,11 +70,6 @@ class TestViewVideo:
             {"url": video_url, "via.foo": "foo", "via.bar": "bar"}
         )
         return pyramid_request
-
-    @pytest.fixture
-    def youtube_service(self, youtube_service):
-        youtube_service.get_video_id.return_value = sentinel.youtube_video_id
-        return youtube_service
 
 
 @pytest.fixture(autouse=True)

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -24,8 +24,6 @@ def youtube(request, url, **kwargs):
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
 
-    request.checkmate.raise_if_blocked(url)
-
     _, client_config = Configuration.extract_from_params(kwargs)
 
     return {


### PR DESCRIPTION
Reverts hypothesis/via#989. There's a problem with the new YouTube page having Checkmate support: Checkmate blocks YouTube! And I [had trouble unblocking it](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1686838693727549). But even if we could unblock YouTube there's still a problem: the new YouTube support only applies to single-video YouTube pages, not to YouTube's front page, channel pages, user pages, etc. Unblocking YouTube would cause all these other YouTube pages to get forwarded to Via HTML and we don't want Via HTML proxying these pages because pywb proxies the bytes of the videos through our servers which causes performance issues with our service.

There's little need for Checkmate support on the new YouTube page anyway: the page can only be used to proxy YouTube videos. The only purpose of Checkmate support would be to enable us to block some YouTube videos while allowing all others by default. I'll re-open <https://github.com/hypothesis/via/issues/978> for that reason but it doesn't seem very important.