### PR TITLE
Unified access to YouTube data via the client

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,6 +61,8 @@ gunicorn==20.1.0
     # via -r requirements/prod.txt
 h-assets==1.0.5
     # via -r requirements/prod.txt
+h-matchers==1.2.15
+    # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
 h-vialib==1.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -215,7 +215,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -280,8 +279,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -205,7 +205,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -270,8 +269,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -60,7 +60,9 @@ gunicorn==20.1.0
 h-assets==1.0.5
     # via -r requirements/prod.txt
 h-matchers==1.2.15
-    # via -r requirements/functests.in
+    # via
+    #   -r requirements/functests.in
+    #   -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
 h-vialib==1.2.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -326,7 +326,6 @@ requests==2.31.0
     #   -r requirements/tests.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/functests.txt
@@ -428,10 +427,6 @@ wired==0.3
     #   pyramid-services
 wrapt==1.12.1
     # via astroid
-youtube-transcript-api==0.6.1
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
 zipp==3.4.1
     # via
     #   -r requirements/functests.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -16,5 +16,4 @@ whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
-youtube-transcript-api
 isodate

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -4,6 +4,7 @@ newrelic
 checkmatelib
 h-assets
 h-pyramid-sentry
+h-matchers
 h-vialib
 importlib_resources
 pyjwt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -30,6 +30,8 @@ gunicorn==20.1.0
     # via -r requirements/prod.in
 h-assets==1.0.5
     # via -r requirements/prod.in
+h-matchers==1.2.15
+    # via -r requirements/prod.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.in
 h-vialib==1.2.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -115,7 +115,6 @@ requests==2.31.0
     #   -r requirements/prod.in
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via google-auth-oauthlib
 rsa==4.7.2
@@ -148,8 +147,6 @@ whitenoise==6.5.0
     # via -r requirements/prod.in
 wired==0.3
     # via pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.in
 zipp==3.4.1
     # via
     #   importlib-metadata

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -62,7 +62,9 @@ gunicorn==20.1.0
 h-assets==1.0.5
     # via -r requirements/prod.txt
 h-matchers==1.2.15
-    # via -r requirements/tests.in
+    # via
+    #   -r requirements/prod.txt
+    #   -r requirements/tests.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
 h-vialib==1.2.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -209,7 +209,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -268,8 +267,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -62,10 +62,4 @@ def pdf_url_builder_service(mock_service):
 
 @pytest.fixture
 def youtube_service(mock_service):
-    youtube_service = mock_service(YouTubeService)
-    youtube_service.enabled = True
-
-    # By default, the mock reports that URLs are not YouTube URLs.
-    youtube_service.get_video_id.return_value = None
-
-    return youtube_service
+    return mock_service(YouTubeService)

--- a/tests/unit/via/services/url_details_test.py
+++ b/tests/unit/via/services/url_details_test.py
@@ -130,6 +130,12 @@ class TestGetURLDetails:
     def clean_headers(self, patch):
         return patch("via.services.url_details.clean_headers", return_value={})
 
+    @pytest.fixture
+    def youtube_service(self, youtube_service):
+        # By default, we don't want everything appearing as a YouTube video
+        youtube_service.get_video_id.return_value = None
+        return youtube_service
+
 
 @pytest.mark.usefixtures("checkmate_service", "http_service", "youtube_service")
 def test_factory(pyramid_request):

--- a/tests/unit/via/services/youtube_api/client_test.py
+++ b/tests/unit/via/services/youtube_api/client_test.py
@@ -1,0 +1,77 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from via.services.youtube_api import (
+    CaptionTrack,
+    Transcript,
+    TranscriptText,
+    YouTubeAPIClient,
+)
+
+
+class TestYouTubeAPIClient:
+    def test_get_video_info(self, client, http_session, Video):
+        video = client.get_video_info("VIDEO_ID")
+
+        http_session.post.assert_called_once_with(
+            "https://youtubei.googleapis.com/youtubei/v1/player",
+            json={
+                "context": {
+                    "client": {
+                        "hl": "en",
+                        "clientName": "WEB",
+                        # Suspicious value right here...
+                        "clientVersion": "2.20210721.00.00",
+                    }
+                },
+                "videoId": "VIDEO_ID",
+            },
+        )
+        response = http_session.post.return_value
+        response.json.assert_called_once_with()
+
+        Video.from_v1_json.assert_called_once_with(data=response.json.return_value)
+        assert video == Video.from_v1_json.return_value
+
+    def test_get_transcript(self, client, http_session):
+        caption_track = CaptionTrack("en", base_url=sentinel.url)
+        response = http_session.get.return_value
+        response.text = """
+        <transcript>
+            <text start="0.21" dur="1.387">Hey there guys,</text>
+
+            <text start="1.597">Lichen&#39; subscribe        </text>
+            <text start="4.327" dur="2.063">
+                &lt;font color=&quot;#A0AAB4&quot;&gt;Buy my merch!&lt;/font&gt;
+            </text>
+        </transcript>
+        """
+
+        transcript = client.get_transcript(caption_track)
+
+        http_session.get.assert_called_once_with(url=caption_track.url)
+        assert transcript == Transcript(
+            track=caption_track,
+            text=[
+                TranscriptText(text="Hey there guys,", start=0.21, duration=1.387),
+                TranscriptText(text="Lichen' subscribe", start=1.597, duration=0.0),
+                TranscriptText(text="Buy my merch!", start=4.327, duration=2.063),
+            ],
+        )
+
+    def test_get_transcript_with_no_url(self, client):
+        with pytest.raises(ValueError):
+            client.get_transcript(CaptionTrack("en", base_url=None))
+
+    @pytest.fixture
+    def client(self):
+        return YouTubeAPIClient()
+
+    @pytest.fixture
+    def Video(self, patch):
+        return patch("via.services.youtube_api.client.Video")
+
+    @pytest.fixture(autouse=True)
+    def http_session(self, patch):
+        return patch("via.services.youtube_api.client.HTTPService").return_value

--- a/tests/unit/via/services/youtube_test.py
+++ b/tests/unit/via/services/youtube_test.py
@@ -23,33 +23,6 @@ class TestYouTubeService:
         )
 
     @pytest.mark.parametrize(
-        "url,expected_video_id",
-        [
-            ("not_an_url", None),
-            ("https://notyoutube:1000000", None),
-            ("https://notyoutube.com", None),
-            ("https://youtube.com", None),
-            ("https://youtube.com?param=nope", None),
-            ("https://youtube.com?v=", None),
-            ("https://youtu/VIDEO_ID", None),
-            ("https://youtube.com?v=VIDEO_ID", "VIDEO_ID"),
-            ("https://www.youtube.com/watch?v=VIDEO_ID", "VIDEO_ID"),
-            ("https://www.youtube.com/watch?v=VIDEO_ID&t=14s", "VIDEO_ID"),
-            (
-                "https://www.youtube.com/v/VIDEO_ID?fs=1&amp;hl=en_US&amp;rel=0",
-                "VIDEO_ID",
-            ),
-            ("https://www.youtube.com/embed/VIDEO_ID?rel=0", "VIDEO_ID"),
-            ("https://youtu.be/VIDEO_ID", "VIDEO_ID"),
-            ("https://youtube.com/shorts/VIDEO_ID?feature=share", "VIDEO_ID"),
-            ("https://www.youtube.com/live/VIDEO_ID?feature=share", "VIDEO_ID"),
-            ("https://m.youtube.com/watch?v=VIDEO_ID", "VIDEO_ID"),
-        ],
-    )
-    def test_get_video_id(self, url, expected_video_id, svc):
-        assert expected_video_id == svc.get_video_id(url)
-
-    @pytest.mark.parametrize(
         "kwargs",
         (
             {"video_url": "https://www.youtube.com/watch?v=VIDEO_ID"},

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -6,7 +6,7 @@ from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 from pyramid.httpexceptions import HTTPUnauthorized
 
 from via.exceptions import BadURL
-from via.views.view_video import youtube
+from via.views.view_video import view_youtube_video
 
 # webargs's kwargs injection into view functions falsely triggers Pylint's
 # no-value-for-parameter all the time so just disable it file-wide.
@@ -18,38 +18,40 @@ class TestViewVideo:
     def test_it(
         self,
         pyramid_request,
-        Configuration,
         youtube_service,
         video_url,
         ViaSecurityPolicy,
     ):
         # Override default `None` response.
-        youtube_service.get_video_id.return_value = sentinel.youtube_video_id
+        pyramid_request.params["via.video.lang"] = sentinel.transcript_id
 
-        response = youtube(pyramid_request)
+        response = view_youtube_video(pyramid_request)
 
         youtube_service.get_video_id.assert_called_once_with(video_url)
-        youtube_service.canonical_video_url.assert_called_once_with(
-            sentinel.youtube_video_id
-        )
+        video_id = youtube_service.get_video_id.return_value
+        youtube_service.canonical_video_url.assert_called_once_with(video_id)
         youtube_service.get_video_title.assert_called_once_with(
             youtube_service.get_video_id.return_value
         )
-        Configuration.extract_from_params.assert_called_once_with(
-            {"via.foo": "foo", "via.bar": "bar"}
-        )
+
         ViaSecurityPolicy.encode_jwt.assert_called_once_with(pyramid_request)
         assert response == {
             "client_embed_url": "http://hypothes.is/embed.js",
-            "client_config": Configuration.extract_from_params.return_value[1],
+            "client_config": {
+                "appType": "via",
+                "openSidebar": False,
+                "showHighlights": True,
+            },
             "title": youtube_service.get_video_title.return_value,
-            "video_id": youtube_service.get_video_id.return_value,
+            "video_id": video_id,
             "video_url": youtube_service.canonical_video_url.return_value,
             "api": {
                 "transcript": {
                     "doc": Any.string(),
                     "url": pyramid_request.route_url(
-                        "api.youtube.transcript", video_id=sentinel.youtube_video_id
+                        "api.youtube.transcript",
+                        video_id=video_id,
+                        transcript_id=sentinel.transcript_id,
                     ),
                     "method": "GET",
                     "headers": {
@@ -59,11 +61,22 @@ class TestViewVideo:
             },
         }
 
+    def test_it_defaults_to_en(self, pyramid_request, youtube_service):
+        pyramid_request.params.pop("via.video.lang", None)
+
+        response = view_youtube_video(pyramid_request)
+
+        assert response["api"]["transcript"]["url"] == pyramid_request.route_url(
+            "api.youtube.transcript",
+            video_id=youtube_service.get_video_id.return_value,
+            transcript_id="en.a",
+        )
+
     def test_it_errors_if_the_url_is_invalid(self, pyramid_request):
         pyramid_request.params["url"] = "not_a_valid_url"
 
         with pytest.raises(MarshmallowValidationError) as exc_info:
-            youtube(pyramid_request)
+            view_youtube_video(pyramid_request)
 
         assert exc_info.value.normalized_messages() == {
             "query": {"url": ["Not a valid URL."]}
@@ -78,7 +91,7 @@ class TestViewVideo:
         youtube_service.get_video_id.return_value = None
 
         with pytest.raises(BadURL) as exc_info:
-            youtube(pyramid_request)
+            view_youtube_video(pyramid_request)
 
         assert str(exc_info.value).startswith("Unsupported video URL")
 
@@ -88,7 +101,7 @@ class TestViewVideo:
         youtube_service.enabled = False
 
         with pytest.raises(HTTPUnauthorized):
-            youtube(pyramid_request)
+            view_youtube_video(pyramid_request)
 
     @pytest.fixture
     def video_url(self):
@@ -96,22 +109,10 @@ class TestViewVideo:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, video_url):
-        pyramid_request.params.update(
-            {"url": video_url, "via.foo": "foo", "via.bar": "bar"}
-        )
+        pyramid_request.params["url"] = video_url
+
         return pyramid_request
 
-
-@pytest.fixture(autouse=True)
-def Configuration(patch):
-    Configuration = patch("via.views.view_video.Configuration")
-    Configuration.extract_from_params.return_value = (
-        sentinel.via_config,
-        sentinel.h_config,
-    )
-    return Configuration
-
-
-@pytest.fixture(autouse=True)
-def ViaSecurityPolicy(patch):
-    return patch("via.views.view_video.ViaSecurityPolicy")
+    @pytest.fixture(autouse=True)
+    def ViaSecurityPolicy(self, patch):
+        return patch("via.views.view_video.ViaSecurityPolicy")

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -1,8 +1,12 @@
 from urllib.parse import parse_qs, quote_plus, urlparse
 
-from youtube_transcript_api import YouTubeTranscriptApi
-
+from via.exceptions import BadURL
 from via.services.http import HTTPService
+from via.services.youtube_api import CaptionTrack, Transcript, Video, YouTubeAPIClient
+
+
+class YouTubeServiceError(Exception):
+    """Something has gone wrong in the YouTube service itself."""
 
 
 class YouTubeDataAPIError(Exception):
@@ -10,9 +14,17 @@ class YouTubeDataAPIError(Exception):
 
 
 class YouTubeService:
-    def __init__(self, enabled: bool, api_key: str, http_service: HTTPService):
+    def __init__(
+        self,
+        enabled: bool,
+        api_client: YouTubeAPIClient,
+        api_key: str,
+        http_service: HTTPService,
+    ):
         self._enabled = enabled
+        self._api_client = api_client
         self._api_key = api_key
+
         self._http_service = http_service
 
     @property
@@ -75,19 +87,32 @@ class YouTubeService:
         except Exception as exc:
             raise YouTubeDataAPIError("getting the video title failed") from exc
 
-    def get_transcript(self, video_id):
-        """
-        Call the YouTube API and return the transcript for the given video_id.
+    def get_video_info(self, video_id=None, video_url=None) -> Video:
+        if video_url:
+            video_id = self.get_video_id(video_url)
 
-        :raise Exception: this method might raise any type of exception that
-            YouTubeTranscriptApi raises
-        """
-        return YouTubeTranscriptApi.get_transcript(video_id)
+        if not video_id:
+            raise BadURL(f"Unsupported video URL: {video_url}", url=video_url)
+
+        return self._api_client.get_video_info(video_id=video_id)
+
+    def get_transcript(self, video_id: str, transcript_id: str) -> Transcript:
+        video = self.get_video_info(video_id=video_id)
+
+        if caption_track := video.caption.find_matching_track(
+            [CaptionTrack.from_id(transcript_id)]
+        ):
+            return self._api_client.get_transcript(caption_track)
+
+        raise YouTubeServiceError(
+            "no_matching_transcript_found", video_id, transcript_id
+        )
 
 
 def factory(_context, request):
     return YouTubeService(
         enabled=request.registry.settings["youtube_transcripts"],
+        api_client=YouTubeAPIClient(),
         api_key=request.registry.settings["youtube_api_key"],
         http_service=request.find_service(HTTPService),
     )

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -1,7 +1,6 @@
-from urllib.parse import parse_qs, quote_plus, urlparse
+from urllib.parse import parse_qs, urlparse
 
 from via.exceptions import BadURL
-from via.services.http import HTTPService
 from via.services.youtube_api import CaptionTrack, Transcript, Video, YouTubeAPIClient
 
 
@@ -9,37 +8,14 @@ class YouTubeServiceError(Exception):
     """Something has gone wrong in the YouTube service itself."""
 
 
-class YouTubeDataAPIError(Exception):
-    """A problem with calling the YouTube Data API."""
-
-
 class YouTubeService:
-    def __init__(
-        self,
-        enabled: bool,
-        api_client: YouTubeAPIClient,
-        api_key: str,
-        http_service: HTTPService,
-    ):
+    def __init__(self, enabled: bool, api_client: YouTubeAPIClient):
         self._enabled = enabled
         self._api_client = api_client
-        self._api_key = api_key
-
-        self._http_service = http_service
 
     @property
     def enabled(self):
-        return bool(self._enabled and self._api_key)
-
-    def canonical_video_url(self, video_id: str) -> str:
-        """
-        Return the canonical URL for a YouTube video.
-
-        This is used as the URL which YouTube transcript annotations are
-        associated with.
-        """
-        escaped_id = quote_plus(video_id)
-        return f"https://www.youtube.com/watch?v={escaped_id}"
+        return bool(self._enabled and self._api_client)
 
     def get_video_id(self, url):
         """Return the YouTube video ID from the given URL, or None."""
@@ -71,33 +47,21 @@ class YouTubeService:
 
         return None
 
-    def get_video_title(self, video_id):
-        """Call the YouTube API and return the title for the given video_id."""
-        # https://developers.google.com/youtube/v3/docs/videos/list
-        try:
-            return self._http_service.get(
-                "https://www.googleapis.com/youtube/v3/videos",
-                params={
-                    "id": video_id,
-                    "key": self._api_key,
-                    "part": "snippet",
-                    "maxResults": "1",
-                },
-            ).json()["items"][0]["snippet"]["title"]
-        except Exception as exc:
-            raise YouTubeDataAPIError("getting the video title failed") from exc
-
-    def get_video_info(self, video_id=None, video_url=None) -> Video:
+    def get_video_info(
+        self, video_id=None, video_url=None, with_captions=False
+    ) -> Video:
         if video_url:
             video_id = self.get_video_id(video_url)
 
         if not video_id:
             raise BadURL(f"Unsupported video URL: {video_url}", url=video_url)
 
-        return self._api_client.get_video_info(video_id=video_id)
+        return self._api_client.get_video_info(
+            video_id=video_id, with_captions=with_captions
+        )
 
     def get_transcript(self, video_id: str, transcript_id: str) -> Transcript:
-        video = self.get_video_info(video_id=video_id)
+        video = self.get_video_info(video_id=video_id, with_captions=True)
 
         if caption_track := video.caption.find_matching_track(
             [CaptionTrack.from_id(transcript_id)]
@@ -110,9 +74,9 @@ class YouTubeService:
 
 
 def factory(_context, request):
+    api_key = request.registry.settings["youtube_api_key"]
+
     return YouTubeService(
         enabled=request.registry.settings["youtube_transcripts"],
-        api_client=YouTubeAPIClient(),
-        api_key=request.registry.settings["youtube_api_key"],
-        http_service=request.find_service(HTTPService),
+        api_client=YouTubeAPIClient(api_key=api_key) if api_key else None,
     )

--- a/via/services/youtube_api/__init__.py
+++ b/via/services/youtube_api/__init__.py
@@ -1,1 +1,2 @@
+from via.services.youtube_api.client import YouTubeAPIClient
 from via.services.youtube_api.models import *

--- a/via/services/youtube_api/client.py
+++ b/via/services/youtube_api/client.py
@@ -1,0 +1,79 @@
+from xml.etree import ElementTree
+
+import requests
+
+from via.services import HTTPService
+from via.services.youtube_api.models import (
+    CaptionTrack,
+    Transcript,
+    TranscriptText,
+    Video,
+)
+
+
+class YouTubeAPIError(Exception):
+    """Something has gone wrong interacting with YouTube."""
+
+
+class YouTubeAPIClient:
+    """A client for interacting with YouTube and manipulating related URLs."""
+
+    def __init__(self):
+        session = requests.Session()
+        # Ensure any translations that Google provides are in English
+        session.headers["Accept-Language"] = "en-US"
+        self._http = HTTPService(session=session)
+
+    def get_video_info(self, video_id: str) -> Video:
+        """Get information for a given YouTube video."""
+
+        response = self._http.post(
+            "https://youtubei.googleapis.com/youtubei/v1/player",
+            json={
+                "context": {
+                    "client": {
+                        "hl": "en",
+                        "clientName": "WEB",
+                        # Suspicious value right here...
+                        "clientVersion": "2.20210721.00.00",
+                    }
+                },
+                "videoId": video_id,
+            },
+        )
+
+        return Video.from_v1_json(data=response.json())
+
+    def get_transcript(self, caption_track: CaptionTrack) -> Transcript:
+        """Get the transcript associated with a caption track.
+
+        You can set the track `translated_language_code` to ensure we translate
+        the value before returning it.
+        """
+
+        if not caption_track.url:
+            raise ValueError("Cannot get a transcript without a URL")
+
+        response = self._http.get(url=caption_track.url)
+        xml_elements = ElementTree.fromstring(response.text)
+
+        return Transcript(
+            track=caption_track,
+            text=[
+                TranscriptText(
+                    text=self._strip_html(xml_element.text),
+                    start=float(xml_element.attrib["start"]),
+                    duration=float(xml_element.attrib.get("dur", "0.0")),
+                )
+                for xml_element in xml_elements
+                if xml_element.text is not None
+            ],
+        )
+
+    @staticmethod
+    def _strip_html(xml_string):
+        """Remove all non-text content from an XML fragment or string."""
+
+        return "".join(
+            ElementTree.fromstring(f"<span>{xml_string}</span>").itertext()
+        ).strip()

--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title }}</title>
-    <link rel="canonical" href="{{ video_url }}"/>
+    <title>{{ video.title }}</title>
+    <link rel="canonical" href="{{ video.url }}"/>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     {% for url in asset_urls("video_player_css") %}
     <link rel="stylesheet" href="{{ url }}">
@@ -16,7 +16,7 @@
       {
         "client_config": {{ client_config | tojson }},
         "client_src": "{{ client_embed_url }}",
-        "video_id": "{{ video_id }}",
+        "video_id": "{{ video.id }}",
         "api": {{ api | tojson }}
       }
     </script>

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -28,7 +28,9 @@ def add_routes(config):  # pragma: no cover
     config.add_route("proxy_d2l_pdf", "/d2l/proxied.pdf", factory=QueryURLResource)
     config.add_route("proxy_python_pdf", "proxied.pdf", factory=QueryURLResource)
 
-    config.add_route("api.youtube.transcript", "/api/youtube/transcript/{video_id}")
+    config.add_route(
+        "api.youtube.transcript", "/api/youtube/transcript/{video_id}/{transcript_id}"
+    )
 
     config.add_route("static_fallback", "/static/{url:.*}")
     config.add_route("proxy", "/{url:.*}", factory=PathURLResource)

--- a/via/views/api/youtube.py
+++ b/via/views/api/youtube.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import asdict
 
 from pyramid.view import view_config
 
@@ -17,13 +18,14 @@ def get_transcript(request):
     """Return the transcript of a given YouTube video."""
 
     video_id = request.matchdict["video_id"]
-
-    transcript = request.find_service(YouTubeService).get_transcript(video_id)
+    transcript = request.find_service(YouTubeService).get_transcript(
+        video_id=video_id, transcript_id=request.matchdict["transcript_id"]
+    )
 
     return {
         "data": {
             "type": "transcripts",
             "id": video_id,
-            "attributes": {"segments": transcript},
+            "attributes": {"segments": asdict(transcript)["text"]},
         }
     }

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -14,7 +14,7 @@ from via.services import YouTubeService
 @use_kwargs(
     {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
 )
-def youtube(request, url, **kwargs):
+def view_youtube_video(request, url, **kwargs):
     youtube_service = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:
@@ -27,7 +27,7 @@ def youtube(request, url, **kwargs):
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
 
-    _, client_config = Configuration.extract_from_params(kwargs)
+    via_config, client_config = Configuration.extract_from_params(kwargs)
 
     return {
         "client_embed_url": request.registry.settings["client_embed_url"],
@@ -38,7 +38,11 @@ def youtube(request, url, **kwargs):
         "api": {
             "transcript": {
                 "doc": "Get the transcript of the current video",
-                "url": request.route_url("api.youtube.transcript", video_id=video_id),
+                "url": request.route_url(
+                    "api.youtube.transcript",
+                    video_id=video_id,
+                    transcript_id=via_config.get("video", {}).get("lang", "en.a"),
+                ),
                 "method": "GET",
                 "headers": {
                     "Authorization": f"Bearer {ViaSecurityPolicy.encode_jwt(request)}"

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,4 +1,5 @@
 import marshmallow
+from h_matchers import Any
 from h_vialib import Configuration
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
@@ -8,6 +9,24 @@ from webargs.pyramidparser import use_kwargs
 from via.exceptions import BadURL
 from via.security import ViaSecurityPolicy
 from via.services import YouTubeService
+from via.services.youtube_api import CaptionTrack
+
+CAPTION_TRACK_PREFERENCES = (
+    # Plain English first
+    CaptionTrack(language_code="en"),
+    # Plain varieties of English
+    CaptionTrack(language_code=Any.string.matching("^en-.*")),
+    # Sub-categories of plain English
+    CaptionTrack(language_code="en", name=Any()),
+    # English varieties with names
+    CaptionTrack(language_code=Any.string.matching("^en-.*"), name=Any()),
+    # Any auto generated English
+    CaptionTrack(language_code=Any.string.matching("^en-.*"), name=Any(), kind=Any()),
+    # Any track which can be translated into English
+    CaptionTrack(
+        language_code=Any(), name=Any(), kind=Any(), translated_language_code="en"
+    ),
+)
 
 
 @view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
@@ -15,17 +34,17 @@ from via.services import YouTubeService
     {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
 )
 def view_youtube_video(request, url, **kwargs):
-    youtube_service = request.find_service(YouTubeService)
+    youtube_service: YouTubeService = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:
         raise HTTPUnauthorized()
 
     video_id = youtube_service.get_video_id(url)
-    video_url = youtube_service.canonical_video_url(video_id)
-    video_title = youtube_service.get_video_title(video_id)
-
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
+
+    video_url = youtube_service.canonical_video_url(video_id)
+    video_title = youtube_service.get_video_title(video_id)
 
     via_config, client_config = Configuration.extract_from_params(kwargs)
 
@@ -41,7 +60,9 @@ def view_youtube_video(request, url, **kwargs):
                 "url": request.route_url(
                     "api.youtube.transcript",
                     video_id=video_id,
-                    transcript_id=via_config.get("video", {}).get("lang", "en.a"),
+                    transcript_id=_get_transcript_id(
+                        youtube_service, video_url, via_config
+                    ),
                 ),
                 "method": "GET",
                 "headers": {
@@ -50,3 +71,20 @@ def view_youtube_video(request, url, **kwargs):
             }
         },
     }
+
+
+def _get_transcript_id(youtube_service, url, via_config):
+    # Try the `via.video.lang` param first
+    if transcript_id := via_config.get("video", {}).get("lang"):
+        return transcript_id
+
+    # Then look up a transcript matching our preferences
+    video = youtube_service.get_video_info(video_url=url)
+    if video.has_captions and (
+        caption_track := video.caption.find_matching_track(CAPTION_TRACK_PREFERENCES)
+    ):
+        return caption_track.id
+
+    # This shouldn't be possible to get to if this was an option, but we need a
+    # fall-back. We could also fail here instead?
+    return "en.a"

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -53,6 +53,8 @@ def view_youtube_video(request, url, **kwargs):
         ):
             transcript_id = caption_track.id
         else:
+            # This should probably be an error. This won't work. If we were
+            # going to find this transcript we would have
             transcript_id = "en.a"
 
     return {


### PR DESCRIPTION
Based on:

 * https://github.com/hypothesis/via/pull/1112
 * https://github.com/hypothesis/via/pull/1100
 * https://github.com/hypothesis/via/pull/1103

This PR:

 * Moves video data getting responsibility to the YouTube client object
 * Unifies the V1 and V3 paths
 * Simplifes the service a lot as a result

## Review notes

This isn't ready yet, we need a lot of other stuff first.

If you look at this, nearly every commit is from other branches I've picked in.