### PR TITLE
Speed up Via's unit tests by running them in parallel

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -34,6 +34,7 @@
     "__docker_network": "via_default",
     "__github_url": "https://github.com/hypothesis/via",
     "__hdev_project_type": "application",
-    "__copyright_year": "2016"
+    "__copyright_year": "2016",
+    "__parallel_unit_tests": true
   }
 }

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -7,3 +7,4 @@ factory-boy
 pytest-factoryboy
 h-matchers
 webtest
+filelock

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -51,6 +51,8 @@ factory-boy==3.3.0
     #   pytest-factoryboy
 faker==18.9.0
     # via factory-boy
+filelock==3.12.4
+    # via -r requirements/functests.in
 google-auth==2.16.0
     # via
     #   -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -75,6 +75,10 @@ exceptiongroup==1.0.0rc9
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
+execnet==2.0.2
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-xdist
 factory-boy==3.3.0
     # via
     #   -r requirements/functests.txt
@@ -85,6 +89,10 @@ faker==18.9.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   factory-boy
+filelock==3.12.4
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 freezegun==1.2.2
     # via -r requirements/tests.txt
 google-auth==2.16.0
@@ -252,6 +260,10 @@ pluggy==0.13.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
+psutil==5.9.5
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-xdist
 psycopg2==2.9.6
     # via
     #   -r requirements/functests.txt
@@ -330,6 +342,7 @@ pytest==7.4.0
     #   -r requirements/tests.txt
     #   pytest-cov
     #   pytest-factoryboy
+    #   pytest-xdist
 pytest-cov==4.1.0
     # via
     #   -r requirements/tests.txt
@@ -344,6 +357,8 @@ pytest-factoryboy==2.5.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+pytest-xdist[psutil]==3.3.1
+    # via -r requirements/tests.txt
 python-dateutil==2.8.2
     # via
     #   -r requirements/functests.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -3,6 +3,8 @@ pip-sync-faster
 -r prod.txt
 pytest
 pytest-coverage
+pytest-xdist[psutil]
+filelock
 factory-boy
 pytest-factoryboy
 h-matchers

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -45,12 +45,16 @@ ecdsa==0.18.0
     #   python-jose
 exceptiongroup==1.0.0rc9
     # via pytest
+execnet==2.0.2
+    # via pytest-xdist
 factory-boy==3.3.0
     # via
     #   -r requirements/tests.in
     #   pytest-factoryboy
 faker==18.9.0
     # via factory-boy
+filelock==3.12.4
+    # via -r requirements/tests.in
 freezegun==1.2.2
     # via -r requirements/tests.in
 google-auth==2.16.0
@@ -162,6 +166,8 @@ plaster-pastedeploy==0.7
     #   pyramid
 pluggy==0.13.1
     # via pytest
+psutil==5.9.5
+    # via pytest-xdist
 psycopg2==2.9.6
     # via -r requirements/prod.txt
 pyasn1==0.4.8
@@ -213,6 +219,7 @@ pytest==7.4.0
     #   -r requirements/tests.in
     #   pytest-cov
     #   pytest-factoryboy
+    #   pytest-xdist
 pytest-cov==4.1.0
     # via pytest-cover
 pytest-cover==3.0.0
@@ -220,6 +227,8 @@ pytest-cover==3.0.0
 pytest-coverage==0.0
     # via -r requirements/tests.in
 pytest-factoryboy==2.5.1
+    # via -r requirements/tests.in
+pytest-xdist[psutil]==3.3.1
     # via -r requirements/tests.in
 python-dateutil==2.8.2
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle via tests bin
     lint: pycodestyle via tests bin
-    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
+    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: coverage combine
     coverage: coverage report


### PR DESCRIPTION
This makes `make test` a couple of seconds faster and as more tests are added over time the advantage will increase. It should make CI a bit faster, more if we add more cores to Via's CI as we have for LMS.

But this actually makes `make sure` a few seconds slower on my machine because `tox` is already running formatting, lint, tests, functests and coverage in parallel jobs and then `pytest-xdist` is also starting one test process per core, you end up with competition for cores.