### PR TITLE
Set a default minimum font size of 16px for inputs on touch devices

### DIFF
--- a/via/static/styles/video_player.css
+++ b/via/static/styles/video_player.css
@@ -3,14 +3,25 @@ CSS entry point for the video player app.
 */
 
 @tailwind base;
-
-body {
-  @apply bg-grey-0;
-  @apply font-sans text-sm text-color-text;
-}
-
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-grey-0;
+    @apply font-sans text-sm text-color-text;
+  }
+
+  /*
+  Input fields must have a minimum size on iOS to avoid the browser zooming in
+  when they are focused.
+  */
+  @media(pointer: coarse) {
+    input, textarea {
+      font-size: max(16px, 100%);
+    }
+  }
+}
 
 p::highlight(transcript-filter-match) {
   text-decoration: underline;


### PR DESCRIPTION
Previously the font size for inputs was taken from the `text-sm` default for `body`, which evaluates to 14px. This is below the threshold on iOS that causes the browser to zoom into the field when focused.

Fixes #1061

See also https://tailwindcss.com/docs/preflight#extending-preflight

**Testing:**

1. Open a video
2. Toggle the mobile device mode in the Chrome devtools toolbar. The search input should be 16px when in mobile mode and 14px otherwise

If testing with the local dev server on an actual mobile device, you will need to edit the [`client_embed_url` setting](https://github.com/hypothesis/via/blob/a89f260c8aa908dd6ef9a8f9c3bca6f4dbab35e8/conf/development.ini#L6) to point to the IP of your dev system, in order for the client to load.