### PR TITLE
Make video player report location and title to top frame

### DIFF
--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -19,6 +19,27 @@ export function init() {
     video_id: videoId,
   } = readConfig();
 
+  // When content is displayed in an iframe, notify top-level of title and
+  // location. This also acts to tell the top-level frame that we finished
+  // loading. See proxy.html.jinja2.
+  if (window !== window.top) {
+    window.parent.postMessage(
+      {
+        type: 'metadatachange',
+        metadata: {
+          // TODO: Once https://github.com/hypothesis/via/pull/1015 lands,
+          // get the URL from `link[rel=canonical]` or pass the video URL as
+          // config.
+          location: `https://www.youtube.com/watch?v=${encodeURIComponent(
+            videoId
+          )}`,
+          title: document.title,
+        },
+      },
+      '*'
+    );
+  }
+
   render(
     <VideoPlayerApp
       videoId={videoId}


### PR DESCRIPTION
This causes the tab title to update and the loading indicator to hide when the video player app has loaded. This matches code in ViaHTML and `pdf_wrapper.html.jinja2`.

Fixes https://github.com/hypothesis/via/issues/991