### PR TITLE
Improve transcript scrolling and jumping to segments

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -282,7 +282,6 @@ export default function Transcript({
     scrollContainer.scrollTo({
       left: 0,
       top: scrollTarget,
-      behavior: 'smooth',
     });
   }, []);
 

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -440,7 +440,16 @@ export default function VideoPlayerApp({
                 controlsRef={transcriptControls}
                 currentTime={timestamp}
                 filter={trimmedFilter}
-                onSelectSegment={segment => setTimestamp(segment.start)}
+                onSelectSegment={segment => {
+                  // Clear the filter before jumping to a segment, so the user
+                  // can easily read the text that comes before and after it.
+                  //
+                  // Note that we always show the current segment, regardless
+                  // of whether a filter is applied.
+                  setFilter('');
+
+                  setTimestamp(segment.start);
+                }}
               >
                 <div
                   data-testid="bucket-bar-channel"

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -77,7 +77,6 @@ describe('Transcript', () => {
     assert.calledWith(scrollTo, {
       left: 0,
       top: 0,
-      behavior: 'smooth',
     });
   });
 
@@ -135,7 +134,6 @@ describe('Transcript', () => {
     assert.calledWith(scrollTo, {
       left: 0,
       top: 0,
-      behavior: 'smooth',
     });
   });
 

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -313,6 +313,24 @@ describe('VideoPlayerApp', () => {
     assert.equal(player.prop('time'), transcriptData.segments[1].start);
   });
 
+  it('clears filter when transcript segment is selected', () => {
+    const wrapper = createVideoPlayer();
+    setFilter(wrapper, 'foobar');
+
+    let transcript = wrapper.find('Transcript');
+    assert.equal(transcript.prop('filter'), 'foobar');
+
+    act(() => {
+      wrapper.find('Transcript').prop('onSelectSegment')(
+        transcriptData.segments[1]
+      );
+    });
+    wrapper.update();
+
+    transcript = wrapper.find('Transcript');
+    assert.equal(transcript.prop('filter'), '');
+  });
+
   it('syncs transcript when "Sync" button is clicked', () => {
     const wrapper = createVideoPlayer();
     const transcriptController = wrapper.find('Transcript').prop('controlsRef');
@@ -372,7 +390,7 @@ describe('VideoPlayerApp', () => {
     assert.equal(transcript.prop('filter'), 'foobar');
   });
 
-  it('clears transcript filter when Hypothesis client scrolls to a highlight', async () => {
+  it('clears filter when Hypothesis client scrolls to a highlight', async () => {
     const wrapper = createVideoPlayer();
 
     setFilter(wrapper, 'foobar');


### PR DESCRIPTION
This PR contains a couple of improvements related to transcript scrolling and jumping to segments, based on my experience testing out the current version on a few videos:

1. Change transcript scrolling from smooth to immediate. Immediate scrolling is IMO less distracting when watching the video, and is also faster for when the transcript scrolls larger distances.
2. Clear the filter after jumping to a segment. This makes it easier to read the text that comes before or after the segment that you've just jumped to.

See notes in commits for more details.