### PR TITLE
Style non-dismissable errors

### DIFF
--- a/via/static/scripts/video_player/components/TranscriptError.tsx
+++ b/via/static/scripts/video_player/components/TranscriptError.tsx
@@ -1,3 +1,5 @@
+import { Callout, CautionIcon } from '@hypothesis/frontend-shared';
+
 import type { APIError } from '../utils/api';
 
 export type TranscriptErrorProps = {
@@ -6,9 +8,9 @@ export type TranscriptErrorProps = {
 
 export default function TranscriptError({ error }: TranscriptErrorProps) {
   return (
-    <div className="p-3">
+    <Callout role="alert" status="error" icon={CautionIcon}>
       <h2 className="text-lg">Unable to load transcript</h2>
-      <p className="mb-3">{error.error?.title ?? error.message}</p>
-    </div>
+      <p>{error.error?.title ?? error.message}</p>
+    </Callout>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,9 +1528,9 @@
     glob "^10.0.0"
 
 "@hypothesis/frontend-shared@^6.1.1":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.3.0.tgz#4b5b5190edab671747a1506316647bd0f5c61862"
-  integrity sha512-vM8BeeLgHJiW4iOi25ZDVFfzM/LE4YGMMT/stWhFIycTJ+g6oujkyDtn1Xu+ZN2GolBtY3Jx3bovvLCVFcW+PA==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.4.0.tgz#149c11d88b1dd5eeb0d9d2d8029c930b15b9ee3b"
+  integrity sha512-GbbVsnJZpLKy1OmdQq/6IKARSotEDumi7AMq/RdpTZc+/lczP3GDqE4Z+P1QBbnZqijgP5CiCdTwZ4I4edaI2g==
   dependencies:
     highlight.js "^11.6.0"
     wouter-preact "^2.10.0-alpha.1"


### PR DESCRIPTION
This small PR adds UI and styling for non-dismiss-able transcript errors. It bumps to v4.6.0 of `frontend-shared` to get its hands on the new `Callout` component.

Note that I've used a caution icon instead of a cancel (x) icon as @robertknight pointed out that the `x` made it look like it was interactive or dismiss-able. I've also added a `role="alert"` so that this error is picked up and read by screen readers.

We can continue to iterate on the layout of the content _inside_ the box as we go, if we so choose.

<img width="531" alt="image" src="https://github.com/hypothesis/via/assets/439947/ffe1e935-f9d7-4a71-bb86-29a2945e0b0f">
