### PR TITLE
Replace usage of deprecated CGI module

### DIFF
--- a/tests/unit/via/services/url_details_test.py
+++ b/tests/unit/via/services/url_details_test.py
@@ -94,7 +94,7 @@ class TestGetURLDetails:
         result = svc.get_url_details(sentinel.youtube_url)
 
         youtube_service.get_video_id.assert_not_called()
-        assert result == ("dummy", 200)
+        assert result == ("application/x-testing", 200)
 
     def test_it_when_url_blocked_by_checkmate(self, checkmate_service, svc):
         checkmate_service.raise_if_blocked.side_effect = BadURL("Bad URL")
@@ -112,7 +112,7 @@ class TestGetURLDetails:
     def response(self, http_service):
         response = Response()
         response.raw = BytesIO(b"")
-        response.headers = {"Content-Type": "dummy"}
+        response.headers = {"Content-Type": "application/x-testing"}
         response.status_code = 200
         http_service.get.return_value = response
 

--- a/via/services/url_details.py
+++ b/via/services/url_details.py
@@ -1,6 +1,6 @@
 """Retrieve details about a resource at a URL."""
-import cgi
 from collections import OrderedDict
+from email.message import Message
 
 from via.requests_tools.headers import add_request_headers, clean_headers
 from via.services.checkmate import CheckmateService
@@ -50,7 +50,9 @@ class URLDetailsService:
         ) as rsp:
             content_type = rsp.headers.get("Content-Type")
             if content_type:
-                mime_type, _ = cgi.parse_header(content_type)
+                message = Message()
+                message["content-type"] = content_type
+                mime_type = message.get_content_type()
             else:
                 mime_type = None
 


### PR DESCRIPTION
Only used to parse MIMETYPES, replaced by email.Messsage

https://peps.python.org/pep-0594/#cgi