### PR TITLE
Use `duration` data from API to set `data-time-end` attribute for last segment

### DIFF
--- a/via/static/scripts/test-util/video-player-fixtures.ts
+++ b/via/static/scripts/test-util/video-player-fixtures.ts
@@ -28,10 +28,12 @@ export const transcriptsAPIResponse = {
         {
           text: '[Music]',
           start: 0.0,
+          duration: 7.52,
         },
         {
           text: 'how many of you remember the first time',
           start: 5.6,
+          duration: 4.72,
         },
       ],
     },

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -87,9 +87,7 @@ type TranscriptSegmentProps = {
 
   isCurrent: boolean;
   onSelect: () => void;
-  startTime: number;
-  endTime?: number;
-  text: string;
+  segment: Segment;
 };
 
 function hasSelection() {
@@ -102,9 +100,7 @@ function TranscriptSegment({
   matches,
   isCurrent,
   onSelect,
-  startTime,
-  endTime,
-  text,
+  segment,
 }: TranscriptSegmentProps) {
   const contentRef = useRef<HTMLParagraphElement>(null);
 
@@ -136,8 +132,7 @@ function TranscriptSegment({
   }, [highlight, matches]);
 
   const hadSelectionOnPointerDown = useRef(false);
-
-  const timestamp = formatTimestamp(startTime);
+  const timestamp = formatTimestamp(segment.start);
 
   return (
     <li
@@ -212,8 +207,8 @@ function TranscriptSegment({
         // by the API. We could improve this in future by rendering each
         // segment of the original transcript as a separate element within this
         // paragraph.
-        data-time-start={startTime}
-        data-time-end={endTime}
+        data-time-start={segment.start}
+        data-time-end={segment.start + segment.duration}
         ref={contentRef}
         // We have a "click" handler here, but don't set a role because
         // this is a secondary way to focus the transcript. The timestamp
@@ -230,7 +225,7 @@ function TranscriptSegment({
           }
         }}
       >
-        {text}
+        {segment.text}
         {
           // Add a trailing space at the end of each segment to avoid the last
           // word of a segment being joined with the first word of the next
@@ -396,30 +391,21 @@ export default function Transcript({
               'bg-grey-3/30'
             )}
           >
-            {transcript.segments.map((segment, index, segments) => {
-              const nextSegment =
-                index < segments.length - 1 ? segments[index + 1] : undefined;
-
-              return (
-                <TranscriptSegment
-                  key={index}
-                  hidden={
-                    filterMatches
-                      ? !filterMatches.has(index) && index !== currentIndex
-                      : false
-                  }
-                  highlight={highlight}
-                  isCurrent={index === currentIndex}
-                  matches={filterMatches?.get(index)}
-                  onSelect={() => onSelectSegment?.(segment)}
-                  startTime={segment.start}
-                  // We are currently missing an end time for the last segment
-                  // because we don't know the duration of the video here.
-                  endTime={nextSegment?.start}
-                  text={segment.text}
-                />
-              );
-            })}
+            {transcript.segments.map((segment, index) => (
+              <TranscriptSegment
+                key={index}
+                hidden={
+                  filterMatches
+                    ? !filterMatches.has(index) && index !== currentIndex
+                    : false
+                }
+                highlight={highlight}
+                isCurrent={index === currentIndex}
+                matches={filterMatches?.get(index)}
+                onSelect={() => onSelectSegment?.(segment)}
+                segment={segment}
+              />
+            ))}
           </ul>
           {children}
         </div>

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -20,7 +20,7 @@ import { callAPI } from '../utils/api';
 import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
 import type { TranscriptData } from '../utils/transcript';
-import { mergeSegments } from '../utils/transcript';
+import { clipDurations, mergeSegments } from '../utils/transcript';
 import CopyButton from './CopyButton';
 import FilterInput from './FilterInput';
 import HypothesisClient from './HypothesisClient';
@@ -143,6 +143,9 @@ export default function VideoPlayerApp({
     callAPI<JSONAPIObject<TranscriptData>>(transcriptSource)
       .then(response => {
         const transcript = response.data.attributes;
+
+        // Ensure segments do not overlap.
+        transcript.segments = clipDurations(transcript.segments);
 
         // Group segments together for better readability.
         transcript.segments = mergeSegments(transcript.segments, 3);

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -10,14 +10,17 @@ describe('Transcript', () => {
     segments: [
       {
         start: 5,
+        duration: 5,
         text: 'Hello and welcome',
       },
       {
         start: 10,
+        duration: 10,
         text: 'To this video about',
       },
       {
         start: 20,
+        duration: 4,
         text: 'how to use Hypothesis',
       },
     ],
@@ -69,7 +72,7 @@ describe('Transcript', () => {
         text: 'how to use Hypothesis ',
         isCurrent: false,
         startTime: 20,
-        endTime: undefined,
+        endTime: 24,
       },
     ]);
   });

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -9,6 +9,7 @@ import {
 } from '../../../test-util/video-player-fixtures';
 import { delay, waitForElement } from '../../../test-util/wait';
 import { APIError } from '../../utils/api';
+import { clipDurations } from '../../utils/transcript';
 import VideoPlayerApp, { $imports } from '../VideoPlayerApp';
 
 describe('VideoPlayerApp', () => {
@@ -18,10 +19,15 @@ describe('VideoPlayerApp', () => {
     segments: [
       {
         start: 0,
+        // nb. Duration is "too long" here, matching what we might get back
+        // from YouTube. It should be normalized before passing to the
+        // Transcript component.
+        duration: 10,
         text: 'Hello',
       },
       {
         start: 5,
+        duration: 7,
         text: 'World',
       },
     ],
@@ -193,10 +199,14 @@ describe('VideoPlayerApp', () => {
 
       // Transcript should be displayed when loading completes.
       const transcript = await waitForElement(wrapper, 'Transcript');
-      assert.equal(
-        transcript.prop('transcript'),
-        transcriptsAPIResponse.data.attributes
-      );
+
+      const expectedTranscript = {
+        ...transcriptsAPIResponse.data.attributes,
+        segments: clipDurations(
+          transcriptsAPIResponse.data.attributes.segments
+        ),
+      };
+      assert.deepEqual(transcript.prop('transcript'), expectedTranscript);
     });
 
     function findCopyButton(wrapper) {

--- a/via/static/scripts/video_player/utils/test/transcript-test.js
+++ b/via/static/scripts/video_player/utils/test/transcript-test.js
@@ -1,5 +1,6 @@
 import { sampleTranscript } from '../../sample-transcript';
 import {
+  clipDurations,
   filterTranscript,
   formatTranscript,
   mergeSegments,
@@ -38,9 +39,55 @@ you saw a playstation 1 game if you were
   });
 });
 
+describe('clipDurations', () => {
+  it('clips durations so that segments do not overlap', () => {
+    const segments = [
+      {
+        start: 1,
+        duration: 3,
+        text: 'One',
+      },
+      {
+        start: 4,
+        duration: 10,
+        text: 'One',
+      },
+      {
+        start: 7,
+        duration: 5,
+        text: 'One',
+      },
+    ];
+
+    const clipped = clipDurations(segments);
+
+    assert.deepEqual(clipped, [
+      {
+        start: 1,
+        duration: 3,
+        text: 'One',
+      },
+      {
+        start: 4,
+        duration: 3,
+        text: 'One',
+      },
+      {
+        start: 7,
+        duration: 5,
+        text: 'One',
+      },
+    ]);
+  });
+});
+
 describe('mergeSegments', () => {
   const captions = ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven'];
-  const segments = captions.map((text, index) => ({ start: index + 1, text }));
+  const segments = captions.map((text, index) => ({
+    start: index + 1,
+    duration: 1,
+    text,
+  }));
 
   [
     {
@@ -50,18 +97,18 @@ describe('mergeSegments', () => {
     {
       groupSize: 2,
       expected: [
-        { start: 1, text: 'One Two' },
-        { start: 3, text: 'Three Four' },
-        { start: 5, text: 'Five Six' },
-        { start: 7, text: 'Seven' },
+        { start: 1, duration: 2, text: 'One Two' },
+        { start: 3, duration: 2, text: 'Three Four' },
+        { start: 5, duration: 2, text: 'Five Six' },
+        { start: 7, duration: 1, text: 'Seven' },
       ],
     },
     {
       groupSize: 3,
       expected: [
-        { start: 1, text: 'One Two Three' },
-        { start: 4, text: 'Four Five Six' },
-        { start: 7, text: 'Seven' },
+        { start: 1, duration: 3, text: 'One Two Three' },
+        { start: 4, duration: 3, text: 'Four Five Six' },
+        { start: 7, duration: 1, text: 'Seven' },
       ],
     },
   ].forEach(({ groupSize, expected }) => {


### PR DESCRIPTION
Use the `duration` property of segments to calculate the end time, rather than the `start` time of the next segment. This allows us to compute the `data-time-end` attribute value for the last segment.

The `duration` data from YouTube can be "too long" such that segments overlap (see comments for explanation). To deal with this, add a normalization step that clips duration values received from the API. We could do this normalization on the backend. For now it is just as easy to do it on the frontend since it is the only consumer.

Part of https://github.com/hypothesis/via/issues/941

**Testing:**

1. Open a video in Via (eg. http://localhost:9083/https://www.youtube.com/watch?v=TbzZIMQC6vk)
2. Inspect several of the `data-time-start` and `data-time-end` attributes for the `<p>` elements containing segment text, including the last segment. The segments should not overlap, the `data-time-start` values should match the displayed timestamps (but represented as seconds), and `data-time-end` should be set for the last segment.