### PR TITLE
Add logic to handle toast messages (useReducer)

### DIFF
--- a/via/static/scripts/video_player/components/CopyToClipboard.tsx
+++ b/via/static/scripts/video_player/components/CopyToClipboard.tsx
@@ -1,0 +1,43 @@
+import { CopyIcon, IconButton } from '@hypothesis/frontend-shared';
+
+import { useToastMessages } from '../hooks/use-toast-messages';
+import type { TranscriptData } from '../utils/transcript';
+import { formatTranscript } from '../utils/transcript';
+
+export type CopyToClipboardProps = {
+  transcript?: TranscriptData;
+};
+
+export default function CopyToClipboard({ transcript }: CopyToClipboardProps) {
+  const { appendToastMessage } = useToastMessages();
+  const copyTranscript = async () => {
+    const formattedTranscript = transcript
+      ? formatTranscript(transcript.segments)
+      : '';
+
+    try {
+      await navigator.clipboard.writeText(formattedTranscript);
+      appendToastMessage({
+        type: 'success',
+        message: 'Transcript copied to clipboard',
+      });
+    } catch (err) {
+      appendToastMessage({
+        type: 'error',
+        message: 'Failed to copy transcript',
+      });
+    }
+  };
+
+  return (
+    <IconButton
+      onClick={copyTranscript}
+      data-testid="copy-button"
+      disabled={!transcript}
+      title="Copy transcript"
+      icon={CopyIcon}
+      size="custom"
+      classes="p-2"
+    />
+  );
+}

--- a/via/static/scripts/video_player/components/ToastMessages.tsx
+++ b/via/static/scripts/video_player/components/ToastMessages.tsx
@@ -1,0 +1,89 @@
+import { Callout } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+
+export type ToastMessage = {
+  id: string;
+  type: 'error' | 'success' | 'notice';
+  message: ComponentChildren;
+  visuallyHidden?: boolean;
+  isDismissed?: boolean;
+};
+
+type ToastMessageItemProps = {
+  message: ToastMessage;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * An individual toast message: a brief and transient success or error message.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ */
+function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
+  // Capitalize the message type for prepending; Don't prepend a message
+  // type for "notice" messages
+  const prefix =
+    message.type !== 'notice'
+      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
+      : '';
+
+  return (
+    <Callout
+      classes={classnames({
+        'sr-only': message.visuallyHidden,
+      })}
+      status={message.type}
+      onClick={() => onDismiss(message.id)}
+      variant="raised"
+    >
+      <strong>{prefix}</strong>
+      {message.message}
+    </Callout>
+  );
+}
+
+export type ToastMessagesProps = {
+  messages: ToastMessage[];
+  onMessageDismiss: (id: string) => void;
+};
+
+/**
+ * A collection of toast messages. These are rendered within an `aria-live`
+ * region for accessibility with screen readers.
+ */
+export default function ToastMessages({
+  messages,
+  onMessageDismiss,
+}: ToastMessagesProps) {
+  // The `ul` containing any toast messages is absolute-positioned and the full
+  // width of the viewport. Each toast message `li` has its position and width
+  // constrained by `container` configuration in tailwind.
+  return (
+    <ul aria-live="polite" aria-relevant="additions" className="w-full">
+      {messages.map(message => (
+        <li
+          className={classnames('relative w-full container', {
+            // Add a bottom margin to visible messages only. Typically, we'd
+            // use a `space-y-2` class on the parent to space children.
+            // Doing that here could cause an undesired top margin on
+            // the first visible message in a list that contains (only)
+            // visually-hidden messages before it.
+            // See https://tailwindcss.com/docs/space#limitations
+            'mb-2': !message.visuallyHidden,
+            // Slide in from right in narrow viewports; fade in larger
+            // viewports to toast message isn't flying too far
+            'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
+              !message.isDismissed,
+            // Only ever fade in if motion-reduction is preferred
+            'motion-reduce:animate-fade-in': !message.isDismissed,
+            'animate-fade-out': message.isDismissed,
+          })}
+          key={message.id}
+        >
+          <ToastMessageItem message={message} onDismiss={onMessageDismiss} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/via/static/scripts/video_player/components/ToastMessagesProvider.tsx
+++ b/via/static/scripts/video_player/components/ToastMessagesProvider.tsx
@@ -1,0 +1,84 @@
+import type { ComponentChildren } from 'preact';
+import { useReducer } from 'preact/hooks';
+
+import type { ToastMessageData } from '../hooks/use-toast-messages';
+import { ToastMessagesContext } from '../hooks/use-toast-messages';
+import { generateHexString } from '../utils/generate-hex-string';
+import type { ToastMessage } from './ToastMessages';
+import ToastMessages from './ToastMessages';
+
+const toastMessageReducer = (
+  state: ToastMessage[],
+  action:
+    | { type: 'append'; toastMessage: ToastMessage }
+    | { type: 'dismiss'; id: string }
+    | { type: 'remove'; id: string }
+) => {
+  switch (action.type) {
+    case 'append':
+      return [...state, action.toastMessage];
+    case 'dismiss':
+      for (const message of state) {
+        if (message.id === action.id) {
+          message.isDismissed = true;
+          break;
+        }
+      }
+
+      return state;
+    case 'remove':
+      return state.filter(message => message.id !== action.id);
+    default:
+      return state;
+  }
+};
+
+export type ToastMessagesProviderProps = {
+  children: ComponentChildren;
+};
+
+export default function ToastMessagesProvider({
+  children,
+}: ToastMessagesProviderProps) {
+  const [toastMessages, dispatch] = useReducer(toastMessageReducer, []);
+  const dismissToastMessage = (id: string) => {
+    dispatch({ type: 'dismiss', id });
+
+    // Wait for transition to finish, then remove message
+    setTimeout(() => {
+      dispatch({ type: 'remove', id });
+    }, 500);
+  };
+  const appendToastMessage = ({
+    autoDismiss = true,
+    ...rest
+  }: ToastMessageData) => {
+    const id = generateHexString(10);
+    dispatch({
+      type: 'append',
+      toastMessage: { ...rest, id },
+    });
+
+    if (autoDismiss) {
+      setTimeout(() => dismissToastMessage(id), 5000);
+    }
+  };
+
+  return (
+    <ToastMessagesContext.Provider
+      value={{
+        toastMessages,
+        appendToastMessage,
+        dismissToastMessage,
+      }}
+    >
+      <div className="absolute z-2 right-0 top-[80px] w-full">
+        <ToastMessages
+          messages={toastMessages}
+          onMessageDismiss={dismissToastMessage}
+        />
+      </div>
+      {children}
+    </ToastMessagesContext.Provider>
+  );
+}

--- a/via/static/scripts/video_player/hooks/use-toast-messages.ts
+++ b/via/static/scripts/video_player/hooks/use-toast-messages.ts
@@ -1,0 +1,26 @@
+import { createContext } from 'preact';
+import { useContext } from 'preact/hooks';
+
+import type { ToastMessage } from '../components/ToastMessages';
+
+export type ToastMessageData = Omit<ToastMessage, 'id'> & {
+  autoDismiss?: boolean;
+};
+
+export type ToastMessagesStore = {
+  toastMessages: ToastMessage[];
+  appendToastMessage: (toastMessage: ToastMessageData) => void;
+  dismissToastMessage: (id: string) => void;
+};
+
+const noop = () => {};
+
+export const ToastMessagesContext = createContext<ToastMessagesStore>({
+  toastMessages: [],
+  appendToastMessage: noop,
+  dismissToastMessage: noop,
+});
+
+export function useToastMessages(): ToastMessagesStore {
+  return useContext(ToastMessagesContext);
+}

--- a/via/static/scripts/video_player/utils/generate-hex-string.ts
+++ b/via/static/scripts/video_player/utils/generate-hex-string.ts
@@ -1,0 +1,15 @@
+function byteToHex(val: number): string {
+  const str = val.toString(16);
+  return str.length === 1 ? '0' + str : str;
+}
+
+/**
+ * Generate a random hex string of `len` chars.
+ *
+ * @param len - An even-numbered length string to generate.
+ */
+export function generateHexString(len: number): string {
+  const bytes = new Uint8Array(len / 2);
+  window.crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(byteToHex).join('');
+}


### PR DESCRIPTION
> **Note**
> This PR is easier to review by ignoring whitespaces.

This PR introduces a proof of concept on how we could handle toast messages for the video app, in a way that we can reuse part of the logic in other apps and have a consistent component stack and UI.

This PR introduces three main pieces.

* A controlled `ToastMessages` component: it is basically the same as `BaseToastMessages` from client, but slightly simplified (the `message` prop is not a string, but `ComponentChildren`, which allows to remove `moreInfoURL` and let consumers determine the full content of a toast message and reduce coupling).
* A context and a hook that can be used to expose the toast messages to components across the app, with mechanisms to append and dismiss messages.
  Any component can do something in these lines:
  ```tsx
  const { toastMessages, appendToastMessage, dismissToastMessage } = useToastMessages();

  // toastMessages is the list of ToastMessage objects.
  // appendToastMessage({ message: 'foo', type: 'error' })
  // dismissToastMessage('abc123')
  ```
* A `ToastMessagesProvider` wrapper, that can be used to expose the context down the component tree, and also handles the toast messages reducer.

In order to verify the logic works and makes sense, it also enhances the copy-to-clipboard button, so that it displays a toast message after content has been copied or an error has occurred.

### TODO / To think

- [ ] Consider extracting `ToastMessages` to frontend-shared, as it can be potentially used in client as well, with no changes.
- [ ] Think if there's a better way to define the toast message handling logic. In client we have the `ToastMessengerService`. Here the logic has been delegated to a simple `useReducer` and exposed via context, but that means only other components can append or dismiss toast messages at the moment.
- [ ] Fix toast message transitions (same problem as in client).
- [ ] Fix toast messages styling and positioning.
- [ ] Think if `ToastMessagesProvider` should wrap `VideoPlayerApp` instead of being "in" it.
  Right now it is in it, as it seems reasonable that, for proper styling, the `ToastMessages` container is inside the app container, to benefit from multicolumn logic.
  However, this means the `VideoPlayerApp` itself cannot use the toast messages context.
  For now the simple workaround is to "extract" `CopyToClipboard` to its own component, as it makes sense anyway.
