### PR TITLE
Run Via's unit and functional tests in parallel

### DIFF
--- a/.cookiecutter/includes/requirements/functests.in
+++ b/.cookiecutter/includes/requirements/functests.in
@@ -1,0 +1,1 @@
+pytest-xdist[psutil]

--- a/.cookiecutter/includes/requirements/tests.in
+++ b/.cookiecutter/includes/requirements/tests.in
@@ -1,0 +1,1 @@
+pytest-xdist[psutil]

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -6,3 +6,4 @@ pytest
 factory-boy
 h-matchers
 webtest
+pytest-xdist[psutil]

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -43,6 +43,8 @@ ecdsa==0.18.0
     #   python-jose
 exceptiongroup==1.0.0rc9
     # via pytest
+execnet==1.9.0
+    # via pytest-xdist
 factory-boy==3.2.1
     # via -r functests.in
 faker==18.9.0
@@ -141,6 +143,8 @@ plaster-pastedeploy==0.7
     #   pyramid
 pluggy==0.13.1
     # via pytest
+psutil==5.9.5
+    # via pytest-xdist
 pyasn1==0.4.8
     # via
     #   -r prod.txt
@@ -183,6 +187,10 @@ pyrsistent==0.17.3
     #   -r prod.txt
     #   jsonschema
 pytest==7.4.0
+    # via
+    #   -r functests.in
+    #   pytest-xdist
+pytest-xdist[psutil]==3.3.1
     # via -r functests.in
 python-dateutil==2.8.2
     # via faker

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -51,7 +51,9 @@ click==8.1.3
     #   -r tests.txt
     #   pip-tools
 coverage[toml]==7.2.7
-    # via -r tests.txt
+    # via
+    #   -r tests.txt
+    #   pytest-cov
 cryptography==41.0.0
     # via
     #   -r functests.txt
@@ -69,6 +71,11 @@ exceptiongroup==1.0.0rc9
     #   -r functests.txt
     #   -r tests.txt
     #   pytest
+execnet==1.9.0
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+    #   pytest-xdist
 factory-boy==3.2.1
     # via
     #   -r functests.txt
@@ -227,6 +234,11 @@ pluggy==0.13.1
     #   -r functests.txt
     #   -r tests.txt
     #   pytest
+psutil==5.9.5
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+    #   pytest-xdist
 pyasn1==0.4.8
     # via
     #   -r functests.txt
@@ -291,6 +303,14 @@ pyrsistent==0.17.3
     #   -r tests.txt
     #   jsonschema
 pytest==7.4.0
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+    #   pytest-cov
+    #   pytest-xdist
+pytest-cov==4.1.0
+    # via -r tests.txt
+pytest-xdist[psutil]==3.3.1
     # via
     #   -r functests.txt
     #   -r tests.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -2,8 +2,10 @@ pip-tools
 pip-sync-faster
 -r prod.txt
 coverage[toml]
+pytest-cov
 pytest
 factory-boy
 h-matchers
 httpretty
 freezegun
+pytest-xdist[psutil]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -32,7 +32,9 @@ checkmatelib==1.0.15
 click==8.1.3
     # via pip-tools
 coverage[toml]==7.2.7
-    # via -r tests.in
+    # via
+    #   -r tests.in
+    #   pytest-cov
 cryptography==41.0.0
     # via
     #   -r prod.txt
@@ -43,6 +45,8 @@ ecdsa==0.18.0
     #   python-jose
 exceptiongroup==1.0.0rc9
     # via pytest
+execnet==1.9.0
+    # via pytest-xdist
 factory-boy==3.2.1
     # via -r tests.in
 faker==18.9.0
@@ -143,6 +147,8 @@ plaster-pastedeploy==0.7
     #   pyramid
 pluggy==0.13.1
     # via pytest
+psutil==5.9.5
+    # via pytest-xdist
 pyasn1==0.4.8
     # via
     #   -r prod.txt
@@ -185,6 +191,13 @@ pyrsistent==0.17.3
     #   -r prod.txt
     #   jsonschema
 pytest==7.4.0
+    # via
+    #   -r tests.in
+    #   pytest-cov
+    #   pytest-xdist
+pytest-cov==4.1.0
+    # via -r tests.in
+pytest-xdist[psutil]==3.3.1
     # via -r tests.in
 python-dateutil==2.8.2
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,8 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle via tests bin
     lint: pycodestyle via tests bin
-    tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
-    functests: pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
+    tests: pytest --cov --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
+    functests: pytest --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: -coverage combine
     coverage: coverage report
     template: python3 bin/make_template {posargs}


### PR DESCRIPTION
This might speed up `make test`, `make functests`, `make sure` and CI,
but it depends on how many tests there are: if there are only a small
number of tests (and the tests are fast) then running them in parallel
can actually be slower.

The amount of parallelism you get from `make sure` is more limited
because it's already running several things in parallel (tests,
functests, linting, etc) so there's fewer cores available to further
parallelise the tests and functests within that. This may make it more
likely that parallelising the unit and functional tests within `make
sure` will actually make it slower: you're paying the overhead of
paralleisation but don't actually have much parallism available.

Whenever there are more or slower unit and functional tests then I think
running them in parallel should start to make things much faster.
