### PR TITLE
Expose dev server's port 9083 for any host, not just 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx-proxy:
     image: nginx:1.17.6-alpine
     ports:
-      - '127.0.0.1:9083:9083'
+      - '9083:9083'
     environment:
       - NGINX_SECURE_LINK_SECRET
     volumes:


### PR DESCRIPTION
This PR changes the behavior of nginx exposed by dev env's `docker compose` config, so that it exposes port `9083` to any IP address, not just 127.0.0.1.

This will allow things like testing the video app from a mobile device that's on the same network as the laptop/computer running via.