### PR TITLE
Cache YouTube video titles in the DB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pytest_factoryboy import register
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from tests.factories import TranscriptFactory
+from tests.factories import TranscriptFactory, VideoFactory
 from tests.factories.factoryboy_sqlalchemy_session import (
     clear_factoryboy_sqlalchemy_session,
     set_factoryboy_sqlalchemy_session,
@@ -16,6 +16,7 @@ from via.db import Base
 
 # Each factory has to be registered with pytest_factoryboy.
 register(TranscriptFactory)
+register(VideoFactory)
 
 
 @pytest.fixture

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,1 +1,2 @@
 from tests.factories.transcript import TranscriptFactory
+from tests.factories.video import VideoFactory

--- a/tests/factories/video.py
+++ b/tests/factories/video.py
@@ -1,0 +1,12 @@
+from factory import Sequence
+from factory.alchemy import SQLAlchemyModelFactory
+
+from via.models import Video
+
+
+class VideoFactory(SQLAlchemyModelFactory):
+    class Meta:
+        model = Video
+
+    video_id = Sequence(lambda n: f"video_id_{n}")
+    title = Sequence(lambda n: f"video_title_{n}")

--- a/via/models/__init__.py
+++ b/via/models/__init__.py
@@ -1,4 +1,5 @@
 from via.models.transcript import Transcript
+from via.models.video import Video
 
 
 def includeme(_config):  # pragma: no cover

--- a/via/models/video.py
+++ b/via/models/video.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import Mapped, mapped_column
+
+from via.db import Base
+from via.models._mixins import AutoincrementingIntegerIDMixin, CreatedUpdatedMixin
+
+
+class Video(AutoincrementingIntegerIDMixin, CreatedUpdatedMixin, Base):
+    __tablename__ = "video"
+
+    video_id: Mapped[str] = mapped_column(unique=True)
+    title: Mapped[str] = mapped_column(repr=False)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via/issues/1118.

## Testing

### Test `models.Video`

```python
$ make shell
>>> video = models.Video(video_id="VIDEO_ID", title="TITLE")
>>> video
Video(id=None, video_id='VIDEO_ID')
>>> db.add(video)
>>> tm.commit()
>>> tm.begin()
<transaction._transaction.Transaction at 0x7f5235b13040>
>>> from sqlalchemy import select
>>> db.scalars(select(models.Video)).all()
[Video(id=1, video_id='VIDEO_ID')]
```

### Test `VideoFactory`

```python
>>> factories.VideoFactory()
Video(id=None, video_id='video_id_0')
>>> factories.VideoFactory()
Video(id=None, video_id='video_id_1')
```

### Test the web UI

<http://localhost:9083/https://www.youtube.com/watch?v=byN4S8WDPt8> (the video title is used for the tab's title and for the document title if you create an annotation)
