### PR TITLE
Add logic to handle toast messages (preact/signals)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@hypothesis/frontend-build": "^2.2.0",
     "@hypothesis/frontend-shared": "^6.1.1",
+    "@preact/signals": "^1.1.5",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-node-resolve": "^15.0.2",

--- a/via/static/scripts/video_player/components/AppContext.tsx
+++ b/via/static/scripts/video_player/components/AppContext.tsx
@@ -1,20 +1,12 @@
+import type { Signal } from '@preact/signals';
 import { createContext } from 'preact';
-import type { StateUpdater } from 'preact/hooks';
 
 import type { ToastMessage } from './ToastMessages';
 
-export type ToastMessagesState = {
-  toastMessages: ToastMessage[];
-  setToastMessages: StateUpdater<ToastMessage[]>;
-};
-
 export type AppStore = {
-  toastMessages: ToastMessagesState;
+  toastMessages: Signal<ToastMessage[]>;
 };
 
 export const AppContext = createContext<AppStore>({
-  toastMessages: {
-    toastMessages: [],
-    setToastMessages: () => {},
-  },
-});
+  toastMessages: {},
+} as AppStore);

--- a/via/static/scripts/video_player/components/AppContext.tsx
+++ b/via/static/scripts/video_player/components/AppContext.tsx
@@ -1,0 +1,20 @@
+import { createContext } from 'preact';
+import type { StateUpdater } from 'preact/hooks';
+
+import type { ToastMessage } from './ToastMessages';
+
+export type ToastMessagesState = {
+  toastMessages: ToastMessage[];
+  setToastMessages: StateUpdater<ToastMessage[]>;
+};
+
+export type AppStore = {
+  toastMessages: ToastMessagesState;
+};
+
+export const AppContext = createContext<AppStore>({
+  toastMessages: {
+    toastMessages: [],
+    setToastMessages: () => {},
+  },
+});

--- a/via/static/scripts/video_player/components/ToastMessages.tsx
+++ b/via/static/scripts/video_player/components/ToastMessages.tsx
@@ -1,0 +1,123 @@
+import { Callout } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
+
+export type ToastMessage = {
+  id: string;
+  type: 'error' | 'success' | 'notice';
+  message: ComponentChildren;
+
+  /**
+   * Visually hidden messages are announced to screen readers but not visible.
+   * Defaults to false.
+   */
+  visuallyHidden?: boolean;
+
+  /**
+   * Determines if the toast message should be auto-dismissed.
+   * Defaults to true.
+   */
+  autoDismiss?: boolean;
+};
+
+type ToastMessageItemProps = {
+  message: ToastMessage;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * An individual toast message: a brief and transient success or error message.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ */
+function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
+  // Capitalize the message type for prepending; Don't prepend a message
+  // type for "notice" messages
+  const prefix =
+    message.type !== 'notice'
+      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
+      : '';
+
+  return (
+    <Callout
+      classes={classnames({
+        'sr-only': message.visuallyHidden,
+      })}
+      status={message.type}
+      onClick={() => onDismiss(message.id)}
+      variant="raised"
+    >
+      <strong>{prefix}</strong>
+      {message.message}
+    </Callout>
+  );
+}
+
+export type ToastMessagesProps = {
+  messages: ToastMessage[];
+  onMessageDismiss: (id: string) => void;
+};
+
+/**
+ * A collection of toast messages. These are rendered within an `aria-live`
+ * region for accessibility with screen readers.
+ */
+export default function ToastMessages({
+  messages,
+  onMessageDismiss,
+}: ToastMessagesProps) {
+  const scheduledMessages = useRef(new Set<string>());
+  const scheduleMessageDismiss = useCallback(
+    (id: string) => {
+      if (scheduledMessages.current.has(id)) {
+        return;
+      }
+
+      // Track that this message has been scheduled to be dismissed. After a
+      // period of time, actually dismiss it
+      scheduledMessages.current.add(id);
+      setTimeout(() => {
+        onMessageDismiss(id);
+        scheduledMessages.current.delete(id);
+      }, 5000);
+    },
+    [onMessageDismiss]
+  );
+
+  useEffect(() => {
+    messages.forEach(({ autoDismiss = true, id }) => {
+      if (autoDismiss) {
+        scheduleMessageDismiss(id);
+      }
+    });
+  }, [messages, scheduleMessageDismiss]);
+
+  // The `ul` containing any toast messages is absolute-positioned and the full
+  // width of the viewport. Each toast message `li` has its position and width
+  // constrained by `container` configuration in tailwind.
+  return (
+    <ul
+      aria-live="polite"
+      aria-relevant="additions"
+      className="w-full space-y-2"
+    >
+      {messages.map(message => (
+        <li
+          className={classnames('relative w-full container', {
+            // Add a bottom margin to visible messages only. Typically, we'd
+            // use a `space-y-2` class on the parent to space children.
+            // Doing that here could cause an undesired top margin on
+            // the first visible message in a list that contains (only)
+            // visually-hidden messages before it.
+            // See https://tailwindcss.com/docs/space#limitations
+            'mb-2': !message.visuallyHidden,
+          })}
+          key={message.id}
+        >
+          <ToastMessageItem message={message} onDismiss={onMessageDismiss} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -20,13 +20,17 @@ import { useSideBySideLayout } from '../hooks/use-side-by-side-layout';
 import { callAPI } from '../utils/api';
 import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
+import { appendToastMessage } from '../utils/toast-messages';
 import type { TranscriptData } from '../utils/transcript';
 import { formatTranscript, mergeSegments } from '../utils/transcript';
+import { AppContext } from './AppContext';
 import FilterInput from './FilterInput';
 import HypothesisClient from './HypothesisClient';
+import type { ToastMessage } from './ToastMessages';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
 import TranscriptError from './TranscriptError';
+import VideoPlayerAppToastMessages from './VideoPlayerAppToastMessages';
 import YouTubeVideoPlayer from './YouTubeVideoPlayer';
 import { PauseIcon, PlayIcon, SyncIcon } from './icons';
 
@@ -253,6 +257,8 @@ export default function VideoPlayerApp({
     };
   }, [syncTranscript]);
 
+  const [toastMessages, setToastMessages] = useState<ToastMessage[]>([]);
+
   const copyTranscript = async () => {
     const formattedTranscript = isTranscript(transcript)
       ? formatTranscript(transcript.segments)
@@ -260,8 +266,13 @@ export default function VideoPlayerApp({
     try {
       await navigator.clipboard.writeText(formattedTranscript);
     } catch (err) {
-      // TODO: Replace this with a toast message in the UI.
-      console.warn('Failed to copy transcript', err);
+      appendToastMessage(
+        {
+          type: 'error',
+          message: 'Failed to copy transcript',
+        },
+        setToastMessages
+      );
     }
   };
 
@@ -283,228 +294,244 @@ export default function VideoPlayerApp({
   }, [baseClientConfig, contentReady]);
 
   return (
-    <div
-      data-testid="app-container"
-      className={classnames('flex flex-col h-[100vh] min-h-0')}
+    <AppContext.Provider
+      value={{
+        toastMessages: {
+          toastMessages,
+          setToastMessages,
+        },
+      }}
     >
-      {multicolumn && (
-        <div
-          data-testid="top-bar"
-          className={classnames(
-            'h-[40px] min-h-[40px] w-full flex items-center gap-x-3',
-            'pl-2 border-b bg-grey-0'
-          )}
-        >
-          <HypothesisLogo />
-          <div className="grow" />
+      <div
+        data-testid="app-container"
+        className={classnames('flex flex-col h-[100vh] min-h-0 relative')}
+      >
+        {multicolumn && (
           <div
-            data-testid="filter-container"
+            data-testid="top-bar"
             className={classnames(
-              'text-right',
-              // Put space to the right of the filter input so it is not
-              // overlaid by sidebar controls. NB: Cannot use margin because it
-              // gets "consumed" in side-by-side mode
-              'pr-4'
+              'h-[40px] min-h-[40px] w-full flex items-center gap-x-3',
+              'pl-2 border-b bg-grey-0'
             )}
+          >
+            <HypothesisLogo />
+            <div className="grow" />
+            <div
+              data-testid="filter-container"
+              className={classnames(
+                'text-right',
+                // Put space to the right of the filter input so it is not
+                // overlaid by sidebar controls. NB: Cannot use margin because it
+                // gets "consumed" in side-by-side mode
+                'pr-4'
+              )}
+              style={{ width: transcriptWidth }}
+            >
+              <FilterInput
+                elementRef={filterInputRef}
+                setFilter={setFilter}
+                filter={filter}
+              />
+            </div>
+          </div>
+        )}
+
+        <main
+          data-testid="app-layout"
+          className={classnames('w-full flex min-h-0', {
+            'flex-col grow': !multicolumn,
+            'flex-row grow h-full': multicolumn,
+          })}
+          ref={appContainerRef}
+        >
+          <div
+            data-testid="embedded-video-container"
+            className={classnames(
+              'flex flex-col',
+              {
+                // Allow video to grow with available horizontal space in
+                // multicolumn layouts (NB: It will take up full width in
+                // single-column)
+                grow: multicolumn,
+              },
+              {
+                // Adapt spacing around video for different app sizes
+                'p-0': appSize === 'sm',
+                'p-1': appSize === 'md',
+                'py-2 px-3': appSize === 'lg',
+                'py-2 px-4': appSize === 'xl',
+              }
+            )}
+          >
+            <YouTubeVideoPlayer
+              videoId={videoId}
+              play={playing}
+              time={timestamp}
+              onPlayingChanged={setPlaying}
+              onTimeChanged={setTimestamp}
+            />
+          </div>
+
+          <div
+            data-testid="transcript-and-controls-container"
+            className={classnames('flex flex-col bg-grey-0 border-x', {
+              // Make transcript fill available vertical space in single-column
+              // layouts
+              'min-h-0 grow': !multicolumn,
+            })}
             style={{ width: transcriptWidth }}
           >
-            <FilterInput
-              elementRef={filterInputRef}
-              setFilter={setFilter}
-              filter={filter}
-            />
-          </div>
-        </div>
-      )}
-
-      <main
-        data-testid="app-layout"
-        className={classnames('w-full flex min-h-0', {
-          'flex-col grow': !multicolumn,
-          'flex-row grow h-full': multicolumn,
-        })}
-        ref={appContainerRef}
-      >
-        <div
-          data-testid="embedded-video-container"
-          className={classnames(
-            'flex flex-col',
-            {
-              // Allow video to grow with available horizontal space in
-              // multicolumn layouts (NB: It will take up full width in
-              // single-column)
-              grow: multicolumn,
-            },
-            {
-              // Adapt spacing around video for different app sizes
-              'p-0': appSize === 'sm',
-              'p-1': appSize === 'md',
-              'py-2 px-3': appSize === 'lg',
-              'py-2 px-4': appSize === 'xl',
-            }
-          )}
-        >
-          <YouTubeVideoPlayer
-            videoId={videoId}
-            play={playing}
-            time={timestamp}
-            onPlayingChanged={setPlaying}
-            onTimeChanged={setTimestamp}
-          />
-        </div>
-        <div
-          data-testid="transcript-and-controls-container"
-          className={classnames('flex flex-col bg-grey-0 border-x', {
-            // Make transcript fill available vertical space in single-column
-            // layouts
-            'min-h-0 grow': !multicolumn,
-          })}
-          style={{ width: transcriptWidth }}
-        >
-          <div
-            data-testid="transcript-controls"
-            className={classnames(
-              // Same height as top-bar
-              'h-[40px] min-h-[40px]',
-              'bg-grey-1 flex items-center',
-              {
-                // Provide the correct right alignment with the sidebar
-                // Multicolumn needs more right-hand space to avoid interference
-                // by sidebar controls
-                'px-1.5': !multicolumn,
-                'pr-4': multicolumn,
-              }
-            )}
-          >
-            {multicolumn && (
-              <>
-                <Button
-                  icon={playing ? PauseIcon : PlayIcon}
-                  onClick={() => setPlaying(playing => !playing)}
-                  data-testid="play-button"
-                  variant="custom"
-                  classes="text-grey-7 hover:text-grey-9 font-semibold"
-                >
-                  {playing ? 'Pause' : 'Play'}
-                </Button>
-                <div className="grow" />
-              </>
-            )}
-            {!multicolumn && (
-              <>
-                <HypothesisLogo />
-                <div className="flex-grow ml-2.5">
-                  <FilterInput
-                    setFilter={setFilter}
-                    elementRef={filterInputRef}
-                    filter={filter}
-                  />
-                </div>
-              </>
-            )}
-
-            <IconButton
-              onClick={syncTranscript}
-              data-testid="sync-button"
-              disabled={!isTranscript(transcript)}
-              icon={SyncIcon}
-              title="Sync transcript to video"
-              size="custom"
-              classes="p-2"
-            />
-            <IconButton
-              onClick={copyTranscript}
-              data-testid="copy-button"
-              disabled={!isTranscript(transcript)}
-              title="Copy transcript"
-              icon={CopyIcon}
-              size="custom"
-              classes="p-2"
-            />
-          </div>
-          <div
-            className={classnames('relative grow', 'min-h-0', 'flex flex-col', {
-              // Ensure that this container uses all available vertical space
-              // on narrow screens
-              'h-full': !multicolumn,
-            })}
-            data-testid="transcript-container"
-          >
-            {isLoading && (
-              <div className="flex justify-center p-8">
-                <Spinner data-testid="transcript-loading-spinner" size="md" />
-              </div>
-            )}
-            {isTranscript(transcript) && (
-              <Transcript
-                autoScroll={autoScroll}
-                transcript={transcript}
-                controlsRef={transcriptControls}
-                currentTime={timestamp}
-                filter={trimmedFilter}
-                onSelectSegment={segment => {
-                  // Clear the filter before jumping to a segment, so the user
-                  // can easily read the text that comes before and after it.
-                  //
-                  // Note that we always show the current segment, regardless
-                  // of whether a filter is applied.
-                  setFilter('');
-
-                  setTimestamp(segment.start);
-                }}
-              >
-                <div
-                  data-testid="bucket-bar-channel"
-                  className={classnames(
-                    // Provide a backdrop for bucket bar buttons. 20px of this
-                    // is overlaid by the sidebar's semi-transparent bucket
-                    // channel.
-                    'bg-gradient-to-r from-white to-grey-1 border-l w-[40px]'
-                  )}
-                />
-              </Transcript>
-            )}
-            {transcript instanceof Error && (
-              <TranscriptError error={transcript} />
-            )}
             <div
-              id={bucketContainerId}
+              data-testid="transcript-controls"
               className={classnames(
-                // Position bucket bar along right edge of transcript, with a
-                // small gap to avoid buckets touching the border.
-                //
-                // The bucket bar width is currently copied from the client.
-                'absolute right-1.5 bottom-0 w-[23px]',
-
-                // Make the bucket bar fill this container.
-                'flex flex-column',
-
+                // Same height as top-bar
+                'h-[40px] min-h-[40px]',
+                'bg-grey-1 flex items-center',
                 {
-                  'top-0': !multicolumn,
-                  // Leave room for sidebar toolbar buttons at top of buckets
-                  // in multi-column layouts
-                  'h-[calc(100%-24px)]': multicolumn,
+                  // Provide the correct right alignment with the sidebar
+                  // Multicolumn needs more right-hand space to avoid interference
+                  // by sidebar controls
+                  'px-1.5': !multicolumn,
+                  'pr-4': multicolumn,
                 }
               )}
-            />
-          </div>
-          <div
-            data-testid="transcript-footer"
-            className="p-2 bg-grey-1 border-b h-[40px] min-h-[40px] flex items-center"
-          >
-            <Checkbox
-              checked={autoScroll}
-              data-testid="autoscroll-checkbox"
-              onChange={e =>
-                setAutoScroll((e.target as HTMLInputElement).checked)
-              }
             >
-              <div className="select-none">Auto-scroll</div>
-            </Checkbox>
+              {multicolumn && (
+                <>
+                  <Button
+                    icon={playing ? PauseIcon : PlayIcon}
+                    onClick={() => setPlaying(playing => !playing)}
+                    data-testid="play-button"
+                    variant="custom"
+                    classes="text-grey-7 hover:text-grey-9 font-semibold"
+                  >
+                    {playing ? 'Pause' : 'Play'}
+                  </Button>
+                  <div className="grow" />
+                </>
+              )}
+              {!multicolumn && (
+                <>
+                  <HypothesisLogo />
+                  <div className="flex-grow ml-2.5">
+                    <FilterInput
+                      setFilter={setFilter}
+                      elementRef={filterInputRef}
+                      filter={filter}
+                    />
+                  </div>
+                </>
+              )}
+
+              <IconButton
+                onClick={syncTranscript}
+                data-testid="sync-button"
+                disabled={!isTranscript(transcript)}
+                icon={SyncIcon}
+                title="Sync transcript to video"
+                size="custom"
+                classes="p-2"
+              />
+              <IconButton
+                onClick={copyTranscript}
+                data-testid="copy-button"
+                disabled={!isTranscript(transcript)}
+                title="Copy transcript"
+                icon={CopyIcon}
+                size="custom"
+                classes="p-2"
+              />
+            </div>
+            <div
+              className={classnames(
+                'relative grow',
+                'min-h-0',
+                'flex flex-col',
+                {
+                  // Ensure that this container uses all available vertical space
+                  // on narrow screens
+                  'h-full': !multicolumn,
+                }
+              )}
+              data-testid="transcript-container"
+            >
+              <VideoPlayerAppToastMessages />
+              {isLoading && (
+                <div className="flex justify-center p-8">
+                  <Spinner data-testid="transcript-loading-spinner" size="md" />
+                </div>
+              )}
+              {isTranscript(transcript) && (
+                <Transcript
+                  autoScroll={autoScroll}
+                  transcript={transcript}
+                  controlsRef={transcriptControls}
+                  currentTime={timestamp}
+                  filter={trimmedFilter}
+                  onSelectSegment={segment => {
+                    // Clear the filter before jumping to a segment, so the user
+                    // can easily read the text that comes before and after it.
+                    //
+                    // Note that we always show the current segment, regardless
+                    // of whether a filter is applied.
+                    setFilter('');
+
+                    setTimestamp(segment.start);
+                  }}
+                >
+                  <div
+                    data-testid="bucket-bar-channel"
+                    className={classnames(
+                      // Provide a backdrop for bucket bar buttons. 20px of this
+                      // is overlaid by the sidebar's semi-transparent bucket
+                      // channel.
+                      'bg-gradient-to-r from-white to-grey-1 border-l w-[40px]'
+                    )}
+                  />
+                </Transcript>
+              )}
+              {transcript instanceof Error && (
+                <TranscriptError error={transcript} />
+              )}
+              <div
+                id={bucketContainerId}
+                className={classnames(
+                  // Position bucket bar along right edge of transcript, with a
+                  // small gap to avoid buckets touching the border.
+                  //
+                  // The bucket bar width is currently copied from the client.
+                  'absolute right-1.5 bottom-0 w-[23px]',
+
+                  // Make the bucket bar fill this container.
+                  'flex flex-column',
+
+                  {
+                    'top-0': !multicolumn,
+                    // Leave room for sidebar toolbar buttons at top of buckets
+                    // in multi-column layouts
+                    'h-[calc(100%-24px)]': multicolumn,
+                  }
+                )}
+              />
+            </div>
+            <div
+              data-testid="transcript-footer"
+              className="p-2 bg-grey-1 border-b h-[40px] min-h-[40px] flex items-center"
+            >
+              <Checkbox
+                checked={autoScroll}
+                data-testid="autoscroll-checkbox"
+                onChange={e =>
+                  setAutoScroll((e.target as HTMLInputElement).checked)
+                }
+              >
+                <div className="select-none">Auto-scroll</div>
+              </Checkbox>
+            </div>
           </div>
-        </div>
-        <HypothesisClient src={clientSrc} config={clientConfig} />
-      </main>
-    </div>
+          <HypothesisClient src={clientSrc} config={clientConfig} />
+        </main>
+      </div>
+    </AppContext.Provider>
   );
 }

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -6,6 +6,7 @@ import {
   LogoIcon,
   Spinner,
 } from '@hypothesis/frontend-shared';
+import { useSignal } from '@preact/signals';
 import classnames from 'classnames';
 import {
   useCallback,
@@ -257,7 +258,7 @@ export default function VideoPlayerApp({
     };
   }, [syncTranscript]);
 
-  const [toastMessages, setToastMessages] = useState<ToastMessage[]>([]);
+  const toastMessages = useSignal<ToastMessage[]>([]);
 
   const copyTranscript = async () => {
     const formattedTranscript = isTranscript(transcript)
@@ -271,7 +272,7 @@ export default function VideoPlayerApp({
           type: 'error',
           message: 'Failed to copy transcript',
         },
-        setToastMessages
+        toastMessages
       );
     }
   };
@@ -294,14 +295,7 @@ export default function VideoPlayerApp({
   }, [baseClientConfig, contentReady]);
 
   return (
-    <AppContext.Provider
-      value={{
-        toastMessages: {
-          toastMessages,
-          setToastMessages,
-        },
-      }}
-    >
+    <AppContext.Provider value={{ toastMessages }}>
       <div
         data-testid="app-container"
         className={classnames('flex flex-col h-[100vh] min-h-0 relative')}

--- a/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
@@ -5,14 +5,13 @@ import { AppContext } from './AppContext';
 import ToastMessages from './ToastMessages';
 
 export default function VideoPlayerAppToastMessages() {
-  const { toastMessages, setToastMessages } =
-    useContext(AppContext).toastMessages;
+  const toastMessages = useContext(AppContext).toastMessages;
 
   return (
     <div className="absolute z-2 top-0 w-full p-2">
       <ToastMessages
-        messages={toastMessages}
-        onMessageDismiss={id => dismissToastMessage(id, setToastMessages)}
+        messages={toastMessages.value}
+        onMessageDismiss={id => dismissToastMessage(id, toastMessages)}
       />
     </div>
   );

--- a/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerAppToastMessages.tsx
@@ -1,0 +1,19 @@
+import { useContext } from 'preact/hooks';
+
+import { dismissToastMessage } from '../utils/toast-messages';
+import { AppContext } from './AppContext';
+import ToastMessages from './ToastMessages';
+
+export default function VideoPlayerAppToastMessages() {
+  const { toastMessages, setToastMessages } =
+    useContext(AppContext).toastMessages;
+
+  return (
+    <div className="absolute z-2 top-0 w-full p-2">
+      <ToastMessages
+        messages={toastMessages}
+        onMessageDismiss={id => dismissToastMessage(id, setToastMessages)}
+      />
+    </div>
+  );
+}

--- a/via/static/scripts/video_player/utils/generate-hex-string.ts
+++ b/via/static/scripts/video_player/utils/generate-hex-string.ts
@@ -1,0 +1,15 @@
+function byteToHex(val: number): string {
+  const str = val.toString(16);
+  return str.length === 1 ? '0' + str : str;
+}
+
+/**
+ * Generate a random hex string of `len` chars.
+ *
+ * @param len - An even-numbered length string to generate.
+ */
+export function generateHexString(len: number): string {
+  const bytes = new Uint8Array(len / 2);
+  window.crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(byteToHex).join('');
+}

--- a/via/static/scripts/video_player/utils/toast-messages.ts
+++ b/via/static/scripts/video_player/utils/toast-messages.ts
@@ -1,0 +1,22 @@
+import type { StateUpdater } from 'preact/hooks';
+
+import type { ToastMessage } from '../components/ToastMessages';
+import { generateHexString } from './generate-hex-string';
+
+export type ToastMessageData = Omit<ToastMessage, 'id'>;
+
+type ToastMessagesUpdater = StateUpdater<ToastMessage[]>;
+
+export const appendToastMessage = (
+  toastMessageData: ToastMessageData,
+  setToastMessages: ToastMessagesUpdater
+) => {
+  const id = generateHexString(10);
+  setToastMessages(messages => [...messages, { ...toastMessageData, id }]);
+};
+
+export const dismissToastMessage = (
+  id: string,
+  setToastMessages: ToastMessagesUpdater
+) =>
+  setToastMessages(messages => messages.filter(message => message.id !== id));

--- a/via/static/scripts/video_player/utils/toast-messages.ts
+++ b/via/static/scripts/video_player/utils/toast-messages.ts
@@ -1,22 +1,25 @@
-import type { StateUpdater } from 'preact/hooks';
+import type { Signal } from '@preact/signals';
 
 import type { ToastMessage } from '../components/ToastMessages';
 import { generateHexString } from './generate-hex-string';
 
 export type ToastMessageData = Omit<ToastMessage, 'id'>;
 
-type ToastMessagesUpdater = StateUpdater<ToastMessage[]>;
+type ToastMessagesSignal = Signal<ToastMessage[]>;
 
 export const appendToastMessage = (
   toastMessageData: ToastMessageData,
-  setToastMessages: ToastMessagesUpdater
+  toastMessages: ToastMessagesSignal
 ) => {
   const id = generateHexString(10);
-  setToastMessages(messages => [...messages, { ...toastMessageData, id }]);
+  toastMessages.value = [...toastMessages.value, { ...toastMessageData, id }];
 };
 
 export const dismissToastMessage = (
   id: string,
-  setToastMessages: ToastMessagesUpdater
-) =>
-  setToastMessages(messages => messages.filter(message => message.id !== id));
+  toastMessages: ToastMessagesSignal
+) => {
+  toastMessages.value = toastMessages.value.filter(
+    message => message.id !== id
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,6 +1631,18 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@preact/signals-core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@preact/signals-core/-/signals-core-1.3.1.tgz#7554563a6f3fc3a91d58ca103597ebe280f48e3b"
+  integrity sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig==
+
+"@preact/signals@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@preact/signals/-/signals-1.1.5.tgz#3bd847dfd6609691fe07a38e30245361d9a7ceea"
+  integrity sha512-OWr9TjuNh9ol/B5rNbLANEA940MvbYDMGcSAjPaKzAHBPhnTpuFCWhBB8vSm9lfy1BxKx6DKJLSs3Cz24otdkw==
+  dependencies:
+    "@preact/signals-core" "^1.3.1"
+
 "@rollup/plugin-babel@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz#07ccde15de278c581673034ad6accdb4a153dfeb"


### PR DESCRIPTION
> **Note**
> This PR is easier to review by ignoring whitespaces.

This PR is a slightly different possible approach to handle toast messages, which differs from https://github.com/hypothesis/via/pull/1089 and https://github.com/hypothesis/via/pull/1094 in:

* The controlled `ToastMessages` component introduced in the two previous PRs is still there. However, anything related with animations has been removed, as it simplifies the logic to dismiss toast mesages.
  The concept of auto-dismiss is still there, but considering we only have a single possible toast message which will almost never happen, we can even get rid of that.
* The toast messages state is handled via `@preact/signals`. This becomes the first use case in any of our projects, so let's review carefully and provide feedback.
  > The first commit uses `useState`, and the second commit introduces signals. In case you want to check the diff.
* The `AppContext` and `VideoPlayerAppToastMessages` introduced in https://github.com/hypothesis/via/pull/1094 are still there.

### Todo

- [ ] Fix tests
- [ ] Decide proper positioning and styling for `VideoPlayerAppToastMessages`.

### Testing steps

1. Open `VideoPlayerApp.tsx`.
2. Right before `await navigator.clipboard.writeText(formattedTranscript);`, add this line.
    ```diff
    + throw new Error('Hi!`);
    await navigator.clipboard.writeText(formattedTranscript);
    ```
3. Open http://localhost:9083/https://www.youtube.com/watch?v=MrORaCfcKxQ and click the copy-to-clipboard button. It should display a toast message every time you click it.
4. Toast messages should be dismissed after 5 seconds.
5. Clicking on a toast message should dismiss it immediatelly.

[Grabación de pantalla desde 2023-07-19 08-37-55.webm](https://github.com/hypothesis/via/assets/2719332/a998ef17-31c9-45a9-b9ce-9b1d77c108e3)
