### PR TITLE
Add aria-live region for transcript search results

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -422,6 +422,18 @@ export default function Transcript({
           {segments}
           {children}
         </div>
+        <div
+          className="sr-only"
+          aria-live="polite"
+          role="status"
+          data-testid="search-status"
+        >
+          {filterMatches && filter && (
+            <>
+              {filter} returned {filterMatches.size} results
+            </>
+          )}
+        </div>
       </Scroll>
     </ScrollContainer>
   );

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -349,4 +349,17 @@ describe('Transcript', () => {
     assert.calledOnce(fakeTextHighlighter.removeHighlights);
     assert.calledWith(fakeTextHighlighter.removeHighlights, element);
   });
+
+  [
+    { filter: 'video', expectedStatus: 'video returned 1 results' },
+    { filter: 'to', expectedStatus: 'to returned 2 results' },
+    { filter: 'no match', expectedStatus: 'no match returned 0 results' },
+  ].forEach(({ filter, expectedStatus }) => {
+    it('shows search status with amount of matching results', () => {
+      const wrapper = createTranscript({ filter });
+      const status = wrapper.find('[data-testid="search-status"]');
+
+      assert.equal(status.text(), expectedStatus);
+    });
+  });
 });


### PR DESCRIPTION
Closes https://github.com/hypothesis/via/issues/1274

This PR creates a new `aria-live="polite"` region to announce transcript search results to screen readers.

There should be no visual changes, as the region is for screen readers only (via `sr-only` class).

### Testing steps

1. Check out this branch and go to http://localhost:9083/https://www.youtube.com/watch?v=EU6TDnV5osM 
2. Run a screen reader
3. Try filtering the transcript.
4. The screen reader should announce a message in the lines of `foo returned 5 results` every time the search term changes to more than 2 characters.
5. Writing more characters should not announce a message per character, but only one at the end.