### PR TITLE
Cache YouTube transcripts in the DB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,19 @@ from os import environ
 import httpretty
 import pytest
 from h_matchers import Any
+from pytest_factoryboy import register
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from tests.factories import TranscriptFactory
 from tests.factories.factoryboy_sqlalchemy_session import (
     clear_factoryboy_sqlalchemy_session,
     set_factoryboy_sqlalchemy_session,
 )
 from via.db import Base
+
+# Each factory has to be registered with pytest_factoryboy.
+register(TranscriptFactory)
 
 
 @pytest.fixture

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+from tests.factories.transcript import TranscriptFactory

--- a/tests/factories/transcript.py
+++ b/tests/factories/transcript.py
@@ -1,0 +1,29 @@
+from factory import Sequence
+from factory.alchemy import SQLAlchemyModelFactory
+
+from via.models import Transcript
+
+
+class TranscriptFactory(SQLAlchemyModelFactory):
+    class Meta:
+        model = Transcript
+
+    video_id = Sequence(lambda n: f"video_id_{n}")
+    transcript_id = Sequence(lambda n: f"transcript_id_{n}")
+    transcript = [
+        {
+            "text": "[Music]",
+            "start": 0.0,
+            "duration": 7.52,
+        },
+        {
+            "text": "how many of you remember the first time",
+            "start": 5.6,
+            "duration": 4.72,
+        },
+        {
+            "text": "you saw a playstation 1 game if you were",
+            "start": 7.52,
+            "duration": 4.72,
+        },
+    ]

--- a/via/models/__init__.py
+++ b/via/models/__init__.py
@@ -1,2 +1,5 @@
+from via.models.transcript import Transcript
+
+
 def includeme(_config):  # pragma: no cover
     pass

--- a/via/models/_mixins.py
+++ b/via/models/_mixins.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
+
+
+class AutoincrementingIntegerIDMixin(MappedAsDataclass):
+    id: Mapped[int] = mapped_column(
+        init=False, primary_key=True, autoincrement=True, sort_order=-100
+    )
+
+
+class CreatedUpdatedMixin(MappedAsDataclass):
+    created: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),  # pylint:disable=not-callable
+        sort_order=-10,
+    )
+    updated: Mapped[datetime] = mapped_column(
+        init=False,
+        repr=False,
+        server_default=func.now(),  # pylint:disable=not-callable
+        onupdate=func.now(),  # pylint:disable=not-callable
+        sort_order=-10,
+    )

--- a/via/models/transcript.py
+++ b/via/models/transcript.py
@@ -1,0 +1,15 @@
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from via.db import Base
+from via.models._mixins import AutoincrementingIntegerIDMixin, CreatedUpdatedMixin
+
+
+class Transcript(AutoincrementingIntegerIDMixin, CreatedUpdatedMixin, Base):
+    __tablename__ = "transcript"
+    __table_args__ = (UniqueConstraint("video_id", "transcript_id"),)
+
+    video_id: Mapped[str]
+    transcript_id: Mapped[str]
+    transcript: Mapped[list] = mapped_column(JSONB, repr=False)


### PR DESCRIPTION
Depends on https://github.com/hypothesis/via/pull/1019. Fixes https://github.com/hypothesis/via/issues/927.

Save YouTube transcripts in the DB and re-serve them from the DB rather than requesting them from the YouTube API again.

Once a transcript has been saved once it'll always be re-served from the DB and never fetched again. We might want to periodically re-fetch transcripts, but we can consider that separately.

## Testing

### Test `models.Transcript` in the shell

```python
$ make shell
>>> transcript = models.Transcript(video_id="VIDEO_ID", transcript_id="TRANSCRIPT_ID", transcript=[])
>>> db.add(transcript)
>>> tm.commit()
>>> tm.begin()
>>> from sqlalchemy import select
>>> db.scalars(select(models.Transcript)).all()
[Transcript(id=1, video_id='VIDEO_ID', transcript_id='TRANSCRIPT_ID')] 
```

### Test `TranscriptFactory` in the shell

```python
$ make shell
>>> # You could actually add this to the DB and commit it if you wanted to.
>>> factories.TranscriptFactory()
Transcript(id=None, video_id='video_id_0', transcript_id='transcript_id_0')
>>> factories.TranscriptFactory()
Transcript(id=None, video_id='video_id_1', transcript_id='transcript_id_1')
```

### Test the transcript API

First get a bearer token for calling the API:

```python
$ make shell
>>> from via.security import ViaSecurityPolicy
>>> ViaSecurityPolicy.encode_jwt(request)
'eyJ***Mt4'
```

Now run `make dev` and in another terminal use [HTTPie](https://httpie.io/) to make requests to the transcript API using the bearer token:

```terminal
$ http GET 'http://localhost:9083/api/youtube/transcript/TbzZIMQC6vk' Authorization:"Bearer eyJ***Mt4"
...
```

You should notice that if you run this command again it's much faster the second time because it's returning the cached transcript from Postgres. If you run `make sql` you can inspect the cached transcript in the `transcript` table:

```terminal
$ make sql
postgres=# select * from transcript;
...
```

### Test the Web UI

<http://localhost:9083/https://www.youtube.com/watch?v=byN4S8WDPt8>