### PR TITLE
Defer loading client until transcript is loaded

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -494,7 +494,12 @@ export default function VideoPlayerApp({
             </Checkbox>
           </div>
         </div>
-        <HypothesisClient src={clientSrc} config={clientConfig} />
+        {isTranscript(transcript) && (
+          // Defer loading Hypothesis client until content is ready. This is
+          // temporary until https://github.com/hypothesis/client/issues/5568
+          // is completed.
+          <HypothesisClient src={clientSrc} config={clientConfig} />
+        )}
       </main>
     </div>
   );

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -183,6 +183,13 @@ describe('VideoPlayerApp', () => {
       assert.isFalse(findSyncButton(wrapper).prop('disabled'));
     });
 
+    it("doesn't load client when transcript is loading", async () => {
+      const wrapper = createVideoPlayerUsingAPI();
+      assert.isFalse(wrapper.exists('HypothesisClient'));
+      await waitForElement(wrapper, 'Transcript');
+      assert.isTrue(wrapper.exists('HypothesisClient'));
+    });
+
     it('displays error if transcript failed to load', async () => {
       const error = new APIError(404);
       fakeCallAPI.withArgs(videoPlayerConfig.api.transcript).rejects(error);


### PR DESCRIPTION
This avoids annotations orphaning if the client tries to anchor before the content is loaded. See https://github.com/hypothesis/client/issues/5568.
