### PR TITLE
Return the first transcript we find, instead of searching only for "en"

### DIFF
--- a/tests/factories/transcript.py
+++ b/tests/factories/transcript.py
@@ -10,20 +10,6 @@ class TranscriptFactory(SQLAlchemyModelFactory):
 
     video_id = Sequence(lambda n: f"video_id_{n}")
     transcript_id = Sequence(lambda n: f"transcript_id_{n}")
-    transcript = [
-        {
-            "text": "[Music]",
-            "start": 0.0,
-            "duration": 7.52,
-        },
-        {
-            "text": "how many of you remember the first time",
-            "start": 5.6,
-            "duration": 4.72,
-        },
-        {
-            "text": "you saw a playstation 1 game if you were",
-            "start": 7.52,
-            "duration": 4.72,
-        },
-    ]
+    transcript = Sequence(
+        lambda n: [{"text": "[Music]", "start": float(n), "duration": float(n + 1)}]
+    )


### PR DESCRIPTION
This paves the way for storing non "en" transcripts in the DB, should we find them. This includes automatically generated, other English dialects like "en-gb" and named English transcripts.

## Testing notes

 * `make service dev`
 * Visit: http://localhost:9083/https://www.youtube.com/watch?v=hzjX4Eldh84