### PR TITLE
Add missing allow attribute in proxy iframe

### DIFF
--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -157,7 +157,7 @@
   </script>
 </head>
   <body>
-    <iframe class="js-content-frame proxied-content-iframe" src={{ src }}></iframe>
+    <iframe class="js-content-frame proxied-content-iframe" allow="clipboard-write" src={{ src }}></iframe>
 
     {# Loading indicator.
 
@@ -166,33 +166,34 @@
        display the tab in a loading state until the iframe has finished loading.
     #}
     <div class="js-loading-indicator loading-bar">
-    <script>
-      /**
-       * Show the loading indicator after a short delay. The delay avoids showing
-       * the "loading started" state if the content loads very quickly, although
-       * the loading bar will still briefly fade in and out.
-       */
-      function showLoadingIndicator() {
-        const loadingIndicator = document.querySelector('.js-loading-indicator');
-        setTimeout(() => loadingIndicator.classList.add('is-loading'), 500);
-      }
-
-      /**
-       * Copy the fragment from the top frame's URL to the iframe's URL.
-       *
-       * This is needed so that direct links to annotations, which use a
-       * `#annotations:` fragment, are respected by the client in the iframe.
-       */
-      function copyFragmentToFrame() {
-        const fragment = location.hash;
-        if (fragment) {
-          const iframe = document.querySelector('.js-content-frame');
-          iframe.src += fragment;
+      <script>
+        /**
+         * Show the loading indicator after a short delay. The delay avoids showing
+         * the "loading started" state if the content loads very quickly, although
+         * the loading bar will still briefly fade in and out.
+         */
+        function showLoadingIndicator() {
+          const loadingIndicator = document.querySelector('.js-loading-indicator');
+          setTimeout(() => loadingIndicator.classList.add('is-loading'), 500);
         }
-      }
 
-      showLoadingIndicator();
-      copyFragmentToFrame();
-    </script>
+        /**
+         * Copy the fragment from the top frame's URL to the iframe's URL.
+         *
+         * This is needed so that direct links to annotations, which use a
+         * `#annotations:` fragment, are respected by the client in the iframe.
+         */
+        function copyFragmentToFrame() {
+          const fragment = location.hash;
+          if (fragment) {
+            const iframe = document.querySelector('.js-content-frame');
+            iframe.src += fragment;
+          }
+        }
+
+        showLoadingIndicator();
+        copyFragmentToFrame();
+      </script>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Adding `allow="clipboard-write"` to the iframe used when proxying pages, so that the "Copy to clipboard" button works when exporting annotations from the sidebar, if loaded document was proxied.

It already works for PDFs and the YouTube video app.

I took the opportunity to add a missing closing tag, so this PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/via/pull/1271/files?w=1)