### PR TITLE
Remove `youtube-transcript-api` from requirements

### DIFF
--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -13,4 +13,3 @@ whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
-youtube-transcript-api

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -232,7 +232,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -311,8 +310,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -222,7 +222,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -300,8 +299,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -349,7 +349,6 @@ requests==2.31.0
     #   -r requirements/tests.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/functests.txt
@@ -464,10 +463,6 @@ wired==0.3
     #   pyramid-services
 wrapt==1.12.1
     # via astroid
-youtube-transcript-api==0.6.1
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
 zipp==3.4.1
     # via
     #   -r requirements/functests.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -21,4 +21,3 @@ whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
-youtube-transcript-api

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -129,7 +129,6 @@ requests==2.31.0
     #   -r requirements/prod.in
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via google-auth-oauthlib
 rsa==4.7.2
@@ -174,8 +173,6 @@ whitenoise==6.5.0
     # via -r requirements/prod.in
 wired==0.3
     # via pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.in
 zipp==3.4.1
     # via
     #   importlib-metadata

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -226,7 +226,6 @@ requests==2.31.0
     #   -r requirements/prod.txt
     #   checkmatelib
     #   requests-oauthlib
-    #   youtube-transcript-api
 requests-oauthlib==1.3.0
     # via
     #   -r requirements/prod.txt
@@ -298,8 +297,6 @@ wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
-youtube-transcript-api==0.6.1
-    # via -r requirements/prod.txt
 zipp==3.4.1
     # via
     #   -r requirements/prod.txt


### PR DESCRIPTION
It's no longer needed as of https://github.com/hypothesis/via/pull/1162.
