### PR TITLE
Catch out of date calls to static content so we don't send fail

### DIFF
--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -1,9 +1,16 @@
 from unittest.mock import create_autospec, sentinel
 
 import pytest
+from pyramid.httpexceptions import HTTPGone
 
 from via.resources import PathURLResource
-from via.views.proxy import proxy
+from via.views.proxy import proxy, static_fallback
+
+
+class TestStaticFallback:
+    def test_it(self):
+        with pytest.raises(HTTPGone):
+            static_fallback(sentinel.context, sentinel.request)
 
 
 class TestProxy:

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -28,6 +28,7 @@ def add_routes(config):  # pragma: no cover
     config.add_route("proxy_d2l_pdf", "/d2l/proxied.pdf", factory=QueryURLResource)
     config.add_route("proxy_python_pdf", "proxied.pdf", factory=QueryURLResource)
 
+    config.add_route("static_fallback", "/static/{url:.*}")
     config.add_route("proxy", "/{url:.*}", factory=PathURLResource)
 
 

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,6 +1,14 @@
+from pyramid.httpexceptions import HTTPGone
 from pyramid.view import view_config
 
 from via.services import URLDetailsService, ViaClientService
+
+
+@view_config(route_name="static_fallback")
+def static_fallback(_context, _request):
+    """Make sure we don't try to proxy out of date static content."""
+
+    raise HTTPGone("It appears you have requested out of date content")
 
 
 @view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")


### PR DESCRIPTION
Normally we'd try to proxy these, then call checkmate, then fail because "static" doesn't validate as a domain name.

This is related to [an incident](https://hypothes-is.slack.com/archives/C074BUPEG/p1687205157061859), and presents a possible solution.

## What's happening?

The fault is as follows I think:

- We deploy a new PDFJS
- This re-generates the content and rehashes it to invalidate caches
- This doesn't invalidate the cache of the calling page, which continues to request the old URL
- Whitenoise doesn't grab the URL for some reason
- We fall through to trying to proxy it as content
- Checkmate (correctly) says this doesn't look like a URL

## Commentary

Although the specific case here is probably a mistake, it's worth pointing out that in the in the general case this behavior is correct. A user visiting:

* http://via.hypothes.is/absoluterubbishurl/path/more_url

Should be presented with the "The URL isn't valid". I'm not sure we want to be waking people up because someone types nonsense into Via / LMS.

## Testing notes

 * Start Via and proxy a PDF
 * Pick a piece of static content with the salt
 * For me this works: http://0.0.0.0:9082/static/c40b3049f4818e2679a49445a1a66bf3/vendor/pdfjs-2/web/images/toolbarButton-menuArrow.svg
 * You should get the content
 * Change the salt to something broken:
 * http://0.0.0.0:9082/static/BROKEN/vendor/pdfjs-2/web/images/toolbarButton-menuArrow.svg
 * In main you get a failure "The URL isn't valid"
 * In this branch you get a 410 Gone