### PR TITLE
Disable client sidebyside; apply layout with useSideBySideLayout hook

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -18,6 +18,7 @@ import {
 } from 'preact/hooks';
 
 import { useAppLayout } from '../hooks/use-app-layout';
+import { useSideBySideLayout } from '../hooks/use-side-by-side-layout';
 import { callAPI } from '../utils/api';
 import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
@@ -139,6 +140,7 @@ export default function VideoPlayerApp({
   const appContainerRef = useRef<HTMLDivElement | null>(null);
 
   const appSize = useAppLayout(appContainerRef);
+  useSideBySideLayout();
   const multicolumn = appSize !== 'sm';
   const transcriptWidths = {
     sm: '100%',
@@ -268,17 +270,16 @@ export default function VideoPlayerApp({
     return {
       ...baseClientConfig,
       bucketContainerSelector: '#' + bucketContainerId,
+      sideBySide: {
+        mode: 'manual',
+      },
     };
   }, [baseClientConfig]);
 
   return (
     <div
       data-testid="app-container"
-      className={classnames(
-        'flex flex-col h-[100vh] min-h-0',
-        // Leave room for the sidebar toolbar/bucket-bar channel on the right
-        'mr-[20px]'
-      )}
+      className={classnames('flex flex-col h-[100vh] min-h-0')}
     >
       {multicolumn && (
         <div

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -454,13 +454,16 @@ describe('VideoPlayerApp', () => {
     assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
   });
 
-  it('configures bucket bar container for client', () => {
+  it('configures client bucket bar and disables side-by-side mode', () => {
     const clientConfig = { openSidebar: true };
     const wrapper = createVideoPlayer({ clientConfig });
     const mergedConfig = wrapper.find('HypothesisClient').prop('config');
     assert.deepEqual(mergedConfig, {
       openSidebar: true,
       bucketContainerSelector: '#bucket-container',
+      sideBySide: {
+        mode: 'manual',
+      },
     });
   });
 

--- a/via/static/scripts/video_player/hooks/test/use-app-layout-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-app-layout-test.js
@@ -46,7 +46,7 @@ describe('useAppLayout', () => {
   [
     { containerWidth: 200, expected: 'sm' },
     { containerWidth: 768, expected: 'sm' },
-    { containerWidth: 769, expected: 'md' },
+    { containerWidth: 856, expected: 'md' },
     { containerWidth: 875, expected: 'md' },
   ].forEach(({ containerWidth, expected }) => {
     it('should provide relative app size when component is rendered', () => {
@@ -66,7 +66,7 @@ describe('useAppLayout', () => {
     assert.equal(appContainerEl.prop('data-app-size'), 'sm');
 
     const steps = [
-      [800, 'md'],
+      [866, 'md'],
       [1000, 'lg'],
       [1200, 'xl'],
       [1500, '2xl'],
@@ -75,11 +75,15 @@ describe('useAppLayout', () => {
     for (const [width, expected] of steps) {
       container.style.width = `${width}px`;
 
-      await waitFor(() => {
-        wrapper.update();
-        const appContainerEl = wrapper.find('[data-testid="appContainer"]');
-        return appContainerEl.prop('data-app-size') === expected;
-      }, /* timeout */ 50);
+      await waitFor(
+        () => {
+          wrapper.update();
+          const appContainerEl = wrapper.find('[data-testid="appContainer"]');
+          return appContainerEl.prop('data-app-size') === expected;
+        },
+        /* timeout */ 50,
+        `reported app size for container of ${width} is ${expected}`
+      );
     }
   });
 });

--- a/via/static/scripts/video_player/hooks/test/use-side-by-side-layout-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-side-by-side-layout-test.js
@@ -1,0 +1,135 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import { useSideBySideLayout } from '../use-side-by-side-layout';
+import { TOOLBAR_WIDTH } from '../use-side-by-side-layout';
+
+describe('useSideBySideLayout', () => {
+  let container;
+  let wrappers;
+  let fakeLayoutDetail;
+
+  // Create a fake component to mount in tests that uses the hook
+  function FakeComponent() {
+    useSideBySideLayout(container);
+    return (
+      <div style="width:100%">
+        <button>Hi</button>
+      </div>
+    );
+  }
+
+  function renderComponent() {
+    const wrapper = mount(<FakeComponent />, { attachTo: container });
+    wrappers.push(wrapper);
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('id', 'container');
+    container.style.width = '1024px';
+    container.style.paddingRight = '0px';
+    document.body.append(container);
+
+    wrappers = [];
+
+    // Layout values here reflect dimensions of the sidebar reported in the
+    // `hypothesis:layoutchange` event at time of authoring.
+    fakeLayoutDetail = {
+      sideBySideActive: false,
+      sidebarLayout: {
+        expanded: true,
+        width: 461,
+        toolbarWidth: 33,
+        height: 0,
+      },
+    };
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+    container.remove();
+  });
+
+  function triggerEvent(detail = fakeLayoutDetail) {
+    const event = new CustomEvent('hypothesis:layoutchange', {
+      detail,
+    });
+    act(() => {
+      document.body.dispatchEvent(event);
+    });
+  }
+
+  function sideBySideState() {
+    const attr = container.getAttribute('data-side-by-side');
+    if (attr === 'true') {
+      return true;
+    } else if (attr === 'false') {
+      return false;
+    } else {
+      return undefined;
+    }
+  }
+
+  describe('initial render', () => {
+    it('does not lay out side-by-side', () => {
+      renderComponent();
+      assert.isFalse(sideBySideState());
+    });
+
+    it('provides room for sidebar controls', () => {
+      renderComponent();
+      assert.equal(container.style.paddingRight, `${TOOLBAR_WIDTH}px`);
+    });
+  });
+
+  describe('when sidebar opens', () => {
+    [875, 876, 1024, 1268].forEach(bodyWidth => {
+      it('applies side-by-side layout when there is enough space', () => {
+        container.style.width = `${bodyWidth}px`;
+        renderComponent();
+        triggerEvent();
+
+        assert.isTrue(sideBySideState());
+      });
+    });
+
+    [450, 600, 874].forEach(bodyWidth => {
+      it('allows sidebar to overlap content on narrow screens', () => {
+        container.style.width = `${bodyWidth}px`;
+        renderComponent();
+        triggerEvent();
+
+        assert.isFalse(sideBySideState());
+      });
+    });
+  });
+
+  describe('when window is resized', () => {
+    it('recalculates side-by-side layout', () => {
+      container.style.width = '450px';
+      renderComponent();
+      triggerEvent();
+
+      assert.isFalse(sideBySideState());
+
+      act(() => {
+        container.style.width = '1450px';
+        window.dispatchEvent(new Event('resize'));
+      });
+      assert.isTrue(sideBySideState());
+    });
+  });
+
+  describe('when sidebar closes', () => {
+    it('does not provide room for sidebar at right', () => {
+      renderComponent();
+      fakeLayoutDetail.sidebarLayout.expanded = false;
+      triggerEvent();
+
+      assert.isFalse(sideBySideState());
+      assert.equal(container.style.paddingRight, `${TOOLBAR_WIDTH}px`);
+    });
+  });
+});

--- a/via/static/scripts/video_player/hooks/use-app-layout.ts
+++ b/via/static/scripts/video_player/hooks/use-app-layout.ts
@@ -1,6 +1,8 @@
 import type { RefObject } from 'preact';
 import { useCallback, useLayoutEffect, useState } from 'preact/hooks';
 
+import { SIDEBYSIDE_THRESHOLD, TOOLBAR_WIDTH } from './use-side-by-side-layout';
+
 /* Relative application container size */
 export type AppSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
@@ -30,12 +32,11 @@ export function useAppLayout(
       containerSize = '2xl';
     } else if (containerWidth > 1024) {
       containerSize = 'xl';
-    } else if (containerWidth > 875) {
+    } else if (containerWidth > SIDEBYSIDE_THRESHOLD) {
       containerSize = 'lg';
-    } else if (containerWidth > 768) {
+    } else if (containerWidth >= SIDEBYSIDE_THRESHOLD - TOOLBAR_WIDTH) {
       containerSize = 'md';
     }
-
     setAppSize(containerSize);
   }, [appContainer]);
 

--- a/via/static/scripts/video_player/hooks/use-side-by-side-layout.ts
+++ b/via/static/scripts/video_player/hooks/use-side-by-side-layout.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+// `hypothesis:layoutchange` is triggered on the host document `body` element by
+// the client's `annotator`. Types are copied from the `client` project. See
+// https://github.com/hypothesis/client/blob/16e37788fdc52fd7e7b8eb9c0eece6a993334424/src/annotator/events.ts
+type SidebarLayout = {
+  /** Whether sidebar is open or closed */
+  expanded: boolean;
+  /** Current width of sidebar in pixels */
+  width: number;
+  /** Current height of sidebar in pixels */
+  height: number;
+  /** Width of controls (toolbar, bucket bar) on the edge of the sidebar */
+  toolbarWidth: number;
+};
+
+type LayoutChangeEventDetail = {
+  sideBySideActive: boolean;
+  sidebarLayout: SidebarLayout;
+};
+
+type LayoutChangeEvent = CustomEvent & { detail: LayoutChangeEventDetail };
+
+// Minimum body width at which laying out side-by-side should be considered
+export const SIDEBYSIDE_THRESHOLD = 875;
+// The sidebar reports its toolbar width as 33px. This is a custom padding
+// amount that allows this app to nestle up more cloesly to the sidebar when
+// closed.
+export const TOOLBAR_WIDTH = 22;
+
+/**
+ * Adjust the available space to the right of app content to make room for
+ * the sidebar when plausible. This mimics the client's "side-by-side" mode,
+ * tuned specifically for this application.
+ *
+ * Side-by-side layout will be re-computed whenever sidebar state via the
+ * `hypothesis:layoutchange` event changes meaningfully, or when the window
+ * is resized.
+ *
+ * @param [container] test seam
+ */
+export function useSideBySideLayout(container = document.body) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sufficientSpace, setSufficientSpace] = useState(
+    container.clientWidth >= SIDEBYSIDE_THRESHOLD
+  );
+  const [sidebarWidth, setSidebarWidth] = useState(0);
+
+  const updateSidebarState = useCallback((e: Event) => {
+    const sidebarInfo: LayoutChangeEventDetail = (e as LayoutChangeEvent)
+      .detail;
+    const layout = sidebarInfo.sidebarLayout;
+
+    setSidebarOpen(layout.expanded);
+    setSidebarWidth(layout.width);
+  }, []);
+
+  // Make room for the sidebar at the right of the app layout when applicable.
+  // Otherwise, provide some room for the sidebar's controls. Padding is used
+  // here (versus margin) because it is part of an element's dimensions
+  // (`clientWidth`) and thus easier to compute with.
+  useEffect(() => {
+    const applySideBySide = sufficientSpace && sidebarOpen;
+    if (applySideBySide) {
+      // prettier-ignore
+      container.style.paddingRight = `${
+        sidebarWidth - (TOOLBAR_WIDTH / 2)
+      }px`;
+    } else {
+      container.style.paddingRight = `${TOOLBAR_WIDTH}px`;
+    }
+    container.setAttribute('data-side-by-side', `${applySideBySide}`);
+  }, [container, sidebarOpen, sidebarWidth, sufficientSpace]);
+
+  useEffect(() => {
+    const onResize = () => {
+      setSufficientSpace(container.clientWidth >= SIDEBYSIDE_THRESHOLD);
+    };
+
+    document.body.addEventListener(
+      'hypothesis:layoutchange',
+      updateSidebarState
+    );
+    window.addEventListener('resize', onResize);
+    return () => {
+      document.body.removeEventListener(
+        'hypothesis:layoutchange',
+        updateSidebarState
+      );
+      window.removeEventListener('resize', onResize);
+    };
+  }, [container, updateSidebarState]);
+}


### PR DESCRIPTION
This PR adds a new hook, `useSideBySideLayout`, disables the client's default side-by-side layout handling and implements its own. 

~~In draft until:~~

* [x] Add tests for `useSideBySideLayout` hook

These changes make it so the layout vis-a-vis the relationship between the sidebar and the app content should be relatively sensible across different viewport widths and sidebar states.

The new hook listens for the `hypothesis:layoutchange` event and updates internal state about sidebar layout. When that state changes, or when there is a window-resize, it will compute whether or not to apply a side-by-side layout (make room to the right of the app content). It tunes the exact dimensions allotted to the sidebar such that the video-app UI tucks up nicely against it in various configurations.

## Testing

On this branch, try sizing your browser to different sizes and opening and collapsing the sidebar. There should no longer be awkward ranges in which the layout is two-column, but side-by-side doesn't apply. Translated, the sidebar will only ever lay on top of content (versus beside it) when the content is in a single-column layout, and will no longer ever obscure the transcript column in a two-column layout.

## Not yet

These changes do not address these things, which will be addressed in follow-up PRs:

* Tuning of breakpoints, and re-distributing them (the `md` size only spans about 11px of range as of these changes, but I didn't want to clutter this diff)
* Addressing layout nits beyond the overall layout with the sidebar (e.g. video size/proportion)
* Refactor of what the `useAppLayout` hook returns to encapsulate more and not have `VideoPlayerApp` doing layout computation

Part of #954