### PR TITLE
Use `hypothesisConfig` global to pass configuration to the client

### DIFF
--- a/via/static/scripts/video_player/components/HypothesisClient.tsx
+++ b/via/static/scripts/video_player/components/HypothesisClient.tsx
@@ -1,7 +1,18 @@
-import { useEffect } from 'preact/hooks';
+import { useLayoutEffect } from 'preact/hooks';
 
 export type HypothesisClientProps = {
+  /** URL of the client's boot script. */
   src?: string;
+
+  /**
+   * Configuration to pass to the Hypothesis client via the `hypothesisConfig`
+   * global [1].
+   *
+   * Note that changing this has no effect once the client is started and read
+   * its configuration.
+   *
+   * [1] https://h.readthedocs.io/projects/client/en/latest/publishers/config.html#configuring-the-client-using-javascript
+   */
   config?: object;
 };
 
@@ -12,17 +23,11 @@ export default function HypothesisClient({
   src = 'https://hypothes.is/embed.js',
   config = {},
 }: HypothesisClientProps) {
-  useEffect(() => {
-    // TODO - Unload the client when unmounted
-  }, []);
+  // nb. Use a layout effect here so that variable is definitely set before
+  // client's boot script executes.
+  useLayoutEffect(() => {
+    (window as any).hypothesisConfig = () => config;
+  }, [config]);
 
-  const clientConfig = JSON.stringify(config);
-  return (
-    <>
-      <script type="application/json" className="js-hypothesis-config">
-        {clientConfig}
-      </script>
-      <script src={src} />
-    </>
-  );
+  return <script src={src} />;
 }

--- a/via/static/scripts/video_player/components/test/HypothesisClient-test.js
+++ b/via/static/scripts/video_player/components/test/HypothesisClient-test.js
@@ -3,6 +3,10 @@ import { mount } from 'enzyme';
 import HypothesisClient from '../HypothesisClient';
 
 describe('HypothesisClient', () => {
+  beforeEach(() => {
+    delete window.hypothesisConfig;
+  });
+
   it('adds Hypothesis client and configuration to page', () => {
     const config = { openSidebar: true };
     const wrapper = mount(
@@ -10,8 +14,7 @@ describe('HypothesisClient', () => {
     );
     assert.isTrue(wrapper.exists('script[src="https://hypothes.is/embed.js"]'));
 
-    const configScript = wrapper.find('script.js-hypothesis-config');
-    assert.isTrue(configScript.exists());
-    assert.equal(configScript.text(), JSON.stringify(config));
+    assert.isFunction(window.hypothesisConfig);
+    assert.equal(window.hypothesisConfig(), config);
   });
 });


### PR DESCRIPTION
This enables us to pass configuration to the client which is not JSON-serializable, such as callbacks.

The immediate use case I'm thinking of is allowing the video player app to pass an "is side-by-side active?" callback to the client ([slack thread](https://hypothes-is.slack.com/archives/C1M8NH76X/p1689065768678309?thread_ts=1689065493.060469&cid=C1M8NH76X)) but it has come up in other contexts that it may be useful to pass non-JSON serializable config. If in future we support [loading Hypothesis via ESM import](https://github.com/hypothesis/client/issues/5569) that will provide a much more direct way to pass arbitrary config to the client.