### PR TITLE
Limit video height in single column view to leave space for transcript

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -324,12 +324,11 @@ export default function VideoPlayerApp({
         <div
           data-testid="embedded-video-container"
           className={classnames(
-            'flex flex-col',
             {
               // Allow video to grow with available horizontal space in
               // multicolumn layouts (NB: It will take up full width in
               // single-column)
-              grow: multicolumn,
+              'flex flex-col grow': multicolumn,
             },
             {
               // Adapt spacing around video for different app sizes
@@ -340,13 +339,25 @@ export default function VideoPlayerApp({
             }
           )}
         >
-          <YouTubeVideoPlayer
-            videoId={videoId}
-            play={playing}
-            time={timestamp}
-            onPlayingChanged={setPlaying}
-            onTimeChanged={setTimestamp}
-          />
+          <div
+            className={classnames({
+              // Limit height of video in single-column views, to leave space
+              // for the transcript. We have to do this by restricting the
+              // width, assuming a 16:9 aspect ratio, rather than the height,
+              // because the video player uses an `AspectRatio` container that
+              // sets the height based on the width. Center the video if it
+              // doesn't fill the full width.
+              'max-w-[calc(40vh*16/9)] mx-auto': !multicolumn,
+            })}
+          >
+            <YouTubeVideoPlayer
+              videoId={videoId}
+              play={playing}
+              time={timestamp}
+              onPlayingChanged={setPlaying}
+              onTimeChanged={setTimestamp}
+            />
+          </div>
         </div>
         <div
           data-testid="transcript-and-controls-container"


### PR DESCRIPTION
In single column layouts with "short" window heights, limit the height of the video to a maximum of ~~half~~ 40% the window height, to ensure there is a good amount of space for the transcript. Since videos have a 16:9 aspect ratio, this means not using the full width and centering the video instead.

This is based on @lyzadanger's patch in https://github.com/hypothesis/via/pull/1105#issuecomment-1645814269.

Fixes https://github.com/hypothesis/via/issues/1085