### PR TITLE
Make `ViaClientService.url_for()`'s `content_type` dependency public

### DIFF
--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -19,21 +19,11 @@ class TestViaClientService:
     def test_content_type(self, mime_type, expected_content_type, svc):
         assert svc.content_type(mime_type) == expected_content_type
 
-    @pytest.mark.parametrize(
-        "mime_type,expected_content_type",
-        [
-            ("application/pdf", ContentType.PDF),
-            ("text/html", ContentType.HTML),
-            (None, ContentType.HTML),
-        ],
-    )
-    def test_url_for(self, mime_type, expected_content_type, svc, via_client):
-        params = {"foo": "bar"}
-
-        url = svc.url_for(sentinel.url, mime_type, params)
+    def test_url_for(self, svc, via_client):
+        url = svc.url_for(sentinel.url, sentinel.content_type, sentinel.params)
 
         via_client.url_for.assert_called_once_with(
-            sentinel.url, expected_content_type, params
+            sentinel.url, sentinel.content_type, sentinel.params
         )
         assert url == via_client.url_for.return_value
 

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -27,8 +27,9 @@ class TestProxy:
 
         pyramid_request.checkmate.raise_if_blocked.assert_called_once_with(url)
         url_details_service.get_url_details.assert_called_once_with(url)
+        via_client_service.content_type.assert_called_once_with(sentinel.mime_type)
         via_client_service.url_for.assert_called_once_with(
-            url, sentinel.mime_type, pyramid_request.params
+            url, via_client_service.content_type.return_value, pyramid_request.params
         )
         assert result == {"src": via_client_service.url_for.return_value}
 

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -53,7 +53,7 @@ class TestRouteByContent:
         )
         via_client_service.content_type.assert_called_once_with(sentinel.mime_type)
         via_client_service.url_for.assert_called_once_with(
-            url, sentinel.mime_type, {"foo": "bar"}
+            url, via_client_service.content_type.return_value, {"foo": "bar"}
         )
         assert response == temporary_redirect_to(
             via_client_service.url_for.return_value

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -17,13 +17,9 @@ class ViaClientService:
     def __init__(self, via_client):
         self.via_client = via_client
 
-    def url_for(self, url, mime_type, params):
+    def url_for(self, url, content_type, params):
         """Return a Via URL for the given `url`."""
-        return self.via_client.url_for(
-            url,
-            content_type=self.content_type(mime_type),
-            options=params,
-        )
+        return self.via_client.url_for(url, content_type=content_type, options=params)
 
 
 def factory(_context, request):

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -20,8 +20,7 @@ def proxy(context, request):
         url
     )
 
-    return {
-        "src": request.find_service(ViaClientService).url_for(
-            url, mime_type, request.params
-        )
-    }
+    via_client_svc = request.find_service(ViaClientService)
+    content_type = via_client_svc.content_type(mime_type)
+
+    return {"src": via_client_svc.url_for(url, content_type, request.params)}

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -19,7 +19,8 @@ def route_by_content(context, request):
     )
     via_client_svc = request.find_service(ViaClientService)
 
-    if via_client_svc.content_type(mime_type) in (ContentType.PDF, ContentType.YOUTUBE):
+    content_type = via_client_svc.content_type(mime_type)
+    if content_type in (ContentType.PDF, ContentType.YOUTUBE):
         caching_headers = _caching_headers(max_age=300)
     else:
         caching_headers = _cache_headers_for_http(status_code)
@@ -27,7 +28,7 @@ def route_by_content(context, request):
     params = dict(request.params)
     params.pop("url", None)
 
-    url = via_client_svc.url_for(url, mime_type, params)
+    url = via_client_svc.url_for(url, content_type, params)
 
     return exc.HTTPFound(url, headers=caching_headers)
 


### PR DESCRIPTION
`ViaClientService.url_for()` privately depends on the `ContentType`
associated with the given MIME type - `ViaClientService` calls its own
`content_type()` method to get the `ContentType` for the given
`mime_type`:

    def url_for(self, url, mime_type, params):
        return self.via_client.url_for(
            url,
            content_type=self.content_type(mime_type),
            options=params,
        )

In the future code that uses `ViaClientService` is going to have to
treat URLs differently based on their content-type. For example YouTube
URLs are going to be treated differently. Make `content_type` an
explicit argument to `url_for()` so that in future PRs we can write
logic like this:

    content_type = via_client_svc.content_type(mime_type)

    if content_type = ContentType.YOUTUBE:
        # Do something.
    else:
        # Do something else.

    url = via_client_svc.url_for(url, content_type, ...)

    # Do something with `url`.
