### PR TITLE
Add Via's source code to `PYTHONPATH` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ COPY ./conf/nginx/includes /etc/nginx/includes
 COPY ./conf/nginx/envsubst.conf.template /var/lib/hypothesis/nginx_envsubst.conf.template
 COPY . .
 
+ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
+
 USER hypothesis
 
 CMD /usr/bin/envsubst '$${NGINX_SECURE_LINK_SECRET}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf


### PR DESCRIPTION
Running DB migrations in Via is currently broken in Docker:

https://hypothes-is.slack.com/archives/C1MA4E9B9/p1690888278906619

(`via/migrations/env.py` does `from via.db import Base` which crashes
with `ModuleNotFoundError: No module named 'via'`.)

Looking at our other apps that have DBs they all add the directory
containing the app's source code to `PYTHONPATH` in their
`Dockerfile`'s, whereas Via doesn't. This seems likely to be the issue.

1. Setting `PYTHONPATH` in LMS's `Dockerfile`:

   https://github.com/hypothesis/lms/blob/22e9a4a78d70cd82e1ad252ead26833a21fb8cc6/Dockerfile#L42

   (Unlike most of our other apps LMS uses `/var/lib/lms` to contain the
   app's source code rather than `/var/lib/hypothesis`.)

2. Setting `PYTHONPATH` in Checkmate's `Dockerfile`:

   https://github.com/hypothesis/checkmate/blob/c818bcb2ec740d317dbabfccb17f0543cf9f1473/Dockerfile#L26C1-L26C47

3. Setting `PYTHONPATH` in h's `Dockerfile`:

   https://github.com/hypothesis/h/blob/dd2737f24ad7731ae3991714bc179b9e70af1783/Dockerfile#L64
