### PR TITLE
Add clear filter to video app search box

### DIFF
--- a/via/static/scripts/video_player/components/FilterInput.tsx
+++ b/via/static/scripts/video_player/components/FilterInput.tsx
@@ -1,0 +1,49 @@
+import { CancelIcon, IconButton, Input } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { Ref } from 'preact';
+
+export type FilterInputProps = {
+  elementRef: Ref<HTMLElement | undefined>;
+  setFilter: (filter: string) => void;
+  filter: string;
+};
+
+export default function FilterInput({
+  elementRef,
+  setFilter,
+  filter,
+}: FilterInputProps) {
+  return (
+    <div className="relative">
+      <Input
+        data-testid="filter-input"
+        aria-label="Transcript filter"
+        classes={classnames(
+          // Match height of search input in sidebar
+          'h-[32px]',
+          // Extra padding right to prevent text and "clear" button overlapping
+          'pr-8'
+        )}
+        elementRef={elementRef}
+        onKeyUp={e => {
+          // Allow user to easily remove focus from search input.
+          if (e.key === 'Escape') {
+            (e.target as HTMLElement).blur();
+          }
+        }}
+        onInput={e => setFilter((e.target as HTMLInputElement).value)}
+        placeholder="Search..."
+        value={filter}
+      />
+      {filter && (
+        <IconButton
+          icon={CancelIcon}
+          data-testid="clear-filter-button"
+          title="Clear filter"
+          onClick={() => setFilter('')}
+          classes="absolute right-0 top-[1px]"
+        />
+      )}
+    </div>
+  );
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,15 +1,12 @@
 import {
   Button,
-  CancelIcon,
   Checkbox,
   CopyIcon,
   IconButton,
-  Input,
   LogoIcon,
   Spinner,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import type { Ref } from 'preact';
 import {
   useCallback,
   useEffect,
@@ -24,6 +21,7 @@ import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
 import type { TranscriptData } from '../utils/transcript';
 import { formatTranscript, mergeSegments } from '../utils/transcript';
+import FilterInput from './FilterInput';
 import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
@@ -61,54 +59,6 @@ function isScrollToRangeEvent(e: Event): e is ScrollToRangeEvent {
     e instanceof CustomEvent &&
     'waitUntil' in e &&
     typeof e.waitUntil === 'function'
-  );
-}
-
-type FilterInputProps = {
-  elementRef: Ref<HTMLElement | undefined>;
-  setFilter: (filter: string) => void;
-  filter: string;
-};
-
-function FilterInput({ elementRef, setFilter, filter }: FilterInputProps) {
-  return (
-    <div className="relative">
-      <Input
-        data-testid="filter-input"
-        aria-label="Transcript filter"
-        classes={classnames(
-          // Match height of search input in sidebar
-          'h-[32px]',
-          // Extra padding right to prevent text and "clear" button overlapping
-          'pr-9'
-        )}
-        elementRef={elementRef}
-        onKeyUp={e => {
-          // Allow user to easily remove focus from search input.
-          if (e.key === 'Escape') {
-            (e.target as HTMLElement).blur();
-          }
-        }}
-        onInput={e => setFilter((e.target as HTMLInputElement).value)}
-        placeholder="Search..."
-        value={filter}
-      />
-      {filter && (
-        <Button
-          data-testid="clear-filter-button"
-          title="Clear"
-          onClick={() => setFilter('')}
-          unstyled
-          classes={classnames(
-            'text-grey-7 hover:text-grey-9 font-semibold',
-            'focus-visible-ring',
-            'absolute right-2 top-[6px] w-5 h-5'
-          )}
-        >
-          <CancelIcon className="w-5 h-5" />
-        </Button>
-      )}
-    </div>
   );
 }
 

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  CancelIcon,
   Checkbox,
   CopyIcon,
   IconButton,
@@ -71,24 +72,43 @@ type FilterInputProps = {
 
 function FilterInput({ elementRef, setFilter, filter }: FilterInputProps) {
   return (
-    <Input
-      data-testid="filter-input"
-      aria-label="Transcript filter"
-      classes={classnames(
-        // Match height of search input in sidebar
-        'h-[32px]'
+    <div className="relative">
+      <Input
+        data-testid="filter-input"
+        aria-label="Transcript filter"
+        classes={classnames(
+          // Match height of search input in sidebar
+          'h-[32px]',
+          // Extra padding right to prevent text and "clear" button overlapping
+          'pr-9'
+        )}
+        elementRef={elementRef}
+        onKeyUp={e => {
+          // Allow user to easily remove focus from search input.
+          if (e.key === 'Escape') {
+            (e.target as HTMLElement).blur();
+          }
+        }}
+        onInput={e => setFilter((e.target as HTMLInputElement).value)}
+        placeholder="Search..."
+        value={filter}
+      />
+      {filter && (
+        <Button
+          data-testid="clear-filter-button"
+          title="Clear"
+          onClick={() => setFilter('')}
+          unstyled
+          classes={classnames(
+            'text-grey-7 hover:text-grey-9 font-semibold',
+            'focus-visible-ring',
+            'absolute right-2 top-[6px] w-5 h-5'
+          )}
+        >
+          <CancelIcon className="w-5 h-5" />
+        </Button>
       )}
-      elementRef={elementRef}
-      onKeyUp={e => {
-        // Allow user to easily remove focus from search input.
-        if (e.key === 'Escape') {
-          (e.target as HTMLElement).blur();
-        }
-      }}
-      onInput={e => setFilter((e.target as HTMLInputElement).value)}
-      placeholder="Search..."
-      value={filter}
-    />
+    </div>
   );
 }
 

--- a/via/static/scripts/video_player/components/test/FilterInput-test.js
+++ b/via/static/scripts/video_player/components/test/FilterInput-test.js
@@ -1,0 +1,62 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import FilterInput from '../FilterInput';
+
+describe('FilterInput', () => {
+  let fakeSetFilter;
+
+  beforeEach(() => {
+    fakeSetFilter = sinon.stub();
+  });
+
+  const createFilterInput = (filter = '') =>
+    mount(
+      <FilterInput
+        filter={filter}
+        setFilter={fakeSetFilter}
+        elementRef={createRef()}
+      />
+    );
+
+  it('sets initial filter', () => {
+    const initialFilter = 'foobar';
+    const wrapper = createFilterInput(initialFilter);
+
+    assert.equal(wrapper.find('Input').prop('value'), initialFilter);
+  });
+
+  it('invokes setFilter when input changes', () => {
+    const wrapper = createFilterInput();
+    const input = wrapper.find('input[data-testid="filter-input"]');
+
+    input.getDOMNode().value = 'new filter';
+    input.simulate('input');
+
+    assert.calledWith(fakeSetFilter, 'new filter');
+  });
+
+  it('displays clear button when filter is not empty', () => {
+    const wrapper = createFilterInput('not empty');
+    const clearButtonSelector = 'button[data-testid="clear-filter-button"]';
+
+    assert.isTrue(wrapper.exists(clearButtonSelector));
+  });
+
+  it('does not display clear button when filter is empty', () => {
+    const wrapper = createFilterInput();
+    const clearButtonSelector = 'button[data-testid="clear-filter-button"]';
+
+    assert.isFalse(wrapper.exists(clearButtonSelector));
+  });
+
+  it('clears filter when clear button is pressed', () => {
+    const wrapper = createFilterInput('foobar');
+    const clearButtonSelector = 'button[data-testid="clear-filter-button"]';
+
+    const clearButton = wrapper.find(clearButtonSelector);
+    clearButton.simulate('click');
+
+    assert.calledWith(fakeSetFilter, '');
+  });
+});


### PR DESCRIPTION
This PR closes #1050 by adding a dynamic button that allows clearing the active search/filter in the video app.

> Take the styling as provisional.

> **Note**
> This PR is easier to review ignoring whitespaces.

[Grabación de pantalla desde 2023-07-12 10-56-48.webm](https://github.com/hypothesis/via/assets/2719332/94863ebf-7369-45a4-a815-c710d3988d99)

### Testing steps:

1. Write some content in the search box. The clear button should appear to the right
2. Remove the content from the search box. The button should disappear.
3. Write content again, and click the button. The content box should be cleared, and the button removed.
4. The button should be part of the focus sequence, after the input, and have a focus ring when focused.
5. Screen readers should announce the button's title when focused.