### PR TITLE
Fix Alembic auto-generation

### DIFF
--- a/via/migrations/env.py
+++ b/via/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from via import models
 from via.db import Base
 
 # this is the Alembic Config object, which provides


### PR DESCRIPTION
You need to import `via.models` in `env.py` so that Alembic migration
auto-generation works.
