### PR TITLE
Dispatch dummy scroll event when filter changes

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -218,6 +218,12 @@ export default function VideoPlayerApp({
     pendingScrollToHighlight.current = false;
   }, [isFilterEmpty, syncTranscript]);
 
+  // Dispatch dummy scroll event when filter changes, to update bucket bar to
+  // reflect changes in visibility and position of highlights.
+  useEffect(() => {
+    document.body.dispatchEvent(new Event('scroll'));
+  }, [trimmedFilter]);
+
   // If we transition from paused to playing while autoscroll is active,
   // immediately scroll the current segment into view. Without this, the
   // transcript will not scroll until playback reaches the next segment.

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -445,6 +445,16 @@ describe('VideoPlayerApp', () => {
     assert.equal(transcript.prop('filter'), 'foobar');
   });
 
+  it('dispatches dummy scroll event when filter changes, to update bucket bar', () => {
+    const wrapper = createVideoPlayer();
+    const onScroll = sinon.stub();
+    document.body.addEventListener('scroll', onScroll, { once: true });
+
+    setFilter(wrapper, 'foobar');
+
+    assert.calledOnce(onScroll);
+  });
+
   it('clears filter when Hypothesis client scrolls to a highlight', async () => {
     const wrapper = createVideoPlayer();
     const transcriptController = wrapper.find('Transcript').prop('controlsRef');


### PR DESCRIPTION
This triggers an update of the bucket bar, so that it reflects changes to the visibility of highlights.

**Testing:**

1. Go to http://localhost:9083/https://www.youtube.com/watch?v=TbzZIMQC6vk
2. Scroll down most of the way and make an annotation
3. Scroll back up to the top and select the first segment
4. Enter a query in the filter bar which matches quite a few segments, but not the one that was annotated (I used "test")

On `main`, the bucket bar indicator for the highlight will remain visible in step 4, even if the highlight is no longer visible. On this branch the bucket bar should update whenever the filter changes.

Step (3) in the above is important because when the video is not scrolled to the top, changing the filter will often cause the content to scroll, which will in turn update the bucket bar anyway.