### PR TITLE
Restrict "More videos" to same channel

### DIFF
--- a/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
@@ -1,5 +1,5 @@
 import { AspectRatio } from '@hypothesis/frontend-shared';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import { loadYouTubeIFrameAPI } from '../utils/youtube';
 
@@ -85,11 +85,22 @@ export default function YouTubeVideoPlayer({
   time,
 }: YouTubeVideoPlayerProps) {
   const [loadError, setLoadError] = useState(null);
-  const encodedId = encodeURIComponent(videoId);
-  const encodedOrigin = encodeURIComponent(window.origin);
 
   // See https://developers.google.com/youtube/player_parameters#Manual_IFrame_Embeds
-  const playerURL = `https://www.youtube.com/embed/${encodedId}?enablejsapi=1&origin=${encodedOrigin}`;
+  const playerURL = useMemo(() => {
+    const encodedId = encodeURIComponent(videoId);
+    const url = new URL(`https://www.youtube.com/embed/${encodedId}`);
+    url.searchParams.set('enablejsapi', '1'); // Enable `YT.Player` API
+    url.searchParams.set('origin', window.origin);
+
+    // Make the "More videos" overlay show only videos from the same channel.
+    //
+    // Ideally we would be able to turn this off entirely. YT doesn't allow
+    // that, but it does at least allow us to avoid showing suggestions from
+    // other channels.
+    url.searchParams.set('rel', '0');
+    return url.toString();
+  }, [videoId]);
 
   const playerController = useRef<YT.Player>();
 

--- a/via/static/scripts/video_player/components/test/YouTubeVideoPlayer-test.js
+++ b/via/static/scripts/video_player/components/test/YouTubeVideoPlayer-test.js
@@ -89,7 +89,7 @@ describe('YouTubeVideoPlayer', () => {
     const origin = encodeURIComponent(window.origin);
     assert.equal(
       iframe.prop('src'),
-      `https://www.youtube.com/embed/abcdef?enablejsapi=1&origin=${origin}`
+      `https://www.youtube.com/embed/abcdef?enablejsapi=1&origin=${origin}&rel=0`
     );
   });
 


### PR DESCRIPTION
YouTube no longer allows turning off the "More videos" overlay [1] but it does allow recommendations to be restricted to the same channel as the current video. I think it makes sense to enable this restriction as:

 - In an education context, it keeps the content shown "closer" to what the teacher selected / from a source the teacher trusts.

 - Thumbnails from other videos in the same channel will tend to have the same aesthetic as the current video, so it makes the overlay a bit less visually jarring.

[1] https://developers.google.com/youtube/player_parameters#august-23,-2018

Closes #1022

----

**Testing:**

1. On main, start a video and pause it a few seconds later. You will see suggestions from a variety of channels.
2. On this branch, start a video and pause it. You will see suggestions only from the current channel.