### PR TITLE
Use `rounded` instead of `rounded-sm` for border radius defaults

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,6 +8,10 @@ export default {
   ],
   theme: {
     extend: {
+      borderRadius: {
+        // Equivalent to tailwind default `rounded-sm` size
+        DEFAULT: '0.125rem',
+      },
       fontFamily: {
         sans: [
           '"Helvetica Neue"',

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -136,7 +136,7 @@ function TranscriptSegment({
   return (
     <li
       className={classnames(
-        'flex gap-x-3 p-1.5 rounded',
+        'flex gap-x-3 p-1.5 rounded-[4px]',
         // Margin needed to provide space for box shadow on current item
         'mb-1',
         {
@@ -152,7 +152,7 @@ function TranscriptSegment({
         onClick={onSelect}
         className={classnames(
           // TODO: Use shared Button to get these styles for free
-          'flex transition-colors focus-visible-ring rounded-sm',
+          'flex transition-colors focus-visible-ring rounded',
           // `peer` allows Tailwind styling based on sibling state
           'peer',
           'font-medium hover:underline',


### PR DESCRIPTION
See similar PR in the `client`: https://github.com/hypothesis/client/pull/5607

In component styles where the intent is to match the default border radius sizing, use unqualified `rounded` instead of `rounded-sm`. The default border radius happens to be 2px, which is equivalent to the default `rounded-sm` value out of the box with Tailwind, but the intent is instead "use the default border radius size".

Add a border-radius default to tailwind config.