### PR TITLE
Fix the `<title>` of `/video/youtube` pages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def pyramid_settings():
         "dev": False,
         "youtube_transcripts": True,
         "api_jwt_secret": "secret",
+        "youtube_api_key": "test_youtube_api_key",
     }
 
 

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -32,6 +32,9 @@ class TestViewVideo:
         youtube_service.canonical_video_url.assert_called_once_with(
             sentinel.youtube_video_id
         )
+        youtube_service.get_video_title.assert_called_once_with(
+            youtube_service.get_video_id.return_value
+        )
         Configuration.extract_from_params.assert_called_once_with(
             {"via.foo": "foo", "via.bar": "bar"}
         )
@@ -39,6 +42,7 @@ class TestViewVideo:
         assert response == {
             "client_embed_url": "http://hypothes.is/embed.js",
             "client_config": Configuration.extract_from_params.return_value[1],
+            "title": youtube_service.get_video_title.return_value,
             "video_id": youtube_service.get_video_id.return_value,
             "video_url": youtube_service.canonical_video_url.return_value,
             "api": {

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: SIGNED_URLS_REQUIRED
+    dev: YOUTUBE_API_KEY
 deps =
     pip-tools
     pip-sync-faster

--- a/via/app.py
+++ b/via/app.py
@@ -29,6 +29,7 @@ PARAMETERS = {
     "enable_front_page": {"formatter": asbool},
     "youtube_transcripts": {"formatter": asbool},
     "api_jwt_secret": {"required": True},
+    "youtube_api_key": {},
 }
 
 

--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Hypothesis Video Player</title>
+    <title>{{ title }}</title>
     <link rel="canonical" href="{{ video_url }}"/>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     {% for url in asset_urls("video_player_css") %}

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -22,6 +22,7 @@ def youtube(request, url, **kwargs):
 
     video_id = youtube_service.get_video_id(url)
     video_url = youtube_service.canonical_video_url(video_id)
+    video_title = youtube_service.get_video_title(video_id)
 
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
@@ -31,6 +32,7 @@ def youtube(request, url, **kwargs):
     return {
         "client_embed_url": request.registry.settings["client_embed_url"],
         "client_config": client_config,
+        "title": video_title,
         "video_id": video_id,
         "video_url": video_url,
         "api": {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via/issues/1071. Depends on https://github.com/hypothesis/devdata/pull/92 (or set `YOUTUBE_API_KEY` in your shell).

This will call the YouTube API to get the video title every time someone loads the `/video/youtube` page. Once we've added a DB to Via we should save video titles in the DB and only call the API the first time.

## Testing

Visit a page like <http://localhost:9083/https://www.youtube.com/watch?v=sWNTsKX5H5M> and you should see that the browser's tab title gets set to the title of the YouTube video.

## Error handling

There are various ways that you can break the code to trigger an error from the YouTube API, for example: break the code to use an invalid API key, break the code to use an invalid API endpoint URL, request a YouTube video that doesn't exist (e.g. <http://localhost:9082/video/youtube?url=https://www.youtube.com/watch?v=foo>), break the code to send invalid request params, turn off your internet connection so the YouTube API can't be reached, etc. They all produce pretty much the same result.

For example let's try breaking the API key:

```diff
diff --git a/via/services/youtube.py b/via/services/youtube.py
index 3b3fcb1..30f10ac 100644
--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -81,6 +81,6 @@ class YouTubeService:
 def factory(_context, request):
     return YouTubeService(
         enabled=request.registry.settings["youtube_transcripts"],
-        api_key=request.registry.settings["youtube_api_key"],
+        api_key="foo",
         http_service=request.find_service(HTTPService),
     )
```

This results in a **400 Bad Request** response from Google with a JSON error body. Via turns this into a **417 Expectation Failed**:

![image](https://github.com/hypothesis/via/assets/22498/e61c05ee-c353-41f5-84cf-2a452de6b50c)

The error also gets reported to Sentry, including the full details of the error message that we received from the YouTube API (including the full error response body). Here's an example from my local dev env: https://sean-hammond.sentry.io/share/issue/ad40b67f46d443768aa2a0553ecfebb9/

The error also gets logged to Papertrail and you'll see the full error response body from the YouTube API there as well, you can see this in your terminal in dev.