### PR TITLE
Report canonical URL from video player to top frame

### DIFF
--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -23,16 +23,15 @@ export function init() {
   // location. This also acts to tell the top-level frame that we finished
   // loading. See proxy.html.jinja2.
   if (window !== window.top) {
+    const canonicalLink = document.querySelector('link[rel=canonical]') as
+      | HTMLLinkElement
+      | undefined;
+    const documentURL = canonicalLink?.href ?? document.location.href;
     window.parent.postMessage(
       {
         type: 'metadatachange',
         metadata: {
-          // TODO: Once https://github.com/hypothesis/via/pull/1015 lands,
-          // get the URL from `link[rel=canonical]` or pass the video URL as
-          // config.
-          location: `https://www.youtube.com/watch?v=${encodeURIComponent(
-            videoId
-          )}`,
+          location: documentURL,
           title: document.title,
         },
       },


### PR DESCRIPTION
Make sure the video player reports the same document URL to the top frame as the Hypothesis client uses to search for annotations.

This doesn't make any functional difference, since the actual values are the same before/after this PR. It just ensures consistency in the future.

See the PR linked in the removed "TODO" comment for more context.