### PR TITLE
Send the actual YouTube video ID to the frontend

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -40,7 +40,7 @@ class TestViewVideo:
                 "transcript": {
                     "doc": Any.string(),
                     "url": pyramid_request.route_url(
-                        "api.youtube.transcript", video_id="1"
+                        "api.youtube.transcript", video_id=sentinel.youtube_video_id
                     ),
                     "method": "GET",
                     "headers": {

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -34,7 +34,7 @@ def youtube(request, url, **kwargs):
         "api": {
             "transcript": {
                 "doc": "Get the transcript of the current video",
-                "url": request.route_url("api.youtube.transcript", video_id="1"),
+                "url": request.route_url("api.youtube.transcript", video_id=video_id),
                 "method": "GET",
                 "headers": {
                     "Authorization": f"Bearer {ViaSecurityPolicy.encode_jwt(request)}"


### PR DESCRIPTION
Oops, forgot to remove the hard-coded fake video ID.

## Testing

The frontend now actually calls the backend API, so just open for example http://localhost:9083/https://www.youtube.com/watch?v=TbzZIMQC6vk and you should see the real transcript of the video.