### PR TITLE
Center "X" button using top + translate in filter input

### DIFF
--- a/via/static/scripts/video_player/components/FilterInput.tsx
+++ b/via/static/scripts/video_player/components/FilterInput.tsx
@@ -41,7 +41,9 @@ export default function FilterInput({
           data-testid="clear-filter-button"
           title="Clear filter"
           onClick={() => setFilter('')}
-          classes="absolute right-0 top-[1px]"
+          // Center button vertically within input. Note the button size will be
+          // larger on touch devices.
+          classes="absolute right-0 top-[50%] translate-y-[-50%]"
         />
       )}
     </div>


### PR DESCRIPTION
`IconButton`s change their size depending on whether mouse vs touch input is being used. Change the positioning of the "X" button so that it remains centered in both cases.

Fixes https://github.com/hypothesis/via/issues/1124