### PR TITLE
Don't call Checkmate for YouTube URLs

### DIFF
--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -15,12 +15,7 @@ class TestStaticFallback:
 
 class TestProxy:
     def test_it(
-        self,
-        context,
-        pyramid_request,
-        url_details_service,
-        via_client_service,
-        checkmate_service,
+        self, context, pyramid_request, url_details_service, via_client_service
     ):
         url_details_service.get_url_details.return_value = (
             sentinel.mime_type,
@@ -30,7 +25,6 @@ class TestProxy:
 
         result = proxy(context, pyramid_request)
 
-        checkmate_service.raise_if_blocked.assert_called_once_with(url)
         url_details_service.get_url_details.assert_called_once_with(url)
         via_client_service.url_for.assert_called_once_with(
             url, sentinel.mime_type, pyramid_request.params

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -36,7 +36,6 @@ class TestRouteByContent:
         pyramid_request,
         status_code,
         via_client_service,
-        checkmate_service,
     ):
         pyramid_request.params = {"url": sentinel.url, "foo": "bar"}
         url_details_service.get_url_details.return_value = (
@@ -48,7 +47,6 @@ class TestRouteByContent:
         response = route_by_content(context, pyramid_request)
 
         url = context.url_from_query.return_value
-        checkmate_service.raise_if_blocked.assert_called_once_with(url)
         url_details_service.get_url_details.assert_called_once_with(
             url, pyramid_request.headers
         )

--- a/via/services/url_details.py
+++ b/via/services/url_details.py
@@ -27,10 +27,10 @@ class URLDetailsService:
         :param headers: The original headers the request was made with
         :return: 2-tuple of (mime type, status code)
 
-        :raise BadURL: When the URL is malformed
+        :raise BadURL: if the URL is malformed
         :raise checkmatelib.BadURL: if the URL is blocked by Checkmate
-        :raise UpstreamServiceError: If we server gives us errors
-        :raise UnhandledException: For all other request based errors
+        :raise UpstreamServiceError: if we get an error from the upstream server
+        :raise UnhandledException: if we get any other request-based error
         """
         if self._youtube.enabled and self._youtube.get_video_id(url):
             return "video/x-youtube", 200

--- a/via/services/url_details.py
+++ b/via/services/url_details.py
@@ -40,13 +40,11 @@ class URLDetailsService:
         if GoogleDriveAPI.parse_file_url(url):
             return "application/pdf", 200
 
-        headers = add_request_headers(clean_headers(headers or OrderedDict()))
-
         with self._http.get(
             url,
             stream=True,
             allow_redirects=True,
-            headers=headers,
+            headers=add_request_headers(clean_headers(headers or OrderedDict())),
             timeout=10,
             raise_for_status=False,
         ) as rsp:

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,7 +1,7 @@
 from pyramid.httpexceptions import HTTPGone
 from pyramid.view import view_config
 
-from via.services import CheckmateService, URLDetailsService, ViaClientService
+from via.services import URLDetailsService, ViaClientService
 
 
 @view_config(route_name="static_fallback")
@@ -14,8 +14,6 @@ def static_fallback(_context, _request):
 @view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")
 def proxy(context, request):
     url = context.url_from_path()
-
-    request.find_service(CheckmateService).raise_if_blocked(url)
 
     mime_type, _status_code = request.find_service(URLDetailsService).get_url_details(
         url

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -4,20 +4,13 @@ from h_vialib import ContentType
 from pyramid import httpexceptions as exc
 from pyramid import view
 
-from via.services import (
-    CheckmateService,
-    URLDetailsService,
-    ViaClientService,
-    has_secure_url_token,
-)
+from via.services import URLDetailsService, ViaClientService, has_secure_url_token
 
 
 @view.view_config(route_name="route_by_content", decorator=(has_secure_url_token,))
 def route_by_content(context, request):
     """Routes the request according to the Content-Type header."""
     url = context.url_from_query()
-
-    request.find_service(CheckmateService).raise_if_blocked(url)
 
     mime_type, status_code = request.find_service(URLDetailsService).get_url_details(
         url, request.headers


### PR DESCRIPTION
This should enable us to enable the new YouTube feature in QA and production by allowing it to bypass Checkmate's YouTube block.

This PR does not enable particular YouTube URLs to still be blocked, but it does refactor the code into a shape that should make that easy to achieve. There's a separate issue for adding it: https://github.com/hypothesis/via/issues/978

## Problem

We've added a new YouTube player/annotator page to Via at `/video/youtube?url={youtube_url}` but this doesn't work in QA and production because all of YouTube is blocked by Checkmate.

[The video view itself](https://github.com/hypothesis/via/blob/eccd9f45178a89d541cfc77b77dbc9b8c308d491/via/views/view_video.py#L13-L44) doesn't actually call Checkmate but [the `proxy()` view](https://github.com/hypothesis/via/blob/eccd9f45178a89d541cfc77b77dbc9b8c308d491/via/views/proxy.py#L14-L27) (called when you paste a YouTube URL into Via's front page) and [the `route_by_content()` view](https://github.com/hypothesis/via/blob/eccd9f45178a89d541cfc77b77dbc9b8c308d491/via/views/route_by_content.py#L10-L32) (called when launch a YouTube assignment in the LMS app) both do call Checkmate, and so these views end up showing a Checkmate error rather than redirecting to or embedding the `video()` view.

The reason why YouTube is blocked is that, prior to the new YouTube feature, YouTube HTML pages would get handled by Via HTML because it tries to proxy the actual bytes of the videos through our servers and this blocks up the service.

With the new YouTube feature it's now okay to allow YouTube pages _that will be handled by the new feature_ to be proxied but the new feature only handles YouTube pages that pertain to a single video and not the YouTube front page, channel or user pages, etc. Those other YouTube pages would still get sent to Via HTML and so they must still remain blocked.

## Solution

To solve this we need to:

1. Not call Checkmate anymore for URLs that would be handled by the new YouTube page
2. Still call Checkmate as before for other URLs, including other YouTube URLs

To achieve this, this commit moves the calls to Checkmate from the `proxy()` and `route_by_content()` views into `URLDetailsService.get_url_details()`, which they both call.
This enables us to no longer call Checkmate in the case of YouTube URLs, while still always calling Checkmate before sending any requests to get the content-types and status codes of any other URLs.