### PR TITLE
Make ToastMessage transitions generic and customizable by consumers

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -466,6 +466,10 @@ export default function VideoPlayerApp({
               <ToastMessages
                 messages={toastMessages}
                 onMessageDismiss={dismissToastMessage}
+                transitionClasses={{
+                  transitionIn:
+                    'lg:motion-safe:animate-slide-in-from-right animate-fade-in motion-reduce:animate-fade-in',
+                }}
               />
             </div>
             {isLoading && (

--- a/via/static/scripts/video_player/components/test/ToastMessages-test.js
+++ b/via/static/scripts/video_player/components/test/ToastMessages-test.js
@@ -123,29 +123,7 @@ describe('ToastMessages', () => {
     assert.equal(fakeOnMessageDismiss.callCount, 1);
   });
 
-  ['slide-in-from-right', 'fade-in', 'fade-out'].forEach(animationName => {
-    it('invokes onTransitionEnd when supported animation is dispatched', () => {
-      const wrapper = createToastMessages(toastMessages, callback =>
-        callback()
-      );
-      const animationContainer = wrapper
-        .find('[data-testid="animation-container"]')
-        .first();
-
-      // Trigger "in" animation for all messages, which will schedule dismiss
-      toastMessages.forEach((_, index) => {
-        triggerAnimationEnd(wrapper, index, 'in');
-      });
-
-      animationContainer
-        .getDOMNode()
-        .dispatchEvent(new AnimationEvent('animationend', { animationName }));
-
-      assert.called(fakeOnMessageDismiss);
-    });
-  });
-
-  it('does not invoke onTransitionEnd for irrelevant animations', () => {
+  it('invokes onTransitionEnd when animation happens on container', () => {
     const wrapper = createToastMessages(toastMessages, callback => callback());
     const animationContainer = wrapper
       .find('[data-testid="animation-container"]')
@@ -158,9 +136,23 @@ describe('ToastMessages', () => {
 
     animationContainer
       .getDOMNode()
-      .dispatchEvent(
-        new AnimationEvent('animationend', { animationName: 'invalid' })
-      );
+      .dispatchEvent(new AnimationEvent('animationend'));
+
+    assert.called(fakeOnMessageDismiss);
+  });
+
+  it('does not invoke onTransitionEnd for animation events bubbling from children', () => {
+    const wrapper = createToastMessages(toastMessages, callback => callback());
+    const invalidAnimationContainer = wrapper.find('Callout').first();
+
+    // Trigger "in" animation for all messages, which will schedule dismiss
+    toastMessages.forEach((_, index) => {
+      triggerAnimationEnd(wrapper, index, 'in');
+    });
+
+    invalidAnimationContainer
+      .getDOMNode()
+      .dispatchEvent(new AnimationEvent('animationend', { bubbles: true }));
 
     assert.notCalled(fakeOnMessageDismiss);
   });


### PR DESCRIPTION
As mentioned in https://github.com/hypothesis/client/pull/5691#issuecomment-1709581938, this PR makes `ToastMessages` use `animate-fade-in` and `animate-fade-out` as its only default transition classes, decoupling it from consumers' needs.

It also adds a new `transitionClasses` optional prop that can be used to override those animation classes with custom values. 

```ts
export type ToastMessageTransitionClasses = {
  /** Classes to apply to a toast message when appended. Defaults to 'animate-fade-in' */
  transitionIn?: string;
  /** Classes to apply to a toast message being dismissed. Defaults to 'animate-fade-out' */
  transitionOut?: string;
};
```

This makes the `ToastMessages` component generic enough to move it to frontend-shared and use it in other apps.

> This PR is part of https://github.com/hypothesis/frontend-shared/issues/1075