### PR TITLE
Add fallback method for highlighting filter matches

### DIFF
--- a/via/static/scripts/types/css-custom-highlights.d.ts
+++ b/via/static/scripts/types/css-custom-highlights.d.ts
@@ -10,6 +10,7 @@ declare class Highlight {
 
 interface HighlightsRegistry {
   delete(name: string): void;
+  get(name: string): Highlight | undefined;
   set(name: string, highlight: Highlight): void;
 }
 

--- a/via/static/scripts/video_player/utils/highlighter.ts
+++ b/via/static/scripts/video_player/utils/highlighter.ts
@@ -1,0 +1,154 @@
+/**
+ * Resolve one or more character offsets within an element to (text node,
+ * position) pairs.
+ *
+ * This function was copied from the Hypothesis client.
+ *
+ * @param element
+ * @param offsets - Offsets, which must be sorted in ascending order
+ * @throws {RangeError}
+ */
+export function resolveOffsets(
+  element: Element,
+  ...offsets: number[]
+): Array<{ node: Text; offset: number }> {
+  let nextOffset = offsets.shift();
+  const nodeIter = element.ownerDocument.createNodeIterator(
+    element,
+    NodeFilter.SHOW_TEXT
+  );
+  const results = [];
+
+  let currentNode = nodeIter.nextNode() as Text | null;
+  let textNode;
+  let length = 0;
+
+  // Find the text node containing the `nextOffset`th character from the start
+  // of `element`.
+  while (nextOffset !== undefined && currentNode) {
+    textNode = currentNode;
+    if (length + textNode.data.length > nextOffset) {
+      results.push({ node: textNode, offset: nextOffset - length });
+      nextOffset = offsets.shift();
+    } else {
+      currentNode = nodeIter.nextNode() as Text | null;
+      length += textNode.data.length;
+    }
+  }
+
+  // Boundary case.
+  while (nextOffset !== undefined && textNode && length === nextOffset) {
+    results.push({ node: textNode, offset: textNode.data.length });
+    nextOffset = offsets.shift();
+  }
+
+  if (nextOffset !== undefined) {
+    throw new RangeError('Offset exceeds text length');
+  }
+
+  return results;
+}
+
+/**
+ * Highlight spans of text content within elements.
+ *
+ * This uses CSS Custom Highlights if supported or falls back to wrapping text
+ * in `<mark>` elements otherwise.
+ *
+ * NOTE: If using this with an element rendered by Preact, the element's content
+ * should either be a single immutable text child, or it should be managed
+ * manually, to avoid Preact's re-rendering conflicting with DOM modifications
+ * from the highlighter.
+ */
+export class TextHighlighter {
+  public highlight?: Highlight;
+  private name: string;
+  private _ranges: Map<HTMLElement, Range[]>;
+
+  /**
+   * @param name -
+   *   Name of the highlight to register in {@link CSS.highlights}. This is
+   *   referenced when styling the highlight via `::highlight(<name>)`
+   *   selectors. For browsers that don't support CSS Custom Highlights, this
+   *   is used as a class name on the `<mark>` elements.
+   */
+  constructor(name: string) {
+    this.name = name;
+    this._ranges = new Map();
+
+    if (CSS.highlights) {
+      let highlight = CSS.highlights.get(name);
+      if (!highlight) {
+        highlight = new Highlight();
+        CSS.highlights.set(name, highlight);
+      }
+      this.highlight = highlight;
+    }
+  }
+
+  /** Remove all highlights created by this highlighter. */
+  dispose() {
+    for (const element of this._ranges.keys()) {
+      this.removeHighlights(element);
+    }
+  }
+
+  /**
+   * Highlight spans of text within `element`.
+   */
+  highlightSpans(
+    element: HTMLElement,
+    spans: Array<{ start: number; end: number }>
+  ) {
+    let ranges = this._ranges.get(element);
+    if (!ranges) {
+      ranges = [];
+      this._ranges.set(element, ranges);
+    }
+
+    for (const { start, end } of spans) {
+      try {
+        const [startPoint, endPoint] = resolveOffsets(element, start, end);
+        const range = new Range();
+        range.setStart(startPoint.node, startPoint.offset);
+        range.setEnd(endPoint.node, endPoint.offset);
+        ranges.push(range);
+
+        if (this.highlight) {
+          this.highlight.add(range);
+        } else {
+          // Fall back to `<mark>` elements. This is probably more expensive
+          // since it involves DOM modifications.
+          const highlightEl = document.createElement('mark');
+          highlightEl.className = this.name;
+          range.surroundContents(highlightEl);
+        }
+      } catch {
+        // If we can't find the span to highlight, we just silently skip it.
+      }
+    }
+  }
+
+  /**
+   * Remove all highlights that this highlighter has created in `element`.
+   */
+  removeHighlights(element: HTMLElement) {
+    const ranges = this._ranges.get(element);
+    if (!ranges) {
+      return;
+    }
+    if (this.highlight) {
+      for (const range of ranges) {
+        this.highlight.delete(range);
+      }
+    } else {
+      const marks = Array.from(element.querySelectorAll('mark'));
+      for (const mark of marks) {
+        mark.replaceWith(mark.textContent!);
+      }
+      // Join adjacent text nodes.
+      element.normalize();
+    }
+    ranges.splice(ranges.length);
+  }
+}

--- a/via/static/scripts/video_player/utils/test/highlighter-test.js
+++ b/via/static/scripts/video_player/utils/test/highlighter-test.js
@@ -1,0 +1,106 @@
+import { TextHighlighter } from '../highlighter';
+
+describe('TextHighlighter', () => {
+  const highlightName = 'test-highlight';
+
+  let highlighters;
+
+  let container;
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.innerHTML = 'Foo <b>bar</b> baz';
+    highlighters = [];
+  });
+
+  afterEach(() => {
+    highlighters.forEach(h => h.dispose());
+  });
+
+  function createHighlighter() {
+    const highlighter = new TextHighlighter(highlightName);
+    highlighters.push(highlighter);
+    return highlighter;
+  }
+
+  if (CSS.highlights) {
+    context('when CSS highlights are supported', () => {
+      describe('#highlightSpans', () => {
+        it('adds ranges to CSS highlight', () => {
+          const highlighter = createHighlighter();
+          highlighter.highlightSpans(container, [
+            { start: 0, end: 3 },
+            { start: 8, end: 11 },
+            { start: 20, end: 25 }, // Invalid offset
+          ]);
+          const highlight = CSS.highlights.get(highlightName);
+          const ranges = [...highlight.keys()];
+          assert.equal(ranges.length, 2);
+          assert.equal(ranges[0].toString(), 'Foo');
+          assert.equal(ranges[1].toString(), 'baz');
+        });
+      });
+
+      describe('#removeHighlights', () => {
+        it('removes ranges from CSS highlight', () => {
+          const highlighter = createHighlighter();
+          highlighter.highlightSpans(container, [
+            { start: 0, end: 3 },
+            { start: 8, end: 11 },
+          ]);
+          const highlight = CSS.highlights.get(highlightName);
+          assert.equal(highlight.size, 2);
+
+          highlighter.removeHighlights(container);
+
+          assert.equal(highlight.size, 0);
+        });
+
+        it('does nothing if there are no highlights for the element', () => {
+          const highlighter = createHighlighter();
+          highlighter.removeHighlights(container);
+        });
+      });
+    });
+  }
+
+  context('when CSS highlights are not supported', () => {
+    let highlightsStub;
+    beforeEach(() => {
+      highlightsStub = sinon.stub(CSS, 'highlights').get(() => null);
+    });
+
+    afterEach(() => {
+      highlightsStub.restore();
+    });
+
+    describe('#highlightSpans', () => {
+      it('wraps spans in `<mark>` elements', () => {
+        const highlighter = createHighlighter();
+        highlighter.highlightSpans(container, [
+          { start: 0, end: 3 },
+          { start: 8, end: 11 },
+        ]);
+        assert.equal(
+          container.innerHTML,
+          `<mark class="${highlightName}">Foo</mark> <b>bar</b> <mark class="${highlightName}">baz</mark>`
+        );
+      });
+    });
+
+    describe('#removeHighlights', () => {
+      it('removes `<mark>` elements', () => {
+        const originalContent = container.innerHTML;
+
+        const highlighter = createHighlighter();
+        highlighter.highlightSpans(container, [
+          { start: 0, end: 3 },
+          { start: 8, end: 11 },
+        ]);
+        assert.notEqual(container.innerHTML, originalContent);
+
+        highlighter.removeHighlights(container);
+        assert.equal(container.innerHTML, originalContent);
+      });
+    });
+  });
+});

--- a/via/static/styles/video_player.css
+++ b/via/static/styles/video_player.css
@@ -26,3 +26,7 @@ CSS entry point for the video player app.
 p::highlight(transcript-filter-match) {
   text-decoration: underline;
 }
+mark.transcript-filter-match {
+  background: none; /* remove default `<mark>` styling */
+  text-decoration: underline;
+}


### PR DESCRIPTION
Add a fallback method for highlighting filter matches in browsers that don't support CSS custom highlights. This involves wrapping matches in `<mark>` elements, similar to how the Hypothesis client inserts highlights. We continue to use CSS custom highlights where available, since it has the potential to be faster due to not modifying the DOM tree.

In the process an issue was fixed where filter matches would not be highlighted if they occurred after highlights inserted by the Hypothesis client.

Fixes https://github.com/hypothesis/via/issues/1122
Fixes https://github.com/hypothesis/via/issues/1075

----

**Testing:**

1. Load a video in Via
2. Type in the search bar. You should see matches for the filter underlined in the text
3. Repeat (2) in Chrome, Firefox and Safari. The result should look the same in each browser.
4. Highlight part of a segment and try searching for matches that occur after the Hypothesis highlight. Matches should be underlined whether they occur before, within or after Hypothesis highlights.