### PR TITLE
Add logic to handle toast messages (smarter `ToastMessages` container).

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,6 +8,11 @@ export default {
   ],
   theme: {
     extend: {
+      animation: {
+        'fade-in': 'fade-in 0.3s forwards',
+        'fade-out': 'fade-out 0.3s forwards',
+        'slide-in-from-right': 'slide-in-from-right 0.3s forwards ease-in-out',
+      },
       borderRadius: {
         // Equivalent to tailwind default `rounded-sm` size
         DEFAULT: '0.125rem',
@@ -25,6 +30,37 @@ export default {
         // Similar to tailwind's default `shadow-inner` but coming from the
         // right edge instead of the left
         'r-inner': 'inset -2px 0 4px 0 rgb(0,0,0,.05)',
+      },
+      keyframes: {
+        'fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          '100%': {
+            opacity: '1',
+          },
+        },
+        'fade-out': {
+          '0%': {
+            opacity: '1',
+          },
+          '100%': {
+            opacity: '0',
+          },
+        },
+        'slide-in-from-right': {
+          '0%': {
+            opacity: '0',
+            left: '100%',
+          },
+          '80%': {
+            left: '-10px',
+          },
+          '100%': {
+            left: '0',
+            opacity: '1',
+          },
+        },
       },
     },
   },

--- a/via/static/scripts/video_player/components/AppProvider.tsx
+++ b/via/static/scripts/video_player/components/AppProvider.tsx
@@ -1,0 +1,43 @@
+import type { ComponentChildren } from 'preact';
+import { createContext } from 'preact';
+import type { StateUpdater } from 'preact/hooks';
+import { useState } from 'preact/hooks';
+
+import type { ToastMessage } from './ToastMessages';
+
+export type ToastMessagesState = {
+  toastMessages: ToastMessage[];
+  setToastMessages: StateUpdater<ToastMessage[]>;
+};
+
+export type AppStore = {
+  toastMessages: ToastMessagesState;
+};
+
+export const AppContext = createContext<AppStore>({
+  toastMessages: {
+    toastMessages: [],
+    setToastMessages: () => {},
+  },
+});
+
+export type AppProviderProps = {
+  children: ComponentChildren;
+};
+
+export default function AppProvider({ children }: AppProviderProps) {
+  const [toastMessages, setToastMessages] = useState<ToastMessage[]>([]);
+
+  return (
+    <AppContext.Provider
+      value={{
+        toastMessages: {
+          toastMessages,
+          setToastMessages,
+        },
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+}

--- a/via/static/scripts/video_player/components/ToastMessages.tsx
+++ b/via/static/scripts/video_player/components/ToastMessages.tsx
@@ -1,0 +1,148 @@
+import { Callout } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+
+export type ToastMessage = {
+  id: string;
+  type: 'error' | 'success' | 'notice';
+  message: ComponentChildren;
+
+  /**
+   * Visually hidden messages are announced to screen readers but not visible.
+   * Defaults to false.
+   */
+  visuallyHidden?: boolean;
+
+  /**
+   * Determines if the toast message should be auto-dismissed.
+   * Defaults to true.
+   */
+  autoDismiss?: boolean;
+};
+
+type ToastMessageItemProps = {
+  message: ToastMessage;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * An individual toast message: a brief and transient success or error message.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ */
+function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
+  // Capitalize the message type for prepending; Don't prepend a message
+  // type for "notice" messages
+  const prefix =
+    message.type !== 'notice'
+      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
+      : '';
+
+  return (
+    <Callout
+      classes={classnames({
+        'sr-only': message.visuallyHidden,
+      })}
+      status={message.type}
+      onClick={() => onDismiss(message.id)}
+      variant="raised"
+    >
+      <strong>{prefix}</strong>
+      {message.message}
+    </Callout>
+  );
+}
+
+export type ToastMessagesProps = {
+  messages: ToastMessage[];
+  onMessageDismiss: (id: string) => void;
+};
+
+/**
+ * A collection of toast messages. These are rendered within an `aria-live`
+ * region for accessibility with screen readers.
+ */
+export default function ToastMessages({
+  messages,
+  onMessageDismiss,
+}: ToastMessagesProps) {
+  const [dismissedMessages, setDismissedMessages] = useState<string[]>([]);
+  const scheduledMessages = useRef(new Set<string>());
+
+  const dismissMessage = useCallback(
+    (id: string) => {
+      if (dismissedMessages.includes(id)) {
+        return;
+      }
+
+      // Track that this message has been dismissed, and once animation ends,
+      // actually remove it
+      setDismissedMessages(ids => [...ids, id]);
+      setTimeout(() => onMessageDismiss(id), 500);
+    },
+    [onMessageDismiss, dismissedMessages]
+  );
+  const scheduleMessageDismiss = useCallback(
+    (id: string) => {
+      if (scheduledMessages.current.has(id)) {
+        return;
+      }
+
+      // Track that this message has been scheduled to be dismissed. After a
+      // period of time, actually dismiss it
+      scheduledMessages.current.add(id);
+      setTimeout(() => {
+        dismissMessage(id);
+        scheduledMessages.current.delete(id);
+      }, 5000);
+    },
+    [dismissMessage]
+  );
+
+  useEffect(() => {
+    messages.forEach(({ autoDismiss = true, id }) => {
+      if (autoDismiss) {
+        scheduleMessageDismiss(id);
+      }
+    });
+  }, [messages, scheduleMessageDismiss]);
+
+  // The `ul` containing any toast messages is absolute-positioned and the full
+  // width of the viewport. Each toast message `li` has its position and width
+  // constrained by `container` configuration in tailwind.
+  return (
+    <ul
+      aria-live="polite"
+      aria-relevant="additions"
+      className="w-full space-y-2"
+    >
+      {messages.map(message => {
+        const isDismissed = dismissedMessages.includes(message.id);
+        return (
+          <li
+            className={classnames('relative w-full container', {
+              // Add a bottom margin to visible messages only. Typically, we'd
+              // use a `space-y-2` class on the parent to space children.
+              // Doing that here could cause an undesired top margin on
+              // the first visible message in a list that contains (only)
+              // visually-hidden messages before it.
+              // See https://tailwindcss.com/docs/space#limitations
+              'mb-2': !message.visuallyHidden,
+              // Slide in from right in narrow viewports; fade in larger
+              // viewports to toast message isn't flying too far
+              'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
+                !isDismissed,
+              // Only ever fade in if motion-reduction is preferred
+              'motion-reduce:animate-fade-in': !isDismissed,
+              'animate-fade-out': isDismissed,
+            })}
+            key={message.id}
+          >
+            <ToastMessageItem message={message} onDismiss={dismissMessage} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -17,6 +17,7 @@ import {
 
 import { useAppLayout } from '../hooks/use-app-layout';
 import { useSideBySideLayout } from '../hooks/use-side-by-side-layout';
+import { useToastMessages } from '../hooks/use-toast-messages';
 import { callAPI } from '../utils/api';
 import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
@@ -27,6 +28,7 @@ import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
 import TranscriptError from './TranscriptError';
+import VideoPlayerAppToastMessages from './VideoPlayerAppToastMessages';
 import YouTubeVideoPlayer from './YouTubeVideoPlayer';
 import { PauseIcon, PlayIcon, SyncIcon } from './icons';
 
@@ -235,15 +237,23 @@ export default function VideoPlayerApp({
     };
   }, [syncTranscript]);
 
+  const { appendToastMessage } = useToastMessages();
+
   const copyTranscript = async () => {
     const formattedTranscript = isTranscript(transcript)
       ? formatTranscript(transcript.segments)
       : '';
     try {
       await navigator.clipboard.writeText(formattedTranscript);
+      appendToastMessage({
+        type: 'success',
+        message: 'Transcript copied to clipboard',
+      });
     } catch (err) {
-      // TODO: Replace this with a toast message in the UI.
-      console.warn('Failed to copy transcript', err);
+      appendToastMessage({
+        type: 'error',
+        message: 'Failed to copy transcript',
+      });
     }
   };
 
@@ -266,7 +276,7 @@ export default function VideoPlayerApp({
   return (
     <div
       data-testid="app-container"
-      className={classnames('flex flex-col h-[100vh] min-h-0')}
+      className={classnames('flex flex-col h-[100vh] min-h-0 relative')}
     >
       {multicolumn && (
         <div
@@ -412,6 +422,7 @@ export default function VideoPlayerApp({
             })}
             data-testid="transcript-container"
           >
+            <VideoPlayerAppToastMessages />
             {isLoading && (
               <div className="flex justify-center p-8">
                 <Spinner data-testid="transcript-loading-spinner" size="md" />

--- a/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
@@ -1,0 +1,15 @@
+import { useToastMessages } from '../hooks/use-toast-messages';
+import ToastMessages from './ToastMessages';
+
+export default function VideoPlayerAppToastMessages() {
+  const { toastMessages, dismissToastMessage } = useToastMessages();
+
+  return (
+    <div className="absolute z-2 top-0 w-full p-2">
+      <ToastMessages
+        messages={toastMessages}
+        onMessageDismiss={dismissToastMessage}
+      />
+    </div>
+  );
+}

--- a/via/static/scripts/video_player/hooks/use-toast-messages.ts
+++ b/via/static/scripts/video_player/hooks/use-toast-messages.ts
@@ -1,0 +1,30 @@
+import { useContext } from 'preact/hooks';
+
+import { AppContext } from '../components/AppProvider';
+import type { ToastMessage } from '../components/ToastMessages';
+import { generateHexString } from '../utils/generate-hex-string';
+
+type ToastMessageData = Omit<ToastMessage, 'id'>;
+
+type ToastMessages = {
+  toastMessages: ToastMessage[];
+  appendToastMessage: (toastMessageData: ToastMessageData) => void;
+  dismissToastMessage: (od: string) => void;
+};
+
+export function useToastMessages(): ToastMessages {
+  const { toastMessages, setToastMessages } =
+    useContext(AppContext).toastMessages;
+  const appendToastMessage = (toastMessageData: ToastMessageData) => {
+    const id = generateHexString(10);
+    setToastMessages(messages => [...messages, { ...toastMessageData, id }]);
+  };
+  const dismissToastMessage = (id: string) =>
+    setToastMessages(messages => messages.filter(message => message.id !== id));
+
+  return {
+    toastMessages,
+    appendToastMessage,
+    dismissToastMessage,
+  };
+}

--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -3,6 +3,7 @@ import { render } from 'preact';
 // Enable debugging checks and devtools. Removed in prod builds by Rollup config.
 import 'preact/debug';
 
+import AppProvider from './components/AppProvider';
 import VideoPlayerApp from './components/VideoPlayerApp';
 import { readConfig } from './config';
 
@@ -40,12 +41,14 @@ export function init() {
   }
 
   render(
-    <VideoPlayerApp
-      videoId={videoId}
-      clientConfig={clientConfig}
-      clientSrc={clientSrc}
-      transcriptSource={api.transcript}
-    />,
+    <AppProvider>
+      <VideoPlayerApp
+        videoId={videoId}
+        clientConfig={clientConfig}
+        clientSrc={clientSrc}
+        transcriptSource={api.transcript}
+      />
+    </AppProvider>,
     rootEl
   );
 }

--- a/via/static/scripts/video_player/utils/generate-hex-string.ts
+++ b/via/static/scripts/video_player/utils/generate-hex-string.ts
@@ -1,0 +1,15 @@
+function byteToHex(val: number): string {
+  const str = val.toString(16);
+  return str.length === 1 ? '0' + str : str;
+}
+
+/**
+ * Generate a random hex string of `len` chars.
+ *
+ * @param len - An even-numbered length string to generate.
+ */
+export function generateHexString(len: number): string {
+  const bytes = new Uint8Array(len / 2);
+  window.crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(byteToHex).join('');
+}


### PR DESCRIPTION
This is PR introduces a different approach to handle toast messages (first one is https://github.com/hypothesis/via/pull/1089).

[Grabación de pantalla desde 2023-07-18 11-19-08.webm](https://github.com/hypothesis/via/assets/2719332/5ed84644-1362-4759-a60e-25ef076ad75d)

The main pieces are:

* A controlled `ToastMessages` component: it is similar to the one in client, but with the addition that it internally handles the logic to dismiss toast messages with a delay that allows for CSS animations to work.
  In some way it makes sense for this component to handle that, as the animations are an implementation detail of the component itself. From external consumers point of view, adding and dismissing toast messages is a matter of adding and removing items from a list.
* A new `AppProvider` component wrapping the entire video app, that we can use as a way to share a store across all components.
  It currently only handles one entry for toast messages, but it can be extended or replaced with something else, like redux.
* A `useToastMessages` hook, which reads the `toastMessages` from the app context, enhances it with a helper function to append and dismiss messages, and returns them together with the list of toast messages.
* A `VideoPlaterAppToastMessagess` component, which wraps the controlled `ToastMessages` components and feeds it with the result from the `useToastMessages` hook.
  This component can then be rendered wherever needed within the video app.

In order to verify the logic works and makes sense, this PR also enhances the copy-to-clipboard button, so that it displays a toast message after content has been copied, or an error has occurred.

### TODO / To think

- [ ] Consider extracting `ToastMessages` to frontend-shared, as it can be potentially used in client as well, with a couple of changes.
- [ ] Fix toast messages styling and positioning (currently rendered over the transcript, but spacing needs to be adjusted).