### PR TITLE
Show error summary from API when transcript fails to load

### DIFF
--- a/via/static/scripts/video_player/components/TranscriptError.tsx
+++ b/via/static/scripts/video_player/components/TranscriptError.tsx
@@ -9,12 +9,6 @@ export default function TranscriptError({ error }: TranscriptErrorProps) {
     <div className="p-3">
       <h2 className="text-lg">Unable to load transcript</h2>
       <p className="mb-3">{error.error?.title ?? error.message}</p>
-      {error.error?.detail && (
-        <details>
-          <summary className="mb-2">Error details:</summary>
-          <p>{error.error.detail}</p>
-        </details>
-      )}
     </div>
   );
 }

--- a/via/static/scripts/video_player/components/TranscriptError.tsx
+++ b/via/static/scripts/video_player/components/TranscriptError.tsx
@@ -1,0 +1,20 @@
+import type { APIError } from '../utils/api';
+
+export type TranscriptErrorProps = {
+  error: APIError;
+};
+
+export default function TranscriptError({ error }: TranscriptErrorProps) {
+  return (
+    <div className="p-3">
+      <h2 className="text-lg">Unable to load transcript</h2>
+      <p className="mb-3">{error.error?.title ?? error.message}</p>
+      {error.error?.detail && (
+        <details>
+          <summary className="mb-2">Error details:</summary>
+          <p>{error.error.detail}</p>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -26,6 +26,7 @@ import { formatTranscript, mergeSegments } from '../utils/transcript';
 import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
+import TranscriptError from './TranscriptError';
 import YouTubeVideoPlayer from './YouTubeVideoPlayer';
 import { PauseIcon, PlayIcon, SyncIcon } from './icons';
 
@@ -459,9 +460,7 @@ export default function VideoPlayerApp({
               </Transcript>
             )}
             {transcript instanceof Error && (
-              <div data-testid="transcript-error">
-                Unable to load transcript: {transcript.message}
-              </div>
+              <TranscriptError error={transcript} />
             )}
             <div
               id={bucketContainerId}

--- a/via/static/scripts/video_player/components/test/TranscriptError-test.js
+++ b/via/static/scripts/video_player/components/test/TranscriptError-test.js
@@ -1,0 +1,33 @@
+import { mount } from 'enzyme';
+
+import { APIError } from '../../utils/api';
+import TranscriptError from '../TranscriptError';
+
+describe('TranscriptError', () => {
+  it('displays just `Error.message` if there are no error details', () => {
+    const wrapper = mount(
+      <TranscriptError error={new Error('Something went wrong')} />
+    );
+    assert.equal(
+      wrapper.text(),
+      ['Unable to load transcript', 'Something went wrong'].join('')
+    );
+  });
+
+  it('displays `APIError.error.title` field if present', () => {
+    const error = new APIError(404, {
+      code: 'VideoNotFound',
+      title: 'The video was not found',
+      detail: 'Some long details here',
+    });
+    const wrapper = mount(<TranscriptError error={error} />);
+    assert.equal(
+      wrapper.text(),
+      [
+        'Unable to load transcript',
+        'The video was not found',
+        'Error details:Some long details here',
+      ].join('')
+    );
+  });
+});

--- a/via/static/scripts/video_player/components/test/TranscriptError-test.js
+++ b/via/static/scripts/video_player/components/test/TranscriptError-test.js
@@ -23,11 +23,7 @@ describe('TranscriptError', () => {
     const wrapper = mount(<TranscriptError error={error} />);
     assert.equal(
       wrapper.text(),
-      [
-        'Unable to load transcript',
-        'The video was not found',
-        'Error details:Some long details here',
-      ].join('')
+      ['Unable to load transcript', 'The video was not found'].join('')
     );
   });
 });

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -195,15 +195,9 @@ describe('VideoPlayerApp', () => {
       fakeCallAPI.withArgs(videoPlayerConfig.api.transcript).rejects(error);
 
       const wrapper = createVideoPlayerUsingAPI();
-      const errorDisplay = await waitForElement(
-        wrapper,
-        '[data-testid="transcript-error"]'
-      );
+      const errorDisplay = await waitForElement(wrapper, 'TranscriptError');
 
-      assert.equal(
-        errorDisplay.text(),
-        `Unable to load transcript: ${error.message}`
-      );
+      assert.equal(errorDisplay.prop('error'), error);
     });
   });
 


### PR DESCRIPTION
The API returns JSON:API error objects with `code`, `title` and `details` fields. Show the `title` to the user instead of a generic "API call failed" message.

Part of https://github.com/hypothesis/via/issues/1028

**Testing:**

1. Go to http://localhost:9083/https://www.youtube.com/watch?v=e-43x-H4CNY
2. You should see the error message below:

<img width="913" alt="Transcript error display" src="https://github.com/hypothesis/via/assets/2458/90a6d71f-1a82-4a77-a445-d3522310b352">

Note that the error title and contents of the "Error details" box need a bunch of work on the backend to refine. For example subtitles are not so much "disabled" for this video as "not available" because the video doesn't have spoken words. This morning I also encountered the same error message for a video where the transcript just hadn't been generated. In the frontend we are just displaying what the backend sends.