### PR TITLE
Limit video height to half window height in single-column layouts

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -109,7 +109,7 @@ export default function VideoPlayerApp({
   const filterInputRef = useRef<HTMLInputElement>();
   const appContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const { appSize, multicolumn, transcriptWidth } =
+  const { appSize, multicolumn, transcriptWidth, videoWidth } =
     useAppLayout(appContainerRef);
   const sideBySideActive = useSideBySideLayout();
 
@@ -315,6 +315,10 @@ export default function VideoPlayerApp({
               // multicolumn layouts (NB: It will take up full width in
               // single-column)
               grow: multicolumn,
+
+              // In single-column layouts, the video may be narrower than the
+              // column width. Center the video in the column.
+              'ml-auto mr-auto': typeof videoWidth !== 'undefined',
             },
             {
               // Adapt spacing around video for different app sizes
@@ -324,6 +328,7 @@ export default function VideoPlayerApp({
               'py-2 px-4': appSize === 'xl',
             }
           )}
+          style={{ width: videoWidth ? `${videoWidth}px` : undefined }}
         >
           <YouTubeVideoPlayer
             videoId={videoId}

--- a/via/static/scripts/video_player/hooks/test/use-app-layout-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-app-layout-test.js
@@ -14,7 +14,11 @@ describe('useAppLayout', () => {
     const myRef = useRef();
     lastAppLayout = useAppLayout(myRef);
     return (
-      <div ref={myRef} style="width:100%" data-testid="appContainer">
+      <div
+        ref={myRef}
+        style={{ width: '100%', height: '100%' }}
+        data-testid="appContainer"
+      >
         <button>Hi</button>
       </div>
     );
@@ -29,6 +33,8 @@ describe('useAppLayout', () => {
   beforeEach(() => {
     container = document.createElement('div');
     container.setAttribute('id', 'container');
+    container.style.width = '800px';
+    container.style.height = '600px';
     document.body.append(container);
 
     wrappers = [];
@@ -59,7 +65,7 @@ describe('useAppLayout', () => {
       if (expected === 'sm') {
         const expectedWidth = Math.min(
           containerWidth,
-          (window.innerHeight / 2) * (16 / 9)
+          (container.clientHeight / 2) * (16 / 9)
         );
         assert.approximately(lastAppLayout.videoWidth, expectedWidth, 1);
       } else {


### PR DESCRIPTION
In single column layouts with "short" window heights, limit the height of the video to a maximum of half the window height, to ensure there is a good amount of space for the transcript. Since videos have a 16:9 aspect ratio, this means not using the full width and centering the video instead.

To make it easier to keep `videoWidth` in sync with the other properties returned by `useAppLayout`, the internals were refactored to separate the external state (the container width and height) from the properties that can be computed from that state (app size enum value, multicolumn, max video width).

Fixes https://github.com/hypothesis/via/issues/1085

----

**Before:**

A single column layout where giving the video full width makes the transcript too short:

<img width="600" alt="Too-short transcript" src="https://github.com/hypothesis/via/assets/2458/cedf5148-fd05-4a95-b5b8-dc8e55cfa7b0">

(See also https://github.com/hypothesis/via/issues/1085 for more extreme examples)

**After:**

<img width="1291" alt="Better-sized transcript" src="https://github.com/hypothesis/via/assets/2458/8b0d4ef5-8b5d-4a67-b343-9877eb1ea801">

Note that in multi-column layouts, and single-column layouts where a full-width video previously resulted in a transcript having >= 50% of the viewport height, the layout should look the same as before.




