### PR TITLE
Side by side active

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -111,7 +111,7 @@ export default function VideoPlayerApp({
 
   const { appSize, multicolumn, transcriptWidth } =
     useAppLayout(appContainerRef);
-  useSideBySideLayout();
+  const sideBySideActive = useSideBySideLayout();
 
   // Fetch transcript when app loads.
   const [transcript, setTranscript] = useState<
@@ -229,12 +229,17 @@ export default function VideoPlayerApp({
   };
 
   const bucketContainerId = 'bucket-container';
+  const prevSideBySideActive = useRef(sideBySideActive);
+  prevSideBySideActive.current = sideBySideActive;
   const clientConfig = useMemo(() => {
     return {
       ...baseClientConfig,
       bucketContainerSelector: '#' + bucketContainerId,
       sideBySide: {
         mode: 'manual',
+        // Using a ref here to make sure the `isActive` callback reference is
+        // kept, and only its return value changes
+        isActive: () => prevSideBySideActive.current,
       },
     };
   }, [baseClientConfig]);

--- a/via/static/scripts/video_player/hooks/test/use-side-by-side-layout-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-side-by-side-layout-test.js
@@ -11,10 +11,11 @@ describe('useSideBySideLayout', () => {
 
   // Create a fake component to mount in tests that uses the hook
   function FakeComponent() {
-    useSideBySideLayout(container);
+    const sideBySideEnabled = useSideBySideLayout(container);
     return (
       <div style="width:100%">
         <button>Hi</button>
+        {sideBySideEnabled && <span data-testid="side-by-side-enabled" />}
       </div>
     );
   }
@@ -62,14 +63,9 @@ describe('useSideBySideLayout', () => {
   }
 
   function sideBySideState() {
-    const attr = container.getAttribute('data-side-by-side');
-    if (attr === 'true') {
-      return true;
-    } else if (attr === 'false') {
-      return false;
-    } else {
-      return undefined;
-    }
+    return (
+      container.querySelector('[data-testid="side-by-side-enabled"]') !== null
+    );
   }
 
   describe('initial render', () => {

--- a/via/static/scripts/video_player/hooks/use-side-by-side-layout.ts
+++ b/via/static/scripts/video_player/hooks/use-side-by-side-layout.ts
@@ -38,13 +38,15 @@ export const TOOLBAR_WIDTH = 22;
  * is resized.
  *
  * @param [container] test seam
+ * @return Whether side-by-side is currently active or not
  */
-export function useSideBySideLayout(container = document.body) {
+export function useSideBySideLayout(container = document.body): boolean {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sufficientSpace, setSufficientSpace] = useState(
     container.clientWidth >= SIDEBYSIDE_THRESHOLD
   );
   const [sidebarWidth, setSidebarWidth] = useState(0);
+  const sideBySideActive = sufficientSpace && sidebarOpen;
 
   const updateSidebarState = useCallback((e: Event) => {
     const sidebarInfo: LayoutChangeEventDetail = (e as LayoutChangeEvent)
@@ -60,8 +62,7 @@ export function useSideBySideLayout(container = document.body) {
   // here (versus margin) because it is part of an element's dimensions
   // (`clientWidth`) and thus easier to compute with.
   useEffect(() => {
-    const applySideBySide = sufficientSpace && sidebarOpen;
-    if (applySideBySide) {
+    if (sideBySideActive) {
       // prettier-ignore
       container.style.paddingRight = `${
         sidebarWidth - (TOOLBAR_WIDTH / 2)
@@ -69,8 +70,7 @@ export function useSideBySideLayout(container = document.body) {
     } else {
       container.style.paddingRight = `${TOOLBAR_WIDTH}px`;
     }
-    container.setAttribute('data-side-by-side', `${applySideBySide}`);
-  }, [container, sidebarOpen, sidebarWidth, sufficientSpace]);
+  }, [container, sidebarWidth, sideBySideActive]);
 
   useEffect(() => {
     const onResize = () => {
@@ -90,4 +90,6 @@ export function useSideBySideLayout(container = document.body) {
       window.removeEventListener('resize', onResize);
     };
   }, [container, updateSidebarState]);
+
+  return sideBySideActive;
 }


### PR DESCRIPTION
https://github.com/hypothesis/via/pull/1063 introduced logic to manually handle side-by-side directly from the video app. This PR extends that logic to let the client know when `side-by-side` is enabled by the app, ensuring the sidebar is not automatically closed if not needed.

### Testing steps

1. Open http://localhost:9083/https://www.youtube.com/watch?v=MrORaCfcKxQ on a resolution big enough so that the sidebar can coexist with the rest of the content.
2. Clicking anywhere outside the sidebar should not close it.
3. Change resolution to something smaller, where the sidebar overlaps with the content when it is open.
4. Clicking anywhere outside the sidebar should close it in this case.

In `main`, the sidebar always gets closed when clicking outside.

> This PR closes https://github.com/hypothesis/via/issues/1084