### PR TITLE
Add trailing slash to `COPY` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20.2.0-alpine as frontend-build
 
 ENV NODE_ENV production
 RUN mkdir -p /tmp/frontend-build
-COPY .babelrc rollup.config.mjs gulpfile.mjs package.json tailwind.config.mjs .yarnrc.yml yarn.lock /tmp/frontend-build
+COPY .babelrc rollup.config.mjs gulpfile.mjs package.json tailwind.config.mjs .yarnrc.yml yarn.lock /tmp/frontend-build/
 COPY .yarn /tmp/frontend-build/.yarn
 COPY via/static /tmp/frontend-build/via/static
 


### PR DESCRIPTION
A [CI build](https://github.com/hypothesis/via/actions/runs/5736907824/job/15547533761) of the prod Docker image failed with:

```
When using COPY with more than one source file, the destination must be a directory and end with a /
```

I didn't experience this locally. I'm guessing this is due to differing Docker versions.