### PR TITLE
Remove SQLALCHEMY_SILENCE_UBER_WARNING now that we are in SQLA 2.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ setenv =
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
     tests,functests: PYTEST_PLUGINS = tests.pytest_plugins.factory_boy
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
-    SQLALCHEMY_SILENCE_UBER_WARNING=1
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:4433/postgres}
     tests: DATABASE_URL = {env:UNITTESTS_DATABASE_URL:postgresql://postgres@localhost:4433/via_tests}
     functests: DATABASE_URL = {env:FUNCTESTS_DATABASE_URL:postgresql://postgres@localhost:4433/via_functests}


### PR DESCRIPTION
Background on https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-e67bfa1efbe52ae40aa842124bc40c51


`
This deprecation warning intends to notify users who may not have set an appropriate constraint in their requirements files to block against a surprise SQLAlchemy 2.0 upgrade and also alert that the SQLAlchemy 2.0 upgrade process is available, as the first full 2.0 release is expected very soon. The deprecation warning can be silenced by setting the environment variable SQLALCHEMY_SILENCE_UBER_WARNING to "1".
`