### PR TITLE
Set URL for videos to canonical YouTube video URL

### DIFF
--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -64,5 +64,8 @@ def pdf_url_builder_service(mock_service):
 def youtube_service(mock_service):
     youtube_service = mock_service(YouTubeService)
     youtube_service.enabled = True
+
+    # By default, the mock reports that URLs are not YouTube URLs.
     youtube_service.get_video_id.return_value = None
+
     return youtube_service

--- a/tests/unit/via/services/youtube_test.py
+++ b/tests/unit/via/services/youtube_test.py
@@ -41,6 +41,25 @@ class TestYouTubeService:
         YouTubeTranscriptApi.get_transcript.assert_called_once_with(sentinel.video_id)
         assert transcript == YouTubeTranscriptApi.get_transcript.return_value
 
+    @pytest.mark.parametrize(
+        "video_id,expected_url",
+        [
+            ("x8TO-nrUtSI", "https://www.youtube.com/watch?v=x8TO-nrUtSI"),
+            # YouTube video IDs don't actually contain any characters that
+            # require escaping, but this is not guaranteed for the future.
+            # See https://webapps.stackexchange.com/questions/54443/format-for-id-of-youtube-video.
+            ("foo bar", "https://www.youtube.com/watch?v=foo+bar"),
+            ("foo/bar", "https://www.youtube.com/watch?v=foo%2Fbar"),
+        ],
+    )
+    def test_canonical_video_url(self, video_id, expected_url, svc):
+        assert expected_url == svc.canonical_video_url(video_id)
+
+    def test_canonical_video_url_raises_if_value_invalid(self, svc):
+        with pytest.raises(ValueError) as exc_info:
+            svc.canonical_video_url("")
+        assert str(exc_info.value) == "Invalid video ID"
+
     @pytest.fixture
     def svc(self):
         return YouTubeService(enabled=True)

--- a/tests/unit/via/services/youtube_test.py
+++ b/tests/unit/via/services/youtube_test.py
@@ -55,11 +55,6 @@ class TestYouTubeService:
     def test_canonical_video_url(self, video_id, expected_url, svc):
         assert expected_url == svc.canonical_video_url(video_id)
 
-    def test_canonical_video_url_raises_if_value_invalid(self, svc):
-        with pytest.raises(ValueError) as exc_info:
-            svc.canonical_video_url("")
-        assert str(exc_info.value) == "Invalid video ID"
-
     @pytest.fixture
     def svc(self):
         return YouTubeService(enabled=True)

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -23,7 +23,7 @@ class TestViewVideo:
         video_url,
         ViaSecurityPolicy,
     ):
-        youtube_service.canonical_video_url.return_value = sentinel.canonical_video_url
+        # Override default `None` response.
         youtube_service.get_video_id.return_value = sentinel.youtube_video_id
 
         response = youtube(pyramid_request)
@@ -39,8 +39,8 @@ class TestViewVideo:
         assert response == {
             "client_embed_url": "http://hypothes.is/embed.js",
             "client_config": Configuration.extract_from_params.return_value[1],
-            "video_id": sentinel.youtube_video_id,
-            "video_url": sentinel.canonical_video_url,
+            "video_id": youtube_service.get_video_id.return_value,
+            "video_url": youtube_service.canonical_video_url.return_value,
             "api": {
                 "transcript": {
                     "doc": Any.string(),

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -23,11 +23,15 @@ class TestViewVideo:
         video_url,
         ViaSecurityPolicy,
     ):
+        youtube_service.canonical_video_url.return_value = sentinel.canonical_video_url
         youtube_service.get_video_id.return_value = sentinel.youtube_video_id
 
         response = youtube(pyramid_request)
 
         youtube_service.get_video_id.assert_called_once_with(video_url)
+        youtube_service.canonical_video_url.assert_called_once_with(
+            sentinel.youtube_video_id
+        )
         Configuration.extract_from_params.assert_called_once_with(
             {"via.foo": "foo", "via.bar": "bar"}
         )
@@ -36,6 +40,7 @@ class TestViewVideo:
             "client_embed_url": "http://hypothes.is/embed.js",
             "client_config": Configuration.extract_from_params.return_value[1],
             "video_id": sentinel.youtube_video_id,
+            "video_url": sentinel.canonical_video_url,
             "api": {
                 "transcript": {
                     "doc": Any.string(),

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -18,9 +18,6 @@ class YouTubeService:
         This is used as the URL which YouTube transcript annotations are
         associated with.
         """
-        if not video_id:
-            raise ValueError("Invalid video ID")
-
         escaped_id = quote_plus(video_id)
         return f"https://www.youtube.com/watch?v={escaped_id}"
 

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote_plus, urlparse
 
 from youtube_transcript_api import YouTubeTranscriptApi
 
@@ -10,6 +10,19 @@ class YouTubeService:
     @property
     def enabled(self):
         return self._enabled
+
+    def canonical_video_url(self, video_id: str) -> str:
+        """
+        Return the canonical URL for a YouTube video.
+
+        This is used as the URL which YouTube transcript annotations are
+        associated with.
+        """
+        if not video_id:
+            raise ValueError("Invalid video ID")
+
+        escaped_id = quote_plus(video_id)
+        return f"https://www.youtube.com/watch?v={escaped_id}"
 
     def get_video_id(self, url):
         """Return the YouTube video ID from the given URL, or None."""

--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hypothesis Video Player</title>
+    <link rel="canonical" href="{{ video_url }}"/>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     {% for url in asset_urls("video_player_css") %}
     <link rel="stylesheet" href="{{ url }}">

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -21,6 +21,7 @@ def youtube(request, url, **kwargs):
         raise HTTPUnauthorized()
 
     video_id = youtube_service.get_video_id(url)
+    video_url = youtube_service.canonical_video_url(video_id)
 
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
@@ -31,6 +32,7 @@ def youtube(request, url, **kwargs):
         "client_embed_url": request.registry.settings["client_embed_url"],
         "client_config": client_config,
         "video_id": video_id,
+        "video_url": video_url,
         "api": {
             "transcript": {
                 "doc": "Get the transcript of the current video",


### PR DESCRIPTION
 - Add a `<link rel=canonical>` to the video transcript page, which the Hypothesis client will use as the URL for annotations.

 - For YouTube videos, set this URL to `https://www.youtube.com/watch?v={video_id}`.  This is the URL that the various other URLs (`https://youtube.com?v={video_id}`, `https://youtu.be/{video_id}`, `https://youtube.com/v/{video_id}`) ultimately redirect to and is what is used as the `<link rel=canonical>` on YouTube video pages.

Part of https://github.com/hypothesis/via/issues/941

----

**Testing:**

1. Go to http://localhost:9083/https://www.youtube.com/watch?v=x8TO-nrUtSI or any of the other recognized YouTube URLs (eg. http://localhost:9083/https://youtu.be/x8TO-nrUtSI)
2. Click the "?" button at the top of the client sidebar and go to "About this version"
3. The document URL displayed in the client should be "https://www.youtube.com/watch?v=x8TO-nrUtSI". There should be a `<link rel=canonical>` tag in the inner iframe's `<head>` with this same value.

If the URL contains additional parameters, such as `t={seconds}` to set the start time, these should *not* appear in the canonical URL.