### PR TITLE
Return the oldest transcript matching the video ID

### DIFF
--- a/tests/factories/transcript.py
+++ b/tests/factories/transcript.py
@@ -10,20 +10,17 @@ class TranscriptFactory(SQLAlchemyModelFactory):
 
     video_id = Sequence(lambda n: f"video_id_{n}")
     transcript_id = Sequence(lambda n: f"transcript_id_{n}")
-    transcript = [
-        {
-            "text": "[Music]",
-            "start": 0.0,
-            "duration": 7.52,
-        },
-        {
-            "text": "how many of you remember the first time",
-            "start": 5.6,
-            "duration": 4.72,
-        },
-        {
-            "text": "you saw a playstation 1 game if you were",
-            "start": 7.52,
-            "duration": 4.72,
-        },
-    ]
+    transcript = Sequence(
+        lambda n: [
+            {
+                "text": f"This is the first line of transcript {n}",
+                "start": 0.0,
+                "duration": 7.52,
+            },
+            {
+                "text": f"This is the second line of transcript {n}",
+                "start": 5.6,
+                "duration": 4.72,
+            },
+        ]
+    )


### PR DESCRIPTION
Just return the oldest saved transcript in the DB that matches the given `video_id`, instead of also searching for the hard-coded `transcript_id` value of `"en"`.

This is a slightly simplified rewrite of https://github.com/hypothesis/via/pull/1159.

`YouTubeService.get_transcript()` currently always saves transcripts in the DB with `transcript.transcript_id="en"` (hard-coded) and it always queries the DB for a transcript with `transcript.video_id=video_id` and `transcript.transcript_id="en"`.

In https://github.com/hypothesis/via/pull/1162 we're going to start saving transcripts in the DB with different `transcript_id`'s (we're going to be generating unique transcript IDs that work even when a video has multiple transcripts with the same language code) so we can no longer always query for a hard-coded `transcript.transcript_id="en"`.

Instead, this PR changes `get_transcript()` to query for `transcript.video_id=video_id` only and then, since there could be more than one saved transcript with the same `video_id`, it just returns the oldest saved transcript.

This should work, and it'll also mean that the default transcripts of previously-annotated videos and assignments don't change when we change the default transcript selection algorithm.

What we should _really_ do here (probably) is persist the choice of default transcript by adding a nullable `video.default_transcript` column to the `video` table (foreign key to the `transcript` table). But for the sake of expedience this will do for now. We can always back-fill a `video.default_transcript` column in future by finding the oldest saved transcript for each `video_id`.