### PR TITLE
Reorganise Via's Gunicorn config

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -34,6 +34,7 @@
     "__docker_network": "via_default",
     "__github_url": "https://github.com/hypothesis/via",
     "__hdev_project_type": "application",
-    "__copyright_year": "2016"
+    "__copyright_year": "2016",
+    "__gunicorn_bind": "unix:/tmp/gunicorn-web.sock"
   }
 }

--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -5,7 +5,7 @@
       "startsecs": "0"
     },
     "web": {
-      "command": "gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini"
+      "command": "newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py"
     },
     "nginx": {
       "command": "docker compose run --rm --service-ports nginx-proxy",

--- a/.cookiecutter/includes/conf/supervisord.conf.json
+++ b/.cookiecutter/includes/conf/supervisord.conf.json
@@ -4,7 +4,7 @@
       "command": "nginx"
     },
     "web": {
-      "command": "newrelic-admin run-program gunicorn --paste conf/production.ini -b unix:/tmp/gunicorn-web.sock"
+      "command": "newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py"
     }
   }
 }

--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -1,0 +1,4 @@
+bind = "0.0.0.0:9082"
+reload = True
+reload_extra_files = "via/templates"
+timeout = 0

--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -1,0 +1,2 @@
+bind = "unix:/tmp/gunicorn-web.sock"
+worker_tmp_dir = "/dev/shm"

--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -1,6 +1,0 @@
-# Configuration settings for Gunicorn in dev
-
-workers = 4
-reload = True
-bind = "0.0.0.0:9082"
-timeout = 0

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -11,7 +11,7 @@ stopasgroup=true
 startsecs=0
 
 [program:web]
-command=gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini
+command=newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal=KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=NONE
 stderr_logfile=NONE
 
 [program:web]
-command=newrelic-admin run-program gunicorn --paste conf/production.ini -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stdout_logfile=NONE


### PR DESCRIPTION
This reorganise's Via's Gunicorn config files following the same pattern
as was recently done in h:

hypothesis/h#8407

I'm applying this simpler and more explicit Gunicorn config approach to
all our apps consistently. For motivation see:

https://docs.google.com/document/d/13AnUPtu9AO3PfRm-fhH7_3RZzyLGSFd4uPv36dIeynA

Benefits:

* Gunicorn config files are explicitly mentioned in the `gunicorn`
  commands in the `supervisord[-dev].conf` files. This makes things less
  confusing/surprising, less likely that a Gunicorn config file will be
  missed (compared to Gunicorn's default behavior if you run it without
  a `--config` argument: it reads any `gunicorn.conf.py` file in the
  current working directory).

* The Gunicorn config files are in the `conf/` directory with the other
  config files. Again: makes it less likely that a config file will go
  unnoticed.

* Separate production and development Gunicorn config files. This is
  consistent with our separate production and development Pyramid config
  files, and is probably a good idea to prevent development settings
  accidentally getting applied in production. (Gunicorn's default
  behavior of reading a root `gunicorn.conf.py` file would mean that
  file gets read in both dev and production).
