### PR TITLE
Ensure transcript container and contents always use full vertical space

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -338,7 +338,7 @@ export default function Transcript({
         data-testid="scroll-container"
         elementRef={scrollRef}
       >
-        <div className="flex">
+        <div className="flex min-h-full">
           <ul
             className={classnames(
               'grow shadow-r-inner p-2',

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -312,7 +312,7 @@ export default function VideoPlayerApp({
       <main
         data-testid="app-layout"
         className={classnames('w-full flex min-h-0', {
-          'flex-col': !multicolumn,
+          'flex-col grow': !multicolumn,
           'flex-row grow h-full': multicolumn,
         })}
         ref={appContainerRef}
@@ -347,7 +347,7 @@ export default function VideoPlayerApp({
         </div>
 
         <div
-          data-testid="transcript-container"
+          data-testid="transcript-and-controls-container"
           className={classnames('flex flex-col bg-grey-0 border-x', {
             // Make transcript fill available vertical space in single-column
             // layouts
@@ -417,16 +417,12 @@ export default function VideoPlayerApp({
             />
           </div>
           <div
-            className={classnames(
-              'relative',
-
-              // Override flex-basis for transcript. Otherwise this container
-              // will be sized to accomodate all transcript elements.
-              'min-h-0',
-
-              // Make the bucket bar fill this container.
-              'flex flex-col'
-            )}
+            className={classnames('relative grow', 'min-h-0', 'flex flex-col', {
+              // Ensure that this container uses all available vertical space
+              // on narrow screens
+              'h-full': !multicolumn,
+            })}
+            data-testid="transcript-container"
           >
             {isLoading && (
               <div className="flex justify-center p-8">


### PR DESCRIPTION
Ensure that the transcript container (column) always fills the full available vertical space, even if there are minimal or no transcript entries. The footer and "auto-scroll" control should always be flush against the bottom of the viewport in both wide- and narrow-screen layouts.

Fixes https://github.com/hypothesis/via/issues/1025

Before:

<img width="522" alt="Screen Shot 2023-06-29 at 1 01 37 PM" src="https://github.com/hypothesis/via/assets/439947/cc96469b-dabd-4457-9c5b-94169b41011f">

<img width="334" alt="Screen Shot 2023-06-29 at 1 01 28 PM" src="https://github.com/hypothesis/via/assets/439947/c3dcc102-7bf4-4847-824e-8f7edf0e59b3">


After:

<img width="527" alt="Screen Shot 2023-06-29 at 1 00 51 PM" src="https://github.com/hypothesis/via/assets/439947/f8b480cf-9878-4159-b9b5-8d66da165a41">

<img width="334" alt="Screen Shot 2023-06-29 at 1 01 02 PM" src="https://github.com/hypothesis/via/assets/439947/e2085f6e-0725-4e8e-832c-388caf40dc19">


