### PR TITLE
Make sentry-sdk a direct requirement

### DIFF
--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -1,5 +1,6 @@
 checkmatelib
 h-assets
+sentry-sdk
 h-pyramid-sentry
 h-vialib
 importlib_resources

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -8,6 +8,7 @@ pyramid-tm
 zope.sqlalchemy
 checkmatelib
 h-assets
+sentry-sdk
 h-pyramid-sentry
 h-vialib
 importlib_resources

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -144,7 +144,9 @@ rsa==4.9
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.2
-    # via h-pyramid-sentry
+    # via
+    #   -r requirements/prod.in
+    #   h-pyramid-sentry
 six==1.16.0
     # via ecdsa
 sqlalchemy==2.0.25


### PR DESCRIPTION
So Dependabot keeps it up to date.
