### PR TITLE
Fix `make template`

### DIFF
--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -3,6 +3,7 @@ h-assets
 h-pyramid-sentry
 h-vialib
 importlib_resources
+pyjwt
 pyramid-exclog
 pyramid-jinja2
 pyramid-sanity
@@ -11,3 +12,5 @@ requests
 whitenoise
 google-auth-oauthlib
 marshmallow
+webargs
+youtube-transcript-api

--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -7,3 +7,4 @@ dev: CHECKMATE_API_KEY = dev_api_key
 dev: ENABLE_FRONT_PAGE = {env:ENABLE_FRONT_PAGE:true}
 dev: DATA_DIRECTORY = .devdata/
 dev: YOUTUBE_TRANSCRIPTS = {env:YOUTUBE_TRANSCRIPTS:true}
+dev: API_JWT_SECRET = secret


### PR DESCRIPTION
Oops: some changes have been made directly to generated files rather
than using `.cookiecutter/includes/`. Fix this so that `make template`
doesn't make any unwanted changes.
