### PR TITLE
Add caching to `CheckmateService.check_url()`

### DIFF
--- a/via/services/checkmate.py
+++ b/via/services/checkmate.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from checkmatelib import BadURL as CheckmateBadURL
 from checkmatelib import CheckmateClient, CheckmateException
 from pyramid.httpexceptions import HTTPTemporaryRedirect
@@ -12,6 +14,7 @@ class CheckmateService:
         self._blocked_for = blocked_for
         self._ignore_reasons = ignore_reasons
 
+    @lru_cache
     def check_url(self, url):
         return self._checkmate_client.check_url(
             url,


### PR DESCRIPTION
This is so that different parts of the Via code (e.g. different views and services) can blindly call `CheckmateService.check_url()` whenever they need to without worrying about whether something else somewhere else in the code has already called `check_url()` in the current request for the same URL: you can call it multiple times and it won't actually make multiple requests to Checkmate.

This is going to make some upcoming behaviour changes simpler to implement.
