### PR TITLE
Support m.youtube.com URLs

### DIFF
--- a/tests/unit/via/services/youtube_test.py
+++ b/tests/unit/via/services/youtube_test.py
@@ -30,6 +30,7 @@ class TestYouTubeService:
             ("https://youtu.be/VIDEO_ID", "VIDEO_ID"),
             ("https://youtube.com/shorts/VIDEO_ID?feature=share", "VIDEO_ID"),
             ("https://www.youtube.com/live/VIDEO_ID?feature=share", "VIDEO_ID"),
+            ("https://m.youtube.com/watch?v=VIDEO_ID", "VIDEO_ID"),
         ],
     )
     def test_get_video_id(self, url, expected_video_id, svc):

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -30,7 +30,7 @@ class YouTubeService:
         if parsed.netloc in "youtu.be" and len(path_parts) >= 2 and not path_parts[0]:
             return path_parts[1]
 
-        if parsed.netloc not in ["www.youtube.com", "youtube.com"]:
+        if parsed.netloc not in ["www.youtube.com", "youtube.com", "m.youtube.com"]:
             return None
 
         query_params = parse_qs(parsed.query)


### PR DESCRIPTION
Support m.youtube.com URLs in the new video player.

Fixes https://github.com/hypothesis/via/issues/1053
