### PR TITLE
Add `data-time-{start, end}` attributes to segments

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -415,7 +415,7 @@ export default function Transcript({
                   startTime={segment.start}
                   // We are currently missing an end time for the last segment
                   // because we don't know the duration of the video here.
-                  endTime={nextSegment ? nextSegment.start : undefined}
+                  endTime={nextSegment?.start}
                   text={segment.text}
                 />
               );

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -39,14 +39,39 @@ describe('Transcript', () => {
     const segments = wrapper.find('[data-testid="segment"]');
     assert.equal(segments.length, 3);
 
-    assert.equal(segments.at(0).text(), 'Hello and welcome ');
-    assert.isTrue(segments.at(0).prop('data-is-current'));
+    const renderedSegments = [];
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments.at(i);
+      const start = segment.find('p').prop('data-time-start');
+      const end = segment.find('p').prop('data-time-end');
+      renderedSegments.push({
+        text: segment.text(),
+        isCurrent: segment.prop('data-is-current'),
+        startTime: start ? parseFloat(start) : undefined,
+        endTime: end ? parseFloat(end) : undefined,
+      });
+    }
 
-    assert.equal(segments.at(1).text(), 'To this video about ');
-    assert.isFalse(segments.at(1).prop('data-is-current'));
-
-    assert.equal(segments.at(2).text(), 'how to use Hypothesis ');
-    assert.isFalse(segments.at(2).prop('data-is-current'));
+    assert.deepEqual(renderedSegments, [
+      {
+        text: 'Hello and welcome ',
+        isCurrent: true,
+        startTime: 5,
+        endTime: 10,
+      },
+      {
+        text: 'To this video about ',
+        isCurrent: false,
+        startTime: 10,
+        endTime: 20,
+      },
+      {
+        text: 'how to use Hypothesis ',
+        isCurrent: false,
+        startTime: 20,
+        endTime: undefined,
+      },
+    ]);
   });
 
   it('renders segments if none is current', () => {


### PR DESCRIPTION
This enables the Hypothesis client to capture media time selectors with annotations, and later use them when anchoring, or for other purposes.

On this branch, the `<p>` elements containing transcript text now have attributes to indicate the corresponding time range of the video. I had a look around for possible existing ARIA or schema.org metadata, but I didn't find anything that looked like an ideal fit, so these are custom attrs. See the client PR for more details.

<img width="580" alt="date-time-attrs" src="https://github.com/hypothesis/via/assets/2458/71dfcf7d-628c-4c40-b1c4-8986f38205c9">

There are a couple of caveats about the precision of timestamps and the end timestamp for the last segment. See notes in the code.

See https://github.com/hypothesis/client/pull/5655.

Part of https://github.com/hypothesis/via/issues/941