### PR TITLE
Implement custom scroll anchoring for transcript container

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
 } from 'preact/hooks';
 
+import { useScrollAnchor } from '../hooks/use-scroll-anchor';
 import { formatTimestamp } from '../utils/time';
 import type { MatchOffset, Segment, TranscriptData } from '../utils/transcript';
 import { filterTranscript } from '../utils/transcript';
@@ -346,6 +347,15 @@ export default function Transcript({
     }
     return filterTranscript(transcript.segments, filter);
   }, [filter, transcript]);
+
+  // Adjust the scroll position when the transcript container is resized, so the
+  // user doesn't lose their place. See
+  // https://github.com/hypothesis/via/issues/1021.
+  const getScrollChildren = useCallback(
+    (element: HTMLElement) => element.querySelectorAll('li'),
+    []
+  );
+  useScrollAnchor(scrollRef, getScrollChildren);
 
   return (
     <ScrollContainer borderless>

--- a/via/static/scripts/video_player/hooks/test/use-scroll-anchor-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-scroll-anchor-test.js
@@ -1,0 +1,138 @@
+import { mount } from 'enzyme';
+import { useCallback, useRef } from 'preact/hooks';
+
+import { useScrollAnchor } from '../use-scroll-anchor';
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+describe('useScrollAnchor', () => {
+  // Scrollable test widget with children that have text wrapping onto
+  // multiple lines. As the width of the container is varied, the
+  // `useScrollAnchor` hook will need to adjust the scroll position to keep
+  // the same child visible.
+  function TestWidget({ width = 200, height = 200 }) {
+    const container = useRef(null);
+    const getChildren = useCallback(
+      () => container.current.querySelectorAll('.child'),
+      []
+    );
+
+    useScrollAnchor(container, getChildren);
+
+    return (
+      <div
+        data-testid="container"
+        ref={container}
+        style={{
+          width: `${width}px`,
+          height: `${height}px`,
+
+          // Hide scrollbars so the `clientWidth` of this element is the same
+          // on all platforms.
+          overflowY: 'hidden',
+        }}
+      >
+        <div className="child">{loremIpsum}</div>
+        <div className="child">{loremIpsum}</div>
+        <div className="child">{loremIpsum}</div>
+        <div className="child">{loremIpsum}</div>
+        <div className="child">{loremIpsum}</div>
+      </div>
+    );
+  }
+
+  let wrappers;
+
+  const renderWidget = props => {
+    const wrapper = mount(<TestWidget {...props} />, {
+      attachTo: document.body,
+    });
+    wrappers.push(wrapper);
+    return wrapper;
+  };
+
+  /** Return Y offset of top of `child` from top of `container`. */
+  function offsetFromTop(container, child) {
+    const containerRect = container.getBoundingClientRect();
+    const childRect = child.getBoundingClientRect();
+    return childRect.top - containerRect.top;
+  }
+
+  function waitForEvent(element, event) {
+    return new Promise(resolve => {
+      element.addEventListener(event, resolve, { once: true });
+    });
+  }
+
+  function waitForResize(element) {
+    return new Promise(resolve => {
+      const ro = new ResizeObserver(() => {
+        resolve();
+        ro.disconnect();
+      });
+      ro.observe(element);
+    });
+  }
+
+  beforeEach(() => {
+    wrappers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+  });
+
+  it('disables built-in scroll anchoring', () => {
+    const wrapper = renderWidget();
+    assert.equal(
+      wrapper.find('[data-testid="container"]').getDOMNode().style
+        .overflowAnchor,
+      'none'
+    );
+  });
+
+  it('adjusts scroll position when container is resized', async () => {
+    const wrapper = renderWidget({ width: 150 });
+    const container = wrapper.find('[data-testid="container"]').getDOMNode();
+
+    // Scroll down enough that, when we make the container wider below, the
+    // content will shift.
+    const scrolled = waitForEvent(container, 'scroll');
+    container.scrollBy(0, 50);
+    await scrolled;
+
+    // Pick the second child for testing. This is the first child that fits
+    // within the viewport and so the one which `useScrollAnchor` will pick as
+    // a scroll anchor.
+    const child = wrapper.find('.child').at(1).getDOMNode();
+    const topOffset = offsetFromTop(container, child);
+    const scrollOffset = container.scrollTop;
+
+    // Make the container wider. The item contents will now wrap onto fewer
+    // lines and so if the scroll position of the container is not updated by
+    // `useScrollAnchor`, the content would shift.
+    const resized = waitForResize(container);
+    wrapper.setProps({ width: 200 });
+    await resized;
+
+    // Check that `useScrollAnchor` did adjust the `scrollTop` of the container
+    // so as to keep the relative offset of the child the same.
+    const topOffset2 = offsetFromTop(container, child);
+    const scrollOffset2 = container.scrollTop;
+
+    assert.notEqual(scrollOffset, scrollOffset2);
+    assert.equal(topOffset, topOffset2);
+
+    // Wait for a repaint. Otherwise we'll get a ResizeObserver loop error
+    // when resizing a second time below.
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    // Resize to zero width/height and trigger a scroll. This exercises code
+    // paths for the case where no scroll anchor can be chosen.
+    const resized2 = waitForResize(container);
+    wrapper.setProps({ width: 0, height: 0 });
+    container.dispatchEvent(new Event('scroll'));
+    await resized2;
+  });
+});

--- a/via/static/scripts/video_player/hooks/use-scroll-anchor.ts
+++ b/via/static/scripts/video_player/hooks/use-scroll-anchor.ts
@@ -1,0 +1,101 @@
+import { useEffect } from 'preact/hooks';
+import type { MutableRef } from 'preact/hooks';
+
+function rectIsEmpty(rect: DOMRect) {
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+/**
+ * Return true if `rectB` is fully contained within `rectA`
+ */
+export function rectContains(rectA: DOMRect, rectB: DOMRect) {
+  if (rectIsEmpty(rectA) || rectIsEmpty(rectB)) {
+    return false;
+  }
+
+  return (
+    rectB.left >= rectA.left &&
+    rectB.right <= rectA.right &&
+    rectB.top >= rectA.top &&
+    rectB.bottom <= rectA.bottom
+  );
+}
+
+/**
+ * Automatically adjust the scroll offset of `scrollRef` when the element is
+ * resized, so that the same content remains at the top of the viewport.
+ *
+ * This works by selecting a _scroll anchor_ when the container is scrolled, and
+ * noting its position relative to the top of the container. When the container
+ * is resized, the scroll position is adjusted to keep the scroll anchor in the
+ * same position relative to the top of the container.
+ *
+ * A known limitation is that the scroll anchoring will break if the scroll
+ * container's height becomes small enough that no child fits fully within its
+ * viewport.
+ *
+ * @param scrollRef - The scrollable container element
+ * @param getChildren - Callback that returns the children of the container that
+ *   should be used as candidates for a scroll anchor
+ */
+export function useScrollAnchor(
+  scrollRef: MutableRef<HTMLElement | null>,
+  getChildren: (element: HTMLElement) => NodeListOf<HTMLElement>
+) {
+  useEffect(() => {
+    /* istanbul ignore next */
+    if (!scrollRef.current) {
+      return undefined;
+    }
+
+    const scrollElement = scrollRef.current!;
+
+    // Turn off the browser's own scroll anchoring, so it doesn't interfere with
+    // ours.
+    scrollElement.style.overflowAnchor = 'none';
+
+    // Element selected as the scroll anchor, and its offset from the top of
+    // the scrollable element.
+    let scrollAnchor: { element: HTMLElement; offset: number } | null = null;
+
+    const observer = new ResizeObserver(() => {
+      if (!scrollAnchor) {
+        return;
+      }
+
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const relativeOffset =
+        scrollAnchor.element.getBoundingClientRect().top - scrollRect.top;
+      const delta = relativeOffset - scrollAnchor.offset;
+      scrollElement.scrollBy(0, delta);
+    });
+    observer.observe(scrollElement);
+
+    const updateScrollAnchor = () => {
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const newScrollAnchor = Array.from(getChildren(scrollElement)).find(
+        child => rectContains(scrollRect, child.getBoundingClientRect())
+      );
+
+      if (!newScrollAnchor) {
+        scrollAnchor = null;
+      } else {
+        const offset =
+          newScrollAnchor.getBoundingClientRect().top - scrollRect.top;
+        scrollAnchor = {
+          element: newScrollAnchor,
+          offset,
+        };
+      }
+    };
+    scrollElement.addEventListener('scroll', updateScrollAnchor);
+
+    // Set initial scroll anchor.
+    updateScrollAnchor();
+
+    return () => {
+      observer.disconnect();
+      scrollElement.removeEventListener('scroll', updateScrollAnchor);
+    };
+  }, [scrollRef, getChildren]);
+}


### PR DESCRIPTION
This PR introduces a new `useScrollAnchor` hook that tries to mimic `overflow-anchor` for browsers that do not support it, with a combination of `ResizeObserver` and `scroll` event.

Since that can consume many resources, the logic is made in a way that it is skipped if the browser natively supports the feature.

### Todo

- [x] Add tests
- [x] Fix cases in which calculation is messed-up. It happens as you get closer to the bottom of the scroll.
- [x] Remove hardcoded `overflow-anchor: none` used to test this on any browser.
- [x] Un-comment check used to verify if `overflow-anchor` is natively supported.

### Testing steps

Using a browser which does not support overflow anchoring (Safair), go to http://localhost:9083/https://www.youtube.com/watch?v=MrORaCfcKxQ and resize your window to try to find a resolution in which the transcript has a different size when the sidebar is open and closed.

One good way to test it is in a resolution where the transcript is moved under the video when the sidebar is open, like this:

[Grabación de pantalla desde 2023-07-11 12-47-21.webm](https://github.com/hypothesis/via/assets/2719332/83e9e498-16f8-49cc-aa63-24a497942f3e)

Once you are there, follow these steps:

1. Scroll down in the transcript, and check what's the first visible segment.
2. Open the sidebar. The first visible segment should still be the same.
3. Scroll again, and then close the sidebar.
4. Again, the first segment should be the same as before closing it.

If you try the same on `main` branch, you'll see the segments can change significantly.

> This PR fixes https://github.com/hypothesis/via/issues/1021