### PR TITLE
Integrate Via's new DB with Pyramid and pytest

### DIFF
--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -1,5 +1,9 @@
 {
   "programs": {
+    "make_db": {
+      "command": "bin/make_db",
+      "startsecs": "0"
+    },
     "web": {
       "command": "gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini"
     },

--- a/.cookiecutter/includes/coverage/omit
+++ b/.cookiecutter/includes/coverage/omit
@@ -1,0 +1,1 @@
+"via/pshell.py",

--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -8,9 +8,11 @@ pyramid-exclog
 pyramid-jinja2
 pyramid-sanity
 pyramid-services
+pyramid-tm
 requests
 whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
 youtube-transcript-api
+zope.sqlalchemy

--- a/bin/make_db
+++ b/bin/make_db
@@ -1,5 +1,35 @@
-"""Initialize the dev environment's DB."""
 #!/usr/bin/env python3
-import sys
+"""Initialize the dev environment's DB."""
+import alembic.command
+import alembic.config
 from pyramid.paster import bootstrap
-bootstrap("conf/development.ini")
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+from via.db import Base, create_engine
+
+
+def is_stamped(engine) -> bool:
+    """Return True if the DB is stamped with an Alembic revision ID."""
+    with engine.connect() as connection:
+        try:
+            if connection.execute(text("select * from alembic_version")).first():
+                return True
+        except ProgrammingError:
+            pass
+
+    return False
+
+
+def main():
+    with bootstrap("conf/development.ini") as env:
+        settings = env["registry"].settings
+        engine = create_engine(settings)
+
+        if not is_stamped(engine):
+            Base.metadata.create_all(engine)
+            alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -2,6 +2,14 @@
 nodaemon=true
 silent=true
 
+[program:make_db]
+command=bin/make_db
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal=KILL
+stopasgroup=true
+startsecs=0
+
 [program:web]
 command=gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini
 stdout_events_enabled=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ parallel = true
 source = ["via", "tests/unit"]
 omit = [
     "*/via/__main__.py",
+    "via/pshell.py",
 ]
 
 [tool.coverage.paths]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -136,6 +136,7 @@ packaging==21.3
     #   build
     #   marshmallow
     #   webargs
+    #   zope-sqlalchemy
 parso==0.8.2
     # via jedi
 pastedeploy==2.1.1
@@ -203,6 +204,7 @@ pyramid==2.0
     #   pyramid-jinja2
     #   pyramid-sanity
     #   pyramid-services
+    #   pyramid-tm
 pyramid-exclog==1.1
     # via -r prod.txt
 pyramid-ipython==0.2
@@ -212,6 +214,8 @@ pyramid-jinja2==2.10
 pyramid-sanity==1.0.3
     # via -r prod.txt
 pyramid-services==2.2
+    # via -r prod.txt
+pyramid-tm==2.5
     # via -r prod.txt
 pyrsistent==0.17.3
     # via
@@ -253,6 +257,7 @@ sqlalchemy==2.0.19
     # via
     #   -r prod.txt
     #   alembic
+    #   zope-sqlalchemy
 stack-data==0.6.2
     # via ipython
 supervisor==4.2.5
@@ -266,6 +271,11 @@ traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
+transaction==3.1.0
+    # via
+    #   -r prod.txt
+    #   pyramid-tm
+    #   zope-sqlalchemy
 translationstring==1.4
     # via
     #   -r prod.txt
@@ -318,7 +328,11 @@ zope-interface==5.2.0
     #   -r prod.txt
     #   pyramid
     #   pyramid-services
+    #   transaction
     #   wired
+    #   zope-sqlalchemy
+zope-sqlalchemy==3.0
+    # via -r prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
@@ -335,3 +349,4 @@ setuptools==67.7.2
     #   supervisor
     #   zope-deprecation
     #   zope-interface
+    #   zope-sqlalchemy

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -135,6 +135,7 @@ packaging==21.3
     #   marshmallow
     #   pytest
     #   webargs
+    #   zope-sqlalchemy
 pastedeploy==2.1.1
     # via
     #   -r prod.txt
@@ -189,6 +190,7 @@ pyramid==2.0
     #   pyramid-jinja2
     #   pyramid-sanity
     #   pyramid-services
+    #   pyramid-tm
 pyramid-exclog==1.1
     # via -r prod.txt
 pyramid-jinja2==2.10
@@ -196,6 +198,8 @@ pyramid-jinja2==2.10
 pyramid-sanity==1.0.3
     # via -r prod.txt
 pyramid-services==2.2
+    # via -r prod.txt
+pyramid-tm==2.5
     # via -r prod.txt
 pyrsistent==0.17.3
     # via
@@ -245,12 +249,18 @@ sqlalchemy==2.0.19
     # via
     #   -r prod.txt
     #   alembic
+    #   zope-sqlalchemy
 tomli==2.0.0
     # via
     #   build
     #   pep517
     #   pip-tools
     #   pytest
+transaction==3.1.0
+    # via
+    #   -r prod.txt
+    #   pyramid-tm
+    #   zope-sqlalchemy
 translationstring==1.4
     # via
     #   -r prod.txt
@@ -307,7 +317,11 @@ zope-interface==5.2.0
     #   -r prod.txt
     #   pyramid
     #   pyramid-services
+    #   transaction
     #   wired
+    #   zope-sqlalchemy
+zope-sqlalchemy==3.0
+    # via -r prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
@@ -323,3 +337,4 @@ setuptools==67.7.2
     #   pyramid
     #   zope-deprecation
     #   zope-interface
+    #   zope-sqlalchemy

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -211,6 +211,7 @@ packaging==21.3
     #   marshmallow
     #   pytest
     #   webargs
+    #   zope-sqlalchemy
 pastedeploy==2.1.1
     # via
     #   -r functests.txt
@@ -296,6 +297,7 @@ pyramid==2.0
     #   pyramid-jinja2
     #   pyramid-sanity
     #   pyramid-services
+    #   pyramid-tm
 pyramid-exclog==1.1
     # via
     #   -r functests.txt
@@ -309,6 +311,10 @@ pyramid-sanity==1.0.3
     #   -r functests.txt
     #   -r tests.txt
 pyramid-services==2.2
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+pyramid-tm==2.5
     # via
     #   -r functests.txt
     #   -r tests.txt
@@ -379,6 +385,7 @@ sqlalchemy==2.0.19
     #   -r functests.txt
     #   -r tests.txt
     #   alembic
+    #   zope-sqlalchemy
 toml==0.10.2
     # via -r lint.in
 tomli==2.0.0
@@ -393,6 +400,12 @@ tomli==2.0.0
     #   pytest
 tomlkit==0.11.0
     # via pylint
+transaction==3.1.0
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+    #   pyramid-tm
+    #   zope-sqlalchemy
 translationstring==1.4
     # via
     #   -r functests.txt
@@ -473,7 +486,13 @@ zope-interface==5.2.0
     #   -r tests.txt
     #   pyramid
     #   pyramid-services
+    #   transaction
     #   wired
+    #   zope-sqlalchemy
+zope-sqlalchemy==3.0
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
@@ -493,3 +512,4 @@ setuptools==67.7.2
     #   pyramid
     #   zope-deprecation
     #   zope-interface
+    #   zope-sqlalchemy

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -14,9 +14,11 @@ pyramid-exclog
 pyramid-jinja2
 pyramid-sanity
 pyramid-services
+pyramid-tm
 requests
 whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
 youtube-transcript-api
+zope.sqlalchemy

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -76,6 +76,7 @@ packaging==21.3
     # via
     #   marshmallow
     #   webargs
+    #   zope-sqlalchemy
 pastedeploy==2.1.1
     # via plaster-pastedeploy
 plaster==1.0
@@ -108,6 +109,7 @@ pyramid==2.0
     #   pyramid-jinja2
     #   pyramid-sanity
     #   pyramid-services
+    #   pyramid-tm
 pyramid-exclog==1.1
     # via -r prod.in
 pyramid-jinja2==2.10
@@ -115,6 +117,8 @@ pyramid-jinja2==2.10
 pyramid-sanity==1.0.3
     # via -r prod.in
 pyramid-services==2.2
+    # via -r prod.in
+pyramid-tm==2.5
     # via -r prod.in
 pyrsistent==0.17.3
     # via jsonschema
@@ -143,6 +147,11 @@ sqlalchemy==2.0.19
     # via
     #   -r prod.in
     #   alembic
+    #   zope-sqlalchemy
+transaction==3.1.0
+    # via
+    #   pyramid-tm
+    #   zope-sqlalchemy
 translationstring==1.4
     # via pyramid
 typing-extensions==4.7.1
@@ -179,7 +188,11 @@ zope-interface==5.2.0
     # via
     #   pyramid
     #   pyramid-services
+    #   transaction
     #   wired
+    #   zope-sqlalchemy
+zope-sqlalchemy==3.0
+    # via -r prod.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==67.7.2
@@ -191,3 +204,4 @@ setuptools==67.7.2
     #   pyramid
     #   zope-deprecation
     #   zope-interface
+    #   zope-sqlalchemy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -137,6 +137,7 @@ packaging==21.3
     #   marshmallow
     #   pytest
     #   webargs
+    #   zope-sqlalchemy
 pastedeploy==2.1.1
     # via
     #   -r prod.txt
@@ -191,6 +192,7 @@ pyramid==2.0
     #   pyramid-jinja2
     #   pyramid-sanity
     #   pyramid-services
+    #   pyramid-tm
 pyramid-exclog==1.1
     # via -r prod.txt
 pyramid-jinja2==2.10
@@ -198,6 +200,8 @@ pyramid-jinja2==2.10
 pyramid-sanity==1.0.3
     # via -r prod.txt
 pyramid-services==2.2
+    # via -r prod.txt
+pyramid-tm==2.5
     # via -r prod.txt
 pyrsistent==0.17.3
     # via
@@ -247,6 +251,7 @@ sqlalchemy==2.0.19
     # via
     #   -r prod.txt
     #   alembic
+    #   zope-sqlalchemy
 tomli==2.0.0
     # via
     #   build
@@ -254,6 +259,11 @@ tomli==2.0.0
     #   pep517
     #   pip-tools
     #   pytest
+transaction==3.1.0
+    # via
+    #   -r prod.txt
+    #   pyramid-tm
+    #   zope-sqlalchemy
 translationstring==1.4
     # via
     #   -r prod.txt
@@ -305,7 +315,11 @@ zope-interface==5.2.0
     #   -r prod.txt
     #   pyramid
     #   pyramid-services
+    #   transaction
     #   wired
+    #   zope-sqlalchemy
+zope-sqlalchemy==3.0
+    # via -r prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
@@ -321,3 +335,4 @@ setuptools==67.7.2
     #   pyramid
     #   zope-deprecation
     #   zope-interface
+    #   zope-sqlalchemy

--- a/tests/factories/factoryboy_sqlalchemy_session.py
+++ b/tests/factories/factoryboy_sqlalchemy_session.py
@@ -1,0 +1,48 @@
+import sys
+
+from factory.alchemy import SQLAlchemyModelFactory
+
+
+def set_factoryboy_sqlalchemy_session(session, persistence=None):
+    # Set the Meta.sqlalchemy_session option on all our SQLAlchemy test factory
+    # classes. We can't do it in the normal Factory Boy way:
+    #
+    #     class MyFactory:
+    #         class Meta:
+    #             sqlalchemy_session = session
+    #
+    # Because we don't have `session` available to us at import time.
+    # So we have to do it this way instead.
+    #
+    # See:
+    # https://factoryboy.readthedocs.io/en/latest/orms.html#sqlalchemy
+    # https://factoryboy.readthedocs.io/en/latest/reference.html#factory.Factory._meta
+    for factory_class in _sqlalchemy_factory_classes():
+        # pylint:disable=protected-access
+        factory_class._meta.sqlalchemy_session = session
+
+        if persistence:
+            factory_class._meta.sqlalchemy_session_persistence = persistence
+
+
+def clear_factoryboy_sqlalchemy_session():
+    # Delete the sqlalchemy session from all our test factories.
+    # Just in case, so we don't have references to the session hanging about.
+    for factory_class in _sqlalchemy_factory_classes():
+        factory_class._meta.sqlalchemy_session = None  # pylint:disable=protected-access
+
+
+def _sqlalchemy_factory_classes():
+    """Return all the SQLAlchemy factory classes from tests.factories."""
+
+    # Get the package that this module belongs to.
+    package = sys.modules[sys.modules[__name__].__package__]
+
+    for value in package.__dict__.values():
+        try:
+            is_sqla_factory = issubclass(value, SQLAlchemyModelFactory)
+        except TypeError:
+            is_sqla_factory = False
+
+        if is_sqla_factory:
+            yield value

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 """A place to put fixture functions that are useful application-wide."""
 import functools
 
+import pytest
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
@@ -34,8 +35,10 @@ def pyramid_config(pyramid_settings):
 
 @pytest.fixture
 def pyramid_request(
+    db_session,
     pyramid_config,  # pylint:disable=unused-argument
 ):
     pyramid_request = testing.DummyRequest()
     apply_request_extensions(pyramid_request)
+    pyramid_request.db = db_session
     return pyramid_request

--- a/tests/unit/via/app_test.py
+++ b/tests/unit/via/app_test.py
@@ -3,8 +3,7 @@ from unittest import mock
 
 import pytest
 
-from via.app import configure_jinja2_assets, create_app, load_settings
-from via.sentry_filters import SENTRY_FILTERS
+from via.app import configure_jinja2_assets, load_settings
 
 
 class TestConfigureJinja2Assets:
@@ -41,29 +40,6 @@ def test_settings_are_configured_from_environment_variables(pyramid_settings):
 
     for key, value in expected_settings.items():
         assert settings[key] == value
-
-
-@pytest.mark.usefixtures("os")
-def test_app(configurator, pyramid, pyramid_settings):
-    create_app()
-
-    expected_settings = dict(
-        {"h_pyramid_sentry.filters": SENTRY_FILTERS}, **pyramid_settings
-    )
-    expected_settings["data_directory"] = Path(pyramid_settings["data_directory"])
-
-    pyramid.config.Configurator.assert_called_once_with(settings=expected_settings)
-    configurator.make_wsgi_app.assert_called_once_with()
-
-
-@pytest.fixture
-def configurator(pyramid):
-    return pyramid.config.Configurator.return_value
-
-
-@pytest.fixture(autouse=True)
-def pyramid(patch):
-    return patch("via.app.pyramid")
 
 
 @pytest.fixture

--- a/via/app.py
+++ b/via/app.py
@@ -13,6 +13,7 @@ from via.sentry_filters import SENTRY_FILTERS
 
 PARAMETERS = {
     "client_embed_url": {"required": True},
+    "database_url": {"required": True},
     "nginx_server": {"required": True},
     "via_html_url": {"required": True},
     "checkmate_url": {"required": True},
@@ -63,17 +64,23 @@ def load_settings(settings):
     return settings
 
 
-def create_app(_=None, **settings):
+def create_app(_=None, **settings):  # pragma: no cover
     """Configure and return the WSGI app."""
     config = pyramid.config.Configurator(settings=load_settings(settings))
 
     config.set_security_policy(ViaSecurityPolicy())
+
+    config.registry.settings["tm.annotate_user"] = False
+    config.registry.settings["tm.manager_hook"] = "pyramid_tm.explicit_manager"
+    config.include("pyramid_tm")
 
     config.include("pyramid_exclog")
     config.include("pyramid_jinja2")
     config.include("pyramid_services")
     config.include("h_pyramid_sentry")
 
+    config.include("via.models")
+    config.include("via.db")
     config.include("via.assets")
     config.include("via.views")
     config.include("via.services")

--- a/via/db.py
+++ b/via/db.py
@@ -1,0 +1,57 @@
+import alembic.command
+import alembic.config
+import zope.sqlalchemy
+from sqlalchemy import MetaData, create_engine, text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Session
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_N_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_N_name)s_%(referred_table_name)s_%(referred_column_0_N_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
+
+
+def stamp(engine):  # pragma: no cover
+    """If the DB isn't already stamped then stamp it with the latest revision."""
+    stamped = False
+
+    with engine.connect() as connection:
+        try:
+            if connection.execute(text("select * from alembic_version")).first():
+                stamped = True
+        except ProgrammingError:
+            pass
+
+    if not stamped:
+        alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
+
+
+def includeme(config):  # pragma: no cover
+    engine = create_engine(config.registry.settings["database_url"])
+
+    def db_session(request):
+        """Return the SQLAlchemy session for the given request."""
+        session = Session(engine, info={"request": request})
+
+        # Register the session with pyramid_tm/transaction so that they'll
+        # create a new DB transaction for each request and close the session at
+        # the end of the request.
+        zope.sqlalchemy.register(session, transaction_manager=request.tm)
+
+        return session
+
+    if config.registry.settings.get("dev"):
+        # Create the database tables if they don't already exist.
+        Base.metadata.create_all(engine)
+        stamp(engine)
+
+    # Make the SQLAlchemy session available as `request.db`.
+    # `reify=True` means it'll create only one session per request.
+    config.add_request_method(db_session, name="db", reify=True)

--- a/via/models/__init__.py
+++ b/via/models/__init__.py
@@ -1,0 +1,2 @@
+def includeme(_config):  # pragma: no cover
+    pass

--- a/via/pshell.py
+++ b/via/pshell.py
@@ -1,2 +1,21 @@
-def setup(_env):  # pragma: no cover
-    return
+from tests import factories
+from tests.factories.factoryboy_sqlalchemy_session import (
+    set_factoryboy_sqlalchemy_session,
+)
+from via import models
+
+
+def setup(env):
+    env["tm"] = env["request"].tm
+    env["tm"].__doc__ = "Active transaction manager (a transaction is already begun)."
+    env["request"].tm.begin()
+
+    env["db"] = env["request"].db
+    env["db"].__doc__ = "Active DB session."
+
+    env["m"] = env["models"] = models
+    env["m"].__doc__ = "The via.models package."
+
+    env["f"] = env["factories"] = factories
+    env["f"].__doc__ = "The test factories for quickly creating objects."
+    set_factoryboy_sqlalchemy_session(env["request"].db)


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/via/pull/1077/>. This PR adds all the manual parts of adding that're needed after running `make template`. This is all the stuff that https://github.com/hypothesis/cookiecutters/pull/128 would have done for Via automatically if we had merged that PR.

## Testing

There's not much to test here since there aren't any models or tables yet. You can try out the various `make` commands. https://github.com/hypothesis/via/pull/1072 actually adds some code that you can test.