### PR TITLE
Speed up Via's functests by running them in parallel

### DIFF
--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -3,6 +3,7 @@ pip-sync-faster
 -r prod.txt
 httpretty
 pytest
+pytest-xdist[psutil]
 factory-boy
 pytest-factoryboy
 h-matchers

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -45,6 +45,8 @@ ecdsa==0.18.0
     #   python-jose
 exceptiongroup==1.0.0rc9
     # via pytest
+execnet==2.0.2
+    # via pytest-xdist
 factory-boy==3.3.0
     # via
     #   -r requirements/functests.in
@@ -162,6 +164,8 @@ plaster-pastedeploy==0.7
     #   pyramid
 pluggy==0.13.1
     # via pytest
+psutil==5.9.5
+    # via pytest-xdist
 psycopg2==2.9.6
     # via -r requirements/prod.txt
 pyasn1==0.4.8
@@ -212,7 +216,10 @@ pytest==7.4.0
     # via
     #   -r requirements/functests.in
     #   pytest-factoryboy
+    #   pytest-xdist
 pytest-factoryboy==2.5.1
+    # via -r requirements/functests.in
+pytest-xdist[psutil]==3.3.1
     # via -r requirements/functests.in
 python-dateutil==2.8.2
     # via faker

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
     lint: pydocstyle via tests bin
     lint: pycodestyle via tests bin
     tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
-    functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
+    functests: python -m pytest --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: coverage combine
     coverage: coverage report
     template: python3 bin/make_template {posargs}


### PR DESCRIPTION
Support for this would have to be added to the cookiecutter.

Other apps like LMS and h can't run the functests in parallel without some work to fix how the functests DB session works. Via's DB stuff was added more recently and I did the unit and functests DB sessions in a simpler and better way, so it's easy to run the functests in parallel as well.

Via doesn't have enough functional tests to benefit from this: it actually makes Via's `make functests` slower on my machine.