### PR TITLE
Notify screen readers when transcript is filtered

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -67,6 +67,12 @@ export type TranscriptProps = {
   filter?: string;
 
   /**
+   * Invoked when the filter is applied to the transcript segments, with the
+   * amount that matched and the filter itself
+   */
+  onFilterMatch?: (filter: string, results: number) => void;
+
+  /**
    * Callback invoked when the user selects a segment from the transcript.
    */
   onSelectSegment?: (segment: Segment) => void;
@@ -270,6 +276,7 @@ export default function Transcript({
   controlsRef,
   currentTime,
   filter = '',
+  onFilterMatch,
   onSelectSegment,
   transcript,
 }: TranscriptProps) {
@@ -360,6 +367,12 @@ export default function Transcript({
     }
     return filterTranscript(transcript.segments, filter);
   }, [filter, transcript]);
+
+  useEffect(() => {
+    if (filterMatches) {
+      onFilterMatch?.(filter, filterMatches.size);
+    }
+  }, [filter, filterMatches, onFilterMatch]);
 
   // Adjust the scroll position when the transcript container is resized, so the
   // user doesn't lose their place. See

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -289,6 +289,15 @@ export default function VideoPlayerApp({
 
   const { toastMessages, appendToastMessage, dismissToastMessage } =
     useToastMessages();
+  const onFilterMatch = useCallback(
+    (filter: string, results: number) =>
+      appendToastMessage({
+        type: 'success',
+        message: `"${filter}" returned ${results} results`,
+        visuallyHidden: true,
+      }),
+    [appendToastMessage]
+  );
 
   return (
     <div
@@ -484,6 +493,7 @@ export default function VideoPlayerApp({
                 controlsRef={transcriptControls}
                 currentTime={timestamp}
                 filter={trimmedFilter}
+                onFilterMatch={onFilterMatch}
                 onSelectSegment={segment => {
                   // Clear the filter before jumping to a segment, so the user
                   // can easily read the text that comes before and after it.

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -349,4 +349,17 @@ describe('Transcript', () => {
     assert.calledOnce(fakeTextHighlighter.removeHighlights);
     assert.calledWith(fakeTextHighlighter.removeHighlights, element);
   });
+
+  [
+    { filter: 'video', expectedMatches: 1 },
+    { filter: 'to', expectedMatches: 2 },
+    { filter: 'no match', expectedMatches: 0 },
+  ].forEach(({ filter, expectedMatches }) => {
+    it('notifies when segments are filtered', () => {
+      const onFilterMatch = sinon.stub();
+      createTranscript({ filter, onFilterMatch });
+
+      assert.calledWith(onFilterMatch, filter, expectedMatches);
+    });
+  });
 });


### PR DESCRIPTION
Closes #1274 

This PR ensures a hidden toast message is appended when filtering the transcript via search term, making screen readers announce the amount of results.

The way this has been implemented is not 100% correct regarding to https://react.dev/learn/you-might-not-need-an-effect, since it adds a side effect to `Transcript` based on some internal state.

The more correct solution would probably imply appending the toast message as part of the `onChange` event handler for the `FilterInput` (I think it would fall under this case https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes), however, at that point we don't know how many segments matched the search term, hence the proposed solution here.

I evaluated other approaches as well, like wrapping `FilterInput` into a component which calculates `filterMatches` and appends the toast message as part of `FilterInput`'s `setFilter` callback, and make that a piece of state that is handled by `VideoPlayerApp` and passed down to `Transcript`. This would mean the raw `filter` is no longer exposed beyond that wrapper component, but it doesn't seem to be needed anyway.

This would require more changes, though.

EDIT: Another argument in favor of going in a different direction is that, if `onFilterMatch` is not properly memoized, you get infinite toast messages appended, which is very unintuitive.

### Testing steps

1. Run a screen reader
2. Try filtering the transcript.
3. The screen reader should announce a message in the lines of `"foo" returned 5 results` every time the search term changes to more than 2 characters.