### PR TITLE
Add `AutoincrementingIntegerIDMixin`

### DIFF
--- a/via/models/_mixins.py
+++ b/via/models/_mixins.py
@@ -4,6 +4,12 @@ from sqlalchemy import func
 from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 
+class AutoincrementingIntegerIDMixin(MappedAsDataclass):
+    id: Mapped[int] = mapped_column(
+        init=False, primary_key=True, autoincrement=True, sort_order=-100
+    )
+
+
 class CreatedUpdatedMixin(MappedAsDataclass):
     created: Mapped[datetime] = mapped_column(
         init=False,

--- a/via/models/transcript.py
+++ b/via/models/transcript.py
@@ -3,14 +3,13 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from via.db import Base
-from via.models._mixins import CreatedUpdatedMixin
+from via.models._mixins import AutoincrementingIntegerIDMixin, CreatedUpdatedMixin
 
 
-class Transcript(CreatedUpdatedMixin, Base):
+class Transcript(AutoincrementingIntegerIDMixin, CreatedUpdatedMixin, Base):
     __tablename__ = "transcript"
     __table_args__ = (UniqueConstraint("video_id", "transcript_id"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True, init=False)
     video_id: Mapped[str]
     transcript_id: Mapped[str]
     transcript: Mapped[list] = mapped_column(JSONB, repr=False)


### PR DESCRIPTION
And fix the `id` column to come before the `created` and `updated`
columns in the SQL.

This mixin can be reused by other classes and plays well with the
existing `CreatedUpdateMixin` in terms of column order.
