### PR TITLE
Position current segment towards top of container when auto-scrolling

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -263,17 +263,17 @@ export default function Transcript({
       return;
     }
 
-    // Scroll container such that the middle of the current segment is centered
-    // in the container. Note that we don't use `currentSegment.scrollIntoView`
-    // here because that may scroll the whole document, which we don't want.
+    // Scroll the container such that the current segment is positioned towards
+    // the top. We allow more space below than above, on the assumption that the
+    // user is likely to want to read forwards further than they want to read
+    // back from the current position.
     const currentSegmentOffset = offsetRelativeTo(
       currentSegment,
       scrollContainer
     );
+
     const scrollTarget =
-      currentSegmentOffset +
-      currentSegment.clientHeight / 2 -
-      scrollContainer.clientHeight / 2;
+      currentSegmentOffset - scrollContainer.clientHeight * (1 / 4);
 
     scrollContainer.scrollTo({
       left: 0,

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -66,18 +66,30 @@ describe('Transcript', () => {
   });
 
   it('scrolls current segment into view', () => {
-    const wrapper = mount(
-      <Transcript transcript={transcript} currentTime={5} />
-    );
-    const scrollContainer = wrapper.find('div[data-testid="scroll-container"]');
-    const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+    let wrapper;
+    try {
+      wrapper = mount(<Transcript transcript={transcript} currentTime={5} />, {
+        // Render into document so transcript has a non-zero height.
+        attachTo: document.body,
+      });
+      const scrollContainer = wrapper.find(
+        'div[data-testid="scroll-container"]'
+      );
+      const scrollTo = sinon.spy(scrollContainer.getDOMNode(), 'scrollTo');
+      const segment = wrapper.find('[data-testid="segment"]').at(1);
+      const expectedTop =
+        segment.getDOMNode().offsetTop -
+        scrollContainer.getDOMNode().clientHeight * (1 / 4);
 
-    wrapper.setProps({ currentTime: 10 });
+      wrapper.setProps({ currentTime: 10 });
 
-    assert.calledWith(scrollTo, {
-      left: 0,
-      top: 0,
-    });
+      assert.calledWith(scrollTo, {
+        left: 0,
+        top: expectedTop,
+      });
+    } finally {
+      wrapper?.unmount();
+    }
   });
 
   it('does not scroll to current segment if `autoScroll` is disabled', () => {


### PR DESCRIPTION
Instead of positioning the current segment in the middle of the transcript container when auto-scrolling, position it closer to the top instead. The rationale is that the user is likely to want read ahead further than they want to read back.

Fixes https://github.com/hypothesis/via/issues/1052

Example of the new vertical positioning:

<img width="1004" alt="adjust-autoscroll-pos" src="https://github.com/hypothesis/via/assets/2458/41860d35-abdc-40d6-af87-94354db9f2b6">
