### PR TITLE
Encapsulate layout logic in `useAppLayout` hook; update breakpoints

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -109,16 +109,9 @@ export default function VideoPlayerApp({
   const filterInputRef = useRef<HTMLInputElement>();
   const appContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const appSize = useAppLayout(appContainerRef);
+  const { appSize, multicolumn, transcriptWidth } =
+    useAppLayout(appContainerRef);
   useSideBySideLayout();
-  const multicolumn = appSize !== 'sm';
-  const transcriptWidths = {
-    sm: '100%',
-    md: '380px',
-    lg: '410px',
-    xl: '450px',
-    '2xl': '480px',
-  };
 
   // Fetch transcript when app loads.
   const [transcript, setTranscript] = useState<
@@ -270,7 +263,7 @@ export default function VideoPlayerApp({
               // gets "consumed" in side-by-side mode
               'pr-4'
             )}
-            style={{ width: transcriptWidths[appSize] }}
+            style={{ width: transcriptWidth }}
           >
             <FilterInput
               elementRef={filterInputRef}
@@ -303,9 +296,8 @@ export default function VideoPlayerApp({
               // Adapt spacing around video for different app sizes
               'p-0': appSize === 'sm',
               'p-1': appSize === 'md',
-              'p-2': appSize === 'lg',
-              'py-2 px-3': appSize === 'xl',
-              'py-2 px-4': appSize === '2xl',
+              'py-2 px-3': appSize === 'lg',
+              'py-2 px-4': appSize === 'xl',
             }
           )}
         >
@@ -325,7 +317,7 @@ export default function VideoPlayerApp({
             // layouts
             'min-h-0 grow': !multicolumn,
           })}
-          style={{ width: transcriptWidths[appSize] }}
+          style={{ width: transcriptWidth }}
         >
           <div
             data-testid="transcript-controls"

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -51,6 +51,7 @@ describe('VideoPlayerApp', () => {
   }
 
   let wrappers;
+  let fakeLayoutInfo;
   let fakeUseAppLayout;
 
   function createVideoPlayer(props = {}) {
@@ -71,7 +72,12 @@ describe('VideoPlayerApp', () => {
 
   beforeEach(() => {
     wrappers = [];
-    fakeUseAppLayout = sinon.stub().returns('lg');
+    fakeLayoutInfo = {
+      appSize: 'lg',
+      multicolumn: true,
+      transcriptWidth: '100%',
+    };
+    fakeUseAppLayout = sinon.stub().returns(fakeLayoutInfo);
     fakeCallAPI = sinon.stub().rejects(new Error('Dummy API error'));
 
     $imports.$mock(mockImportedComponents());
@@ -98,30 +104,27 @@ describe('VideoPlayerApp', () => {
 
   describe('app layout', () => {
     context('multi-column layout for wider widths', () => {
-      for (const appSize of ['md', 'lg', 'xl', '2xl']) {
-        it('renders a top bar with branding and filter input', () => {
-          fakeUseAppLayout.returns(appSize);
-          const wrapper = createVideoPlayer();
+      beforeEach(() => {
+        fakeLayoutInfo.multicolumn = true;
+      });
+      it('renders a top bar with branding and filter input', () => {
+        const wrapper = createVideoPlayer();
 
-          const topBar = wrapper.find('[data-testid="top-bar"]');
-          assert.isTrue(topBar.exists());
-          assert.isTrue(
-            topBar.find('[data-testid="hypothesis-logo"]').exists()
-          );
-          assert.isTrue(topBar.find('FilterInput').exists());
-        });
+        const topBar = wrapper.find('[data-testid="top-bar"]');
+        assert.isTrue(topBar.exists());
+        assert.isTrue(topBar.find('[data-testid="hypothesis-logo"]').exists());
+        assert.isTrue(topBar.find('FilterInput').exists());
+      });
 
-        it('renders a play/pause button', () => {
-          fakeUseAppLayout.returns(appSize);
-          const wrapper = createVideoPlayer();
-          assert.isTrue(wrapper.find('[data-testid="play-button"]').exists());
-        });
-      }
+      it('renders a play/pause button', () => {
+        const wrapper = createVideoPlayer();
+        assert.isTrue(wrapper.find('[data-testid="play-button"]').exists());
+      });
     });
 
     context('single-column layout for narrow widths', () => {
       beforeEach(() => {
-        fakeUseAppLayout.returns('sm');
+        fakeLayoutInfo.multicolumn = false;
       });
 
       it('does not render a top bar', () => {


### PR DESCRIPTION
This PR:

* Encapsulates computed layout values within the `useAppLayout` hook and removes computation from `VideoPlayerApp`. Instead of returning a single `appSize` string, `useAppLayout` now returns a layout info object. This object should only be updated if the relative container size changes.
* Reshuffles breakpoints and removes `2xl` size.

There should be very minimal visible changes (very small adjustments to padding around the video in some widths).

Depends on #1063

Fixes https://github.com/orgs/hypothesis/projects/118/views/1?pane=issue&itemId=33204585

