### PR TITLE
Make segments current when clicked, if not (de-)selecting text

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -87,6 +87,10 @@ type TranscriptSegmentProps = {
   text: string;
 };
 
+function hasSelection() {
+  return Boolean(window.getSelection()?.toString());
+}
+
 function TranscriptSegment({
   hidden = false,
   highlight,
@@ -124,6 +128,8 @@ function TranscriptSegment({
       ranges.forEach(r => highlight.delete(r));
     };
   }, [highlight, matches]);
+
+  const hadSelectionOnPointerDown = useRef(false);
 
   const timestamp = formatTimestamp(time);
 
@@ -194,6 +200,20 @@ function TranscriptSegment({
         )}
         data-testid="transcript-text"
         ref={contentRef}
+        // We have a "click" handler here, but don't set a role because
+        // this is a secondary way to focus the transcript. The timestamp
+        // button is the primary control for this action.
+        onPointerDown={() => {
+          hadSelectionOnPointerDown.current = hasSelection();
+        }}
+        onPointerUp={() => {
+          // Allow the user to easily select a segment by clicking it, but
+          // don't seek the video if they are selecting or de-selecting text
+          // to annotate.
+          if (!hadSelectionOnPointerDown.current && !hasSelection()) {
+            onSelect();
+          }
+        }}
       >
         {text}
         {

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -46,7 +46,7 @@ describe('Transcript', () => {
     assert.isFalse(segments.at(0).prop('data-is-current'));
   });
 
-  it('invokes callback when segment is clicked', () => {
+  it('invokes `onSelectSegment` callback when segment timestamp is clicked', () => {
     const selectSegment = sinon.stub();
     const wrapper = mount(
       <Transcript
@@ -63,6 +63,46 @@ describe('Transcript', () => {
     timestamp.simulate('click');
 
     assert.calledWith(selectSegment, transcript.segments[1]);
+  });
+
+  it('invokes `onSelectSegment` callback when segment text is clicked', () => {
+    let wrapper;
+
+    try {
+      const selectSegment = sinon.stub();
+      const wrapper = mount(
+        <Transcript
+          transcript={transcript}
+          currentTime={5}
+          onSelectSegment={selectSegment}
+        />,
+        { attachTo: document.body }
+      );
+      const timestamp = wrapper.find('[data-testid="segment"]').at(1).find('p');
+
+      // Click on segment text with no selection. This should select the segment.
+      timestamp.simulate('pointerdown');
+      timestamp.simulate('pointerup');
+      assert.calledWith(selectSegment, transcript.segments[1]);
+      selectSegment.resetHistory();
+
+      // Click on segment text, clearing existing selection in the process.
+      // This should be ignored.
+      window.getSelection().selectAllChildren(document.body);
+      timestamp.simulate('pointerdown');
+      window.getSelection().empty();
+      timestamp.simulate('pointerup');
+      assert.notCalled(selectSegment);
+
+      // Click on segment text, creating a new selection in the process.
+      // This should be ignored.
+      timestamp.simulate('pointerdown');
+      window.getSelection().selectAllChildren(document.body);
+      timestamp.simulate('pointerup');
+      assert.notCalled(selectSegment);
+    } finally {
+      wrapper?.unmount();
+    }
   });
 
   it('scrolls current segment into view', () => {


### PR DESCRIPTION
Enable users to seek to a segment by clicking the segment's text, as an alternative to clicking the timestamp, but only if the click does not create or remove a text selection. The aim is to make seeking the video more convenient / intuitive, but without causing the video position to jump if the user is trying to select text to annotate, or de-select text to remove the Annotate/Highlight popup.

Fixes https://github.com/hypothesis/via/issues/1051

**Testing:**

1. Open a video in the video player
2. Click on a segment's text, it should be made current and the video should seek to that position
3. Start selecting the text of a different segment. It should not be made current when the mouse is released.
4. Clear the selection created in step 3 by clicking on a different non-current segment. It should not be made current when the mouse is released