### PR TITLE
Memo the transcript segment list and segment contents

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -16,6 +16,7 @@ import {
 
 import { useAppLayout } from '../hooks/use-app-layout';
 import { useSideBySideLayout } from '../hooks/use-side-by-side-layout';
+import { useStableCallback } from '../hooks/use-stable-callback';
 import { callAPI } from '../utils/api';
 import type { APIMethod, APIError, JSONAPIObject } from '../utils/api';
 import { useNextRender } from '../utils/next-render';
@@ -271,8 +272,7 @@ export default function VideoPlayerApp({
   }, [syncTranscript]);
 
   const bucketContainerId = 'bucket-container';
-  const prevSideBySideActive = useRef(sideBySideActive);
-  prevSideBySideActive.current = sideBySideActive;
+  const isActive = useStableCallback(() => sideBySideActive);
   const clientConfig = useMemo(() => {
     return {
       ...baseClientConfig,
@@ -280,12 +280,10 @@ export default function VideoPlayerApp({
       contentReady,
       sideBySide: {
         mode: 'manual',
-        // Using a ref here to make sure the `isActive` callback reference is
-        // kept, and only its return value changes
-        isActive: () => prevSideBySideActive.current,
+        isActive,
       },
     };
-  }, [baseClientConfig, contentReady]);
+  }, [baseClientConfig, contentReady, isActive]);
 
   return (
     <div

--- a/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
@@ -1,6 +1,7 @@
 import { AspectRatio } from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
+import { useStableCallback } from '../hooks/use-stable-callback';
 import { loadYouTubeIFrameAPI } from '../utils/youtube';
 
 /**
@@ -104,13 +105,10 @@ export default function YouTubeVideoPlayer({
 
   const playerController = useRef<YT.Player>();
 
-  // Capture last-seen values of props so we can invoke callbacks without
-  // re-running effects when they change.
-  const onPlayingChangedCallback = useRef<(playing: boolean) => void>();
-  onPlayingChangedCallback.current = onPlayingChanged;
-
-  const onTimeChangedCallback = useRef<(timestamp: number) => void>();
-  onTimeChangedCallback.current = onTimeChanged;
+  // Wrap callbacks to avoid re-running effects when they change.
+  const noop = () => {};
+  const onPlayingChangedCallback = useStableCallback(onPlayingChanged ?? noop);
+  const onTimeChangedCallback = useStableCallback(onTimeChanged ?? noop);
 
   const videoFrame = useRef(null);
 
@@ -126,20 +124,18 @@ export default function YouTubeVideoPlayer({
               playerController.current = player;
 
               // Report initial state when the video loads.
-              onPlayingChangedCallback.current?.(
-                isPlaying(player.getPlayerState())
-              );
+              onPlayingChangedCallback(isPlaying(player.getPlayerState()));
             },
 
             onStateChange: event => {
               if (event.data === PlayerState.UNSTARTED) {
                 return;
               }
-              onPlayingChangedCallback.current?.(isPlaying(event.data));
+              onPlayingChangedCallback(isPlaying(event.data));
             },
 
             onVideoProgress: event => {
-              onTimeChangedCallback.current?.(event.data);
+              onTimeChangedCallback(event.data);
             },
           } as PlayerEvents,
         });
@@ -148,7 +144,7 @@ export default function YouTubeVideoPlayer({
         console.error('Error loading video:', err);
         setLoadError(err);
       });
-  }, []);
+  }, [onPlayingChangedCallback, onTimeChangedCallback]);
 
   // Play/pause video when `play` prop changes.
   useEffect(() => {

--- a/via/static/scripts/video_player/hooks/test/use-stable-callback-test.js
+++ b/via/static/scripts/video_player/hooks/test/use-stable-callback-test.js
@@ -1,0 +1,39 @@
+// These tests use Preact directly, rather than via Enzyme, to simplify debugging.
+import { render } from 'preact';
+
+import { useStableCallback } from '../use-stable-callback';
+
+describe('useStableCallback', () => {
+  let container;
+  let stableCallbackValues;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    stableCallbackValues = [];
+  });
+
+  function Widget({ callback }) {
+    const stableCallback = useStableCallback(callback);
+    stableCallbackValues.push(stableCallback);
+    return <button onClick={stableCallback}>Test</button>;
+  }
+
+  it('returns a wrapper with a stable identity', () => {
+    render(<Widget callback={() => {}} />, container);
+    render(<Widget callback={() => {}} />, container);
+
+    assert.equal(stableCallbackValues.length, 2);
+    assert.equal(stableCallbackValues[0], stableCallbackValues[1]);
+  });
+
+  it('returned wrapper forwards to the latest callback', () => {
+    const stub = sinon.stub();
+    render(<Widget callback={() => {}} />, container);
+    render(<Widget callback={stub} />, container);
+
+    assert.equal(stableCallbackValues.length, 2);
+    stableCallbackValues.at(-1)('foo', 'bar', 'baz');
+
+    assert.calledWith(stub, 'foo', 'bar', 'baz');
+  });
+});

--- a/via/static/scripts/video_player/hooks/use-stable-callback.ts
+++ b/via/static/scripts/video_player/hooks/use-stable-callback.ts
@@ -1,0 +1,23 @@
+import { useRef } from 'preact/hooks';
+
+/**
+ * Return a function which wraps a callback to give it a stable value.
+ *
+ * The wrapper has a stable value across renders, but always forwards to the
+ * callback from the most recent render. This is useful if you want to use a
+ * callback inside a `useEffect` or `useMemo` hook without re-running the effect
+ * or re-computing the memoed value when the callback changes.
+ */
+export function useStableCallback<R, A extends any[], F extends (...a: A) => R>(
+  callback: F
+): F {
+  const wrapper = useRef({
+    callback,
+    call: (...args: A) => wrapper.current.callback(...args),
+  });
+
+  // On each render, save the last callback value.
+  wrapper.current.callback = callback;
+
+  return wrapper.current.call as F;
+}


### PR DESCRIPTION
Reduce re-rendering of the segment list and individual segments with `useMemo` and `useStableCallback`.

This improves responsiveness when typing in the filter bar in very long videos in Chrome (see https://github.com/hypothesis/via/issues/1029 for example video). In Safari and Firefox the improvements here still apply, but are overshadowed by the much slower fallback highlighting process in `TextHighlighter`, which needs to be improved separately.

Use the option to [ignore whitespace changes](https://github.com/hypothesis/via/pull/1130/files?diff=unified&w=1) in the diff when reviewing this.

Part of https://github.com/hypothesis/via/issues/1029.