### PR TITLE
Move API error handling into exception view

### DIFF
--- a/tests/unit/via/views/api/exceptions_test.py
+++ b/tests/unit/via/views/api/exceptions_test.py
@@ -1,6 +1,36 @@
+import logging
+
 import pytest
 
 from via.views.api.exceptions import APIExceptionViews
+
+
+def test_exception(views, context, pyramid_request, report_exception_to_sentry, caplog):
+    response = views.exception()
+
+    report_exception_to_sentry.assert_called_once_with(context)
+    assert caplog.record_tuples == [
+        ("via.views.api.exceptions", logging.ERROR, str(context))
+    ]
+    assert pyramid_request.response.status_int == 500
+    assert response == {
+        "errors": [
+            {
+                "status": 500,
+                "code": "RuntimeError",
+                "title": "Something went wrong",
+                "detail": str(context).strip(),
+            }
+        ]
+    }
+
+
+def test_exception_with_a_cause(views, context):
+    context.cause = "The cause of the error"
+
+    response = views.exception()
+
+    assert response["errors"][0]["title"] == context.cause
 
 
 def test_forbidden(views, pyramid_request):
@@ -18,5 +48,15 @@ def test_notfound(views, pyramid_request):
 
 
 @pytest.fixture
-def views(pyramid_request):
-    return APIExceptionViews(pyramid_request)
+def context():
+    return RuntimeError("Test error")
+
+
+@pytest.fixture
+def views(context, pyramid_request):
+    return APIExceptionViews(context, pyramid_request)
+
+
+@pytest.fixture(autouse=True)
+def report_exception_to_sentry(patch):
+    return patch("via.views.api.exceptions.report_exception_to_sentry")

--- a/tests/unit/via/views/api/youtube_test.py
+++ b/tests/unit/via/views/api/youtube_test.py
@@ -1,4 +1,3 @@
-import logging
 from unittest.mock import sentinel
 
 import pytest
@@ -19,37 +18,7 @@ class TestGetTranscript:
             }
         }
 
-    def test_it_handles_errors_from_youtube(
-        self, caplog, pyramid_request, youtube_service, report_exception_to_sentry
-    ):
-        exception = youtube_service.get_transcript.side_effect = RuntimeError(
-            "Test error"
-        )
-
-        response = youtube.get_transcript(pyramid_request)
-
-        report_exception_to_sentry.assert_called_once_with(exception)
-        assert caplog.record_tuples == [
-            ("via.views.api.youtube", logging.ERROR, str(exception))
-        ]
-        assert pyramid_request.response.status_int == 500
-        assert response == {
-            "errors": [
-                {
-                    "status": 500,
-                    "code": "RuntimeError",
-                    "title": "Failed to get transcript from YouTube",
-                    "detail": str(exception).strip(),
-                }
-            ]
-        }
-
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.matchdict["video_id"] = sentinel.video_id
         return pyramid_request
-
-
-@pytest.fixture(autouse=True)
-def report_exception_to_sentry(patch):
-    return patch("via.views.api.youtube.report_exception_to_sentry")

--- a/via/views/api/exceptions.py
+++ b/via/views/api/exceptions.py
@@ -1,10 +1,45 @@
-from pyramid.view import forbidden_view_config, notfound_view_config, view_defaults
+import logging
+
+from h_pyramid_sentry import report_exception as report_exception_to_sentry
+from pyramid.view import (
+    exception_view_config,
+    forbidden_view_config,
+    notfound_view_config,
+    view_defaults,
+)
+
+logger = logging.getLogger(__name__)
 
 
 @view_defaults(path_info="^/api/.*", renderer="json")
 class APIExceptionViews:
-    def __init__(self, request):
+    def __init__(self, context, request):
+        self.context = context
         self.request = request
+
+    @exception_view_config(Exception)
+    def exception(self):
+        report_exception_to_sentry(self.context)
+        logger.exception(self.context)
+
+        self.request.response.status_int = 500
+
+        return {
+            "errors": [
+                {
+                    "status": self.request.response.status_int,
+                    "code": self.context.__class__.__name__,
+                    "title": str(
+                        getattr(
+                            self.context,
+                            "cause",
+                            "Something went wrong",
+                        )
+                    ),
+                    "detail": str(self.context).strip(),
+                }
+            ]
+        }
 
     @forbidden_view_config()
     def forbidden(self):

--- a/via/views/api/youtube.py
+++ b/via/views/api/youtube.py
@@ -1,6 +1,5 @@
 import logging
 
-from h_pyramid_sentry import report_exception as report_exception_to_sentry
 from pyramid.view import view_config
 
 from via.services import YouTubeService
@@ -19,26 +18,7 @@ def get_transcript(request):
 
     video_id = request.matchdict["video_id"]
 
-    try:
-        transcript = request.find_service(YouTubeService).get_transcript(video_id)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        report_exception_to_sentry(exc)
-        logger.exception(exc)
-
-        request.response.status_int = 500
-
-        return {
-            "errors": [
-                {
-                    "status": request.response.status_int,
-                    "code": exc.__class__.__name__,
-                    "title": str(
-                        getattr(exc, "cause", "Failed to get transcript from YouTube")
-                    ),
-                    "detail": str(exc).strip(),
-                }
-            ]
-        }
+    transcript = request.find_service(YouTubeService).get_transcript(video_id)
 
     return {
         "data": {


### PR DESCRIPTION
This arguably doesn't have any benefit whilst there's only one view using it but it gets the code into the right shape: services and views (and their tests) don't need to bother with exception handling or error responses at all, that's all handled by an exception view (which will apply to all views).