### PR TITLE
Implement video transcript annotation using HTML `<video>` and WebVTT

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -13,17 +13,17 @@ importlib-metadata==7.0.1
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/build.in
+    # via -r build.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/build.in
+    #   -r build.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via build
 wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0
-    # via -r requirements/build.in
+    # via -r build.in
 zipp==3.17.0
     # via importlib-metadata
 

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -5,7 +5,7 @@
 #    pip-compile --allow-unsafe requirements/checkformatting.in
 #
 black==24.1.1
-    # via -r requirements/checkformatting.in
+    # via -r checkformatting.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
@@ -15,7 +15,7 @@ click==8.1.7
 importlib-metadata==7.0.1
     # via pip-sync-faster
 isort==5.13.2
-    # via -r requirements/checkformatting.in
+    # via -r checkformatting.in
 mypy-extensions==1.0.0
     # via black
 packaging==23.2
@@ -25,10 +25,10 @@ packaging==23.2
 pathspec==0.12.1
     # via black
 pip-sync-faster==0.0.3
-    # via -r requirements/checkformatting.in
+    # via -r checkformatting.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/checkformatting.in
+    #   -r checkformatting.in
     #   pip-sync-faster
 platformdirs==4.1.0
     # via black

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -9,18 +9,16 @@ build==1.0.3
 click==8.1.7
     # via pip-tools
 coverage[toml]==7.4.1
-    # via
-    #   -r requirements/coverage.in
-    #   coverage
+    # via -r coverage.in
 importlib-metadata==7.0.1
     # via pip-sync-faster
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/coverage.in
+    # via -r coverage.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/coverage.in
+    #   -r coverage.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -42,6 +42,10 @@ cryptography==42.0.4
     #   python-jose
 decorator==5.1.1
     # via ipython
+docopt==0.6.2
+    # via
+    #   -r prod.txt
+    #   webvtt-py
 ecdsa==0.18.0
     # via
     #   -r prod.txt
@@ -298,6 +302,8 @@ webob==1.8.7
     #   -r prod.txt
     #   h-vialib
     #   pyramid
+webvtt-py==0.4.6
+    # via -r prod.txt
 wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -5,7 +5,7 @@
 #    pip-compile --allow-unsafe requirements/format.in
 #
 black==24.1.1
-    # via -r requirements/format.in
+    # via -r format.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
@@ -15,7 +15,7 @@ click==8.1.7
 importlib-metadata==7.0.1
     # via pip-sync-faster
 isort==5.13.2
-    # via -r requirements/format.in
+    # via -r format.in
 mypy-extensions==1.0.0
     # via black
 packaging==23.2
@@ -25,10 +25,10 @@ packaging==23.2
 pathspec==0.12.1
     # via black
 pip-sync-faster==0.0.3
-    # via -r requirements/format.in
+    # via -r format.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/format.in
+    #   -r format.in
     #   pip-sync-faster
 platformdirs==4.1.0
     # via black

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -40,6 +40,10 @@ cryptography==42.0.4
     # via
     #   -r prod.txt
     #   python-jose
+docopt==0.6.2
+    # via
+    #   -r prod.txt
+    #   webvtt-py
 ecdsa==0.18.0
     # via
     #   -r prod.txt
@@ -291,6 +295,8 @@ webob==1.8.7
     #   webtest
 webtest==3.0.0
     # via -r functests.in
+webvtt-py==0.4.6
+    # via -r prod.txt
 wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -67,6 +67,11 @@ cryptography==42.0.4
     #   python-jose
 dill==0.3.7
     # via pylint
+docopt==0.6.2
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
+    #   webvtt-py
 ecdsa==0.18.0
     # via
     #   -r functests.txt
@@ -445,6 +450,10 @@ webob==1.8.7
     #   webtest
 webtest==3.0.0
     # via -r functests.txt
+webvtt-py==0.4.6
+    # via
+    #   -r functests.txt
+    #   -r tests.txt
 wheel==0.42.0
     # via
     #   -r functests.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -22,3 +22,4 @@ whitenoise
 google-auth-oauthlib
 marshmallow
 webargs
+webvtt-py

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -24,6 +24,8 @@ checkmatelib==1.0.15
     # via -r prod.in
 cryptography==42.0.4
     # via python-jose
+docopt==0.6.2
+    # via webvtt-py
 ecdsa==0.18.0
     # via python-jose
 google-auth==2.26.2
@@ -176,6 +178,8 @@ webob==1.8.7
     # via
     #   h-vialib
     #   pyramid
+webvtt-py==0.4.6
+    # via -r prod.in
 whitenoise==6.6.0
     # via -r prod.in
 wired==0.3

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -21,7 +21,7 @@ click==8.1.7
     #   cookiecutter
     #   pip-tools
 cookiecutter==2.5.0
-    # via -r requirements/template.in
+    # via -r template.in
 idna==3.6
     # via requests
 importlib-metadata==7.0.1
@@ -37,10 +37,10 @@ mdurl==0.1.2
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/template.in
+    # via -r template.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/template.in
+    #   -r template.in
     #   pip-sync-faster
 pygments==2.17.2
     # via rich

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -42,6 +42,10 @@ cryptography==42.0.4
     # via
     #   -r prod.txt
     #   python-jose
+docopt==0.6.2
+    # via
+    #   -r prod.txt
+    #   webvtt-py
 ecdsa==0.18.0
     # via
     #   -r prod.txt
@@ -293,6 +297,8 @@ webob==1.8.7
     #   -r prod.txt
     #   h-vialib
     #   pyramid
+webvtt-py==0.4.6
+    # via -r prod.txt
 wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0

--- a/requirements/updatepdfjs.txt
+++ b/requirements/updatepdfjs.txt
@@ -11,14 +11,14 @@ click==8.1.7
 importlib-metadata==7.0.1
     # via pip-sync-faster
 importlib-resources==6.1.1
-    # via -r requirements/updatepdfjs.in
+    # via -r updatepdfjs.in
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/updatepdfjs.in
+    # via -r updatepdfjs.in
 pip-tools==7.3.0
     # via
-    #   -r requirements/updatepdfjs.in
+    #   -r updatepdfjs.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via build

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -8,6 +8,7 @@ from via.services import (
     HTTPService,
     PDFURLBuilder,
     SecureLinkService,
+    TranscriptService,
     URLDetailsService,
     ViaClientService,
     YouTubeService,
@@ -59,6 +60,11 @@ def http_service(mock_service):
 @pytest.fixture
 def pdf_url_builder_service(mock_service):
     return mock_service(PDFURLBuilder)
+
+
+@pytest.fixture
+def transcript_service(mock_service):
+    return mock_service(TranscriptService)
 
 
 @pytest.fixture

--- a/tests/unit/via/services/transcript_test.py
+++ b/tests/unit/via/services/transcript_test.py
@@ -1,0 +1,74 @@
+from io import BytesIO
+from unittest.mock import create_autospec
+
+import pytest
+from requests.models import Response
+
+from via.services.http import HTTPService
+from via.services.transcript import TranscriptService, factory
+
+
+def make_response(status: int, text: str) -> Response:
+    rsp = Response()
+    rsp.status_code = status
+    rsp.raw = BytesIO(text.encode("utf-8"))
+    return rsp
+
+
+EXAMPLE_WEBVTT = """WEBVTT
+
+00:11.000 --> 00:13.000
+<v Roger Bingham>We are in New York City
+
+00:13.000 --> 00:16.000
+<v Roger Bingham>We're actually at the Lucern Hotel, just down the street
+"""
+
+EXAMPLE_SRT = """
+1
+00:00:11,000 --> 00:00:13,000
+We are in New York City
+
+2
+00:00:13,000 --> 00:00:16,000
+We're actually at the Lucern Hotel, just down the street
+"""
+
+EXAMPLE_TRANSCRIPT = [
+    {"start": 11.0, "duration": 2.0, "text": "We are in New York City"},
+    {
+        "start": 13.0,
+        "duration": 3.0,
+        "text": "We're actually at the Lucern Hotel, just down the street",
+    },
+]
+
+
+class TestTranscriptService:
+
+    @pytest.mark.parametrize(
+        "url,content,expected",
+        [
+            ("https://example.com/transcript.vtt", EXAMPLE_WEBVTT, EXAMPLE_TRANSCRIPT),
+            ("https://example.com/transcript.srt", EXAMPLE_SRT, EXAMPLE_TRANSCRIPT),
+        ],
+    )
+    def test_get_transcript(self, svc, http_service, url, content, expected):
+        http_service.get.return_value = make_response(200, content)
+        transcript = svc.get_transcript(url)
+
+        http_service.get.assert_called_with(url)
+        assert transcript == expected
+
+    @pytest.fixture
+    def svc(self, http_service):
+        return TranscriptService(http_service=http_service)
+
+    @pytest.fixture
+    def http_service(self):
+        return create_autospec(HTTPService, spec_set=True, instance=True)
+
+
+@pytest.mark.usefixtures("http_service")
+def test_factory(pyramid_request):
+    factory({}, pyramid_request)

--- a/tests/unit/via/views/api/transcript_test.py
+++ b/tests/unit/via/views/api/transcript_test.py
@@ -1,0 +1,22 @@
+from via.views.api.transcript import get_transcript
+
+# Ignore false positive with `use_kwargs`.
+# pylint: disable=no-value-for-parameter
+
+
+class TestGetTranscript:
+    def test_it(self, pyramid_request, transcript_service):
+        url = "https://example.com/transcript.vtt"
+        pyramid_request.params["url"] = url
+
+        response = get_transcript(pyramid_request)
+
+        transcript_service.get_transcript.assert_called_once_with(url)
+        assert response == {
+            "data": {
+                "type": "transcripts",
+                "attributes": {
+                    "segments": transcript_service.get_transcript.return_value
+                },
+            }
+        }

--- a/via/services/__init__.py
+++ b/via/services/__init__.py
@@ -10,6 +10,7 @@ from via.services.google_drive import GoogleDriveAPI
 from via.services.http import HTTPService
 from via.services.pdf_url import PDFURLBuilder
 from via.services.secure_link import SecureLinkService, has_secure_url_token
+from via.services.transcript import TranscriptService
 from via.services.url_details import URLDetailsService
 from via.services.via_client import ViaClientService
 from via.services.youtube import YouTubeService
@@ -35,6 +36,10 @@ def includeme(config):  # pragma: no cover
     config.register_service_factory("via.services.http.factory", iface=HTTPService)
 
     config.register_service_factory("via.services.pdf_url.factory", iface=PDFURLBuilder)
+
+    config.register_service_factory(
+        "via.services.transcript.factory", iface=TranscriptService
+    )
 
     config.register_service_factory(
         "via.services.youtube.factory", iface=YouTubeService

--- a/via/services/transcript.py
+++ b/via/services/transcript.py
@@ -1,0 +1,49 @@
+from io import StringIO
+
+from webvtt import WebVTT
+from webvtt.parsers import SRTParser
+
+from via.services.http import HTTPService
+
+
+class TranscriptService:
+    """Fetch transcripts in WebVTT or SRT formats."""
+
+    def __init__(self, http_service: HTTPService):
+        self._http_service = http_service
+
+    def get_transcript(self, url: str):
+        """Fetch a transcript and return it in JSON format."""
+
+        transcript = self._get_vtt(url)
+        segments = []
+
+        for caption in transcript:
+            start = caption.start_in_seconds
+            end = caption.end_in_seconds
+            segments.append(
+                {"start": start, "duration": end - start, "text": caption.text}
+            )
+
+        return segments
+
+    def _get_vtt(self, url: str) -> WebVTT:
+        response = self._http_service.get(url)
+        content = response.text.strip()
+        content_buf = StringIO(content)
+
+        # See https://www.w3.org/TR/webvtt1/#file-structure
+        if content.startswith("WEBVTT"):
+            return WebVTT.read_buffer(content_buf)
+
+        # If video is not WebVTT, assume SRT.
+
+        # `WebVTT.read_buffer` only supports WebVTT format, and
+        # `WebVTT.from_srt` only supports file paths. We have to use the
+        # underlying parser directly to import SRT from a buffer.
+        parser = SRTParser().read_from_buffer(content_buf)
+        return WebVTT(captions=parser.captions)
+
+
+def factory(_context, request):
+    return TranscriptService(http_service=request.find_service(HTTPService))

--- a/via/static/scripts/video_player/components/HTMLVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/HTMLVideoPlayer.tsx
@@ -1,0 +1,128 @@
+import { AspectRatio } from '@hypothesis/frontend-shared';
+import { useEffect, useRef } from 'preact/hooks';
+
+import type { TranscriptData } from '../utils/transcript';
+import { transcriptToCues } from '../utils/transcript';
+
+/**
+ * Common props for different video player components.
+ */
+export type VideoPlayerProps = {
+  /**
+   * Whether the video is playing or paused.
+   *
+   * Note that even if this is set to `true` when the component is mounted, the
+   * browser may prevent automatic playback of the video until the user has
+   * interacted with the page.
+   */
+  play?: boolean;
+
+  /**
+   * Current play time of the video, expressed as a number of seconds since
+   * the start.
+   */
+  time?: number;
+
+  /**
+   * Callback invoked at a regular interval (eg. 1 second) when the timestamp
+   * of the video changes.
+   */
+  onTimeChanged?: (timestamp: number) => void;
+
+  /**
+   * Callback invoked when the playing/paused state of the video changes.
+   */
+  onPlayingChanged?: (playing: boolean) => void;
+};
+
+export type HTMLVideoPlayerProps = VideoPlayerProps & {
+  /**
+   * URL for video. Must be in a format supported by the browser's
+   * `<video>` element.
+   */
+  videoURL: string;
+
+  /**
+   * Transcript for video.
+   *
+   * This is used to generate a caption `<track>` for the video.
+   */
+  transcript?: TranscriptData;
+};
+
+/**
+ * Video player built on the browser's native `<video>` element.
+ */
+export default function HTMLVideoPlayer({
+  videoURL,
+  transcript,
+  play = false,
+  time,
+  onTimeChanged,
+  onPlayingChanged,
+}: HTMLVideoPlayerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Play/pause video when `play` prop changes.
+  useEffect(() => {
+    const video = videoRef.current!;
+    if (play) {
+      video.play();
+    } else {
+      video.pause();
+    }
+  }, [play]);
+
+  // Seek video when `time` prop is out of sync with current play time by
+  // more than some threshold.
+  useEffect(() => {
+    if (time === undefined) {
+      return;
+    }
+
+    const video = videoRef.current!;
+    const delta = Math.abs(video.currentTime - time);
+    if (delta < 1.0) {
+      return;
+    }
+    video.currentTime = time;
+  }, [time]);
+
+  // Populate caption track for the video.
+  const trackRef = useRef<HTMLTrackElement>(null);
+  useEffect(() => {
+    const trackEl = trackRef.current;
+    if (!trackEl || !transcript) {
+      return () => {};
+    }
+
+    const cues = transcriptToCues(transcript);
+    for (const cue of cues) {
+      trackEl.track.addCue(cue);
+    }
+
+    return () => {
+      for (const cue of cues) {
+        trackEl.track.removeCue(cue);
+      }
+    };
+  }, [transcript]);
+
+  return (
+    <AspectRatio>
+      <video
+        ref={videoRef}
+        controls
+        src={videoURL}
+        onTimeUpdate={event => {
+          const video = event.target as HTMLVideoElement;
+          onTimeChanged?.(video.currentTime);
+        }}
+        onPlay={() => onPlayingChanged?.(true)}
+        onPause={() => onPlayingChanged?.(false)}
+      >
+        <track default kind="captions" ref={trackRef} />
+      </video>
+    </AspectRatio>
+  );
+}

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -26,6 +26,7 @@ import type { TranscriptData } from '../utils/transcript';
 import { clipDurations, mergeSegments } from '../utils/transcript';
 import CopyButton from './CopyButton';
 import FilterInput from './FilterInput';
+import HTMLVideoPlayer from './HTMLVideoPlayer';
 import HypothesisClient from './HypothesisClient';
 import Transcript from './Transcript';
 import type { TranscriptControls } from './Transcript';
@@ -35,13 +36,19 @@ import { DownIcon, PauseIcon, PlayIcon, SyncIcon, UpIcon } from './icons';
 
 export type VideoPlayerAppProps = {
   /** ID of the YouTube video to load. */
-  videoId: string;
+  videoId?: string;
+
+  /** URL of the video to load in a `<video>` element. */
+  videoURL?: string;
 
   /** URL of the boot script for the Hypothesis client. */
   clientSrc: string;
 
   /** JSON-serializable configuration for the Hypothesis client. */
   clientConfig: object;
+
+  /** Media player to use. */
+  player: 'youtube' | 'html-video';
 
   /**
    * The data source for the transcript. Either an API to call when the player
@@ -93,8 +100,10 @@ function isTranscript(value: any): value is TranscriptData {
  */
 export default function VideoPlayerApp({
   videoId,
+  videoURL,
   clientSrc,
   clientConfig: baseClientConfig,
+  player,
   transcriptSource,
 }: VideoPlayerAppProps) {
   // Current play time of the video, in seconds since the start.
@@ -362,13 +371,25 @@ export default function VideoPlayerApp({
               'max-w-[calc(40vh*16/9)] mx-auto': !multicolumn,
             })}
           >
-            <YouTubeVideoPlayer
-              videoId={videoId}
-              play={playing}
-              time={timestamp}
-              onPlayingChanged={setPlaying}
-              onTimeChanged={setTimestamp}
-            />
+            {player === 'youtube' && (
+              <YouTubeVideoPlayer
+                videoId={videoId!}
+                play={playing}
+                time={timestamp}
+                onPlayingChanged={setPlaying}
+                onTimeChanged={setTimestamp}
+              />
+            )}
+            {player === 'html-video' && (
+              <HTMLVideoPlayer
+                videoURL={videoURL!}
+                transcript={isTranscript(transcript) ? transcript : undefined}
+                play={playing}
+                time={timestamp}
+                onPlayingChanged={setPlaying}
+                onTimeChanged={setTimestamp}
+              />
+            )}
           </div>
         </div>
         <div

--- a/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/YouTubeVideoPlayer.tsx
@@ -2,6 +2,7 @@ import { AspectRatio, useStableCallback } from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import { loadYouTubeIFrameAPI } from '../utils/youtube';
+import type { VideoPlayerProps } from './HTMLVideoPlayer';
 
 /**
  * Playback state values.
@@ -21,35 +22,9 @@ export const PlayerState = {
   CUED: 4,
 };
 
-export type YouTubeVideoPlayerProps = {
+export type YouTubeVideoPlayerProps = VideoPlayerProps & {
   /** ID of the YouTube video to load. */
   videoId: string;
-
-  /**
-   * Whether the video is playing or paused.
-   *
-   * Note that even if this is set to `true` when the component is mounted, the
-   * browser may prevent automatic playback of the video until the user has
-   * interacted with the page.
-   */
-  play?: boolean;
-
-  /**
-   * Current play time of the video, expressed as a number of seconds since
-   * the start.
-   */
-  time?: number;
-
-  /**
-   * Callback invoked at a regular interval (eg. 1 second) when the timestamp
-   * of the video changes.
-   */
-  onTimeChanged?: (timestamp: number) => void;
-
-  /**
-   * Callback invoked when the playing/paused state of the video changes.
-   */
-  onPlayingChanged?: (playing: boolean) => void;
 };
 
 function isPlaying(state: YT.PlayerState) {

--- a/via/static/scripts/video_player/components/test/HTMLVideoPlayer-test.js
+++ b/via/static/scripts/video_player/components/test/HTMLVideoPlayer-test.js
@@ -1,0 +1,108 @@
+import { mount } from 'enzyme';
+
+import HTMLVideoPlayer from '../HTMLVideoPlayer';
+
+describe('HTMLVideoPlayer', () => {
+  let players;
+
+  const createPlayer = (props = {}) => {
+    const player = mount(<HTMLVideoPlayer {...props} />);
+    players.push(player);
+    return player;
+  };
+
+  beforeEach(() => {
+    players = [];
+  });
+
+  afterEach(() => {
+    players.forEach(player => player.unmount());
+  });
+
+  it('should render video', () => {
+    const wrapper = createPlayer({ videoURL: 'test-video.mp4' });
+    const video = wrapper.find('video');
+    assert.equal(video.prop('src'), 'test-video.mp4');
+
+    const videoEl = video.getDOMNode();
+
+    // We stub, rather than spy on, `play` here because the real method will
+    // trigger an async error if the user has not interacted with the document.
+    const playStub = sinon.stub(videoEl, 'play');
+    const pauseStub = sinon.stub(videoEl, 'pause');
+
+    wrapper.setProps({ play: true });
+    assert.calledOnce(playStub);
+
+    wrapper.setProps({ play: false });
+    assert.calledOnce(pauseStub);
+  });
+
+  it('should invoke callback when video is paused/un-paused', () => {
+    const onPlayingChanged = sinon.stub();
+    const wrapper = createPlayer({
+      videoURL: 'test-video.mp4',
+      onPlayingChanged,
+    });
+    const video = wrapper.find('video').getDOMNode();
+
+    video.dispatchEvent(new Event('play'));
+    assert.calledWith(onPlayingChanged, true);
+
+    video.dispatchEvent(new Event('pause'));
+    assert.calledWith(onPlayingChanged, false);
+  });
+
+  it('should invoke callback when video time changes', () => {
+    const onTimeChanged = sinon.stub();
+    const wrapper = createPlayer({ videoURL: 'test-video.mp4', onTimeChanged });
+    const video = wrapper.find('video').getDOMNode();
+
+    video.dispatchEvent(new Event('timeupdate'));
+    assert.calledWith(onTimeChanged, video.currentTime);
+  });
+
+  it('should seek video if `time` prop is out of sync with `currentTime`', () => {
+    const wrapper = createPlayer({ videoURL: 'test-video.mp4', time: 0 });
+    const video = wrapper.find('video').getDOMNode();
+
+    const currentTimeSpy = sinon.spy(video, 'currentTime', ['set']);
+    wrapper.setProps({ time: 5 });
+
+    assert.calledWith(currentTimeSpy.set, 5);
+  });
+
+  it('should populate caption track', () => {
+    const transcript = {
+      segments: [
+        {
+          start: 1,
+          duration: 3,
+          text: 'One',
+        },
+        {
+          start: 4,
+          duration: 3,
+          text: 'Two',
+        },
+        {
+          start: 7,
+          duration: 3,
+          text: 'Three',
+        },
+      ],
+    };
+
+    const wrapper = createPlayer({ videoURL: 'test-video.mp4', transcript });
+    const video = wrapper.find('video').getDOMNode();
+    assert.equal(video.textTracks.length, 1);
+
+    const track = video.textTracks[0];
+
+    // The `cues` property returns `null` unless the mode is set, although the
+    // browser may still show the track.
+    track.mode = 'showing';
+
+    assert.equal(track.cues.length, 3);
+  });
+});

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -82,6 +82,7 @@ describe('VideoPlayerApp', () => {
         videoId="1234"
         clientSrc="https://dummy.hypothes.is/embed.js"
         clientConfig={{}}
+        player="youtube"
         // By default start with the transcript already loaded, instead of
         // using the API to fetch it.
         transcriptSource={transcriptData}
@@ -300,6 +301,22 @@ describe('VideoPlayerApp', () => {
       const errorDisplay = await waitForElement(wrapper, 'TranscriptError');
 
       assert.equal(errorDisplay.prop('error'), error);
+    });
+  });
+
+  [
+    {
+      player: 'youtube',
+      component: 'YouTubeVideoPlayer',
+    },
+    {
+      player: 'html-video',
+      component: 'HTMLVideoPlayer',
+    },
+  ].forEach(({ player, component }) => {
+    it('renders player component that matches `player` prop', () => {
+      const wrapper = createVideoPlayer({ player });
+      assert.isTrue(wrapper.exists(component));
     });
   });
 
@@ -584,6 +601,7 @@ describe('VideoPlayerApp', () => {
           videoId="1234"
           clientSrc="https://dummy.hypothes.is/embed.js"
           clientConfig={{}}
+          player="youtube"
           transcriptSource={transcriptData}
         />,
         { attachTo: document.body }

--- a/via/static/scripts/video_player/config.ts
+++ b/via/static/scripts/video_player/config.ts
@@ -7,13 +7,19 @@ export type APIIndex = {
 
 export type ConfigObject = {
   /** ID of the YouTube video to load. */
-  video_id: string;
+  video_id?: string;
 
   /** Configuration for the Hypothesis client. */
   client_config: object;
 
   /** URL of the Hypothesis client to load. */
   client_src: string;
+
+  /** Frontend player to use. */
+  player: 'youtube' | 'html-video';
+
+  /** URL for use with an HTML `<video>` element. */
+  video_src?: string;
 
   /** API index. */
   api: APIIndex;

--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -16,7 +16,9 @@ export function init() {
     api,
     client_config: clientConfig,
     client_src: clientSrc,
+    player,
     video_id: videoId,
+    video_src: videoURL,
   } = readConfig();
 
   // When content is displayed in an iframe, notify top-level of title and
@@ -42,8 +44,10 @@ export function init() {
   render(
     <VideoPlayerApp
       videoId={videoId}
+      videoURL={videoURL}
       clientConfig={clientConfig}
       clientSrc={clientSrc}
+      player={player}
       transcriptSource={api.transcript}
     />,
     rootEl

--- a/via/static/scripts/video_player/utils/test/transcript-test.js
+++ b/via/static/scripts/video_player/utils/test/transcript-test.js
@@ -4,6 +4,7 @@ import {
   filterTranscript,
   formatTranscript,
   mergeSegments,
+  transcriptToCues,
 } from '../transcript';
 
 describe('filterTranscript', () => {
@@ -116,5 +117,35 @@ describe('mergeSegments', () => {
       const merged = mergeSegments(segments, groupSize);
       assert.deepEqual(merged, expected);
     });
+  });
+});
+
+describe('transcriptToCues', () => {
+  it('returns list of VTTCue objects', () => {
+    const segments = [
+      {
+        start: 1,
+        duration: 3,
+        text: 'One',
+      },
+      {
+        start: 4,
+        duration: 2,
+        text: 'Two',
+      },
+      {
+        start: 7,
+        duration: 5,
+        text: 'Three',
+      },
+    ];
+
+    const cues = transcriptToCues({ segments });
+
+    sinon.assert.match(cues, [
+      sinon.match({ startTime: 1, endTime: 4, text: 'One' }),
+      sinon.match({ startTime: 4, endTime: 6, text: 'Two' }),
+      sinon.match({ startTime: 7, endTime: 12, text: 'Three' }),
+    ]);
   });
 });

--- a/via/static/scripts/video_player/utils/transcript.ts
+++ b/via/static/scripts/video_player/utils/transcript.ts
@@ -29,6 +29,17 @@ export type TranscriptData = {
 };
 
 /**
+ * Generate a {@link VTTCue} list from a transcript.
+ *
+ * This can be used to create cues for use with an HTML media element.
+ */
+export function transcriptToCues(transcript: TranscriptData): VTTCue[] {
+  return transcript.segments.map(
+    seg => new VTTCue(seg.start, seg.start + seg.duration, seg.text)
+  );
+}
+
+/**
  * Escape characters in `str` which have a special meaning in a regex pattern.
  *
  * Taken from https://stackoverflow.com/a/6969486.

--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -16,7 +16,16 @@
       {
         "client_config": {{ client_config | tojson }},
         "client_src": "{{ client_embed_url }}",
+        "player": {{ player | tojson }},
+
+        {% if video_id %}
         "video_id": "{{ video_id }}",
+        {% endif %}
+
+        {% if video_src %}
+        "video_src": {{ video_src | tojson }},
+        {% endif %}
+
         "api": {{ api | tojson }}
       }
     </script>

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -10,6 +10,7 @@ def add_routes(config):  # pragma: no cover
     config.add_route("index", "/", factory=QueryURLResource)
     config.add_route("status", "/_status")
     config.add_route("view_pdf", "/pdf", factory=QueryURLResource)
+    config.add_route("video", "/video")
     config.add_route("youtube", "/video/youtube", factory=QueryURLResource)
     config.add_route("route_by_content", "/route", factory=QueryURLResource)
     config.add_route("debug_headers", "/debug/headers")
@@ -29,6 +30,7 @@ def add_routes(config):  # pragma: no cover
     config.add_route("proxy_d2l_pdf", "/d2l/proxied.pdf", factory=QueryURLResource)
     config.add_route("proxy_python_pdf", "proxied.pdf", factory=QueryURLResource)
 
+    config.add_route("api.video.transcript", "/api/video/transcript")
     config.add_route("api.youtube.transcript", "/api/youtube/transcript/{video_id}")
 
     config.add_route("static_fallback", "/static/{url:.*}")

--- a/via/views/api/transcript.py
+++ b/via/views/api/transcript.py
@@ -1,0 +1,31 @@
+import marshmallow
+from pyramid.view import view_config
+from webargs import fields
+from webargs.pyramidparser import use_kwargs
+
+from via.services import TranscriptService
+
+
+@view_config(
+    route_name="api.video.transcript",
+    request_method="GET",
+    permission="api",
+    renderer="json",
+)
+@use_kwargs(
+    {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
+def get_transcript(request, url: str):
+    """Fetch a video transcript.
+
+    Fetches a transcript in WebVTT or SRT format and returns it as JSON.
+    """
+
+    transcript = request.find_service(TranscriptService).get_transcript(url)
+
+    return {
+        "data": {
+            "type": "transcripts",
+            "attributes": {"segments": transcript},
+        }
+    }

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -10,6 +10,12 @@ from via.security import ViaSecurityPolicy
 from via.services import YouTubeService
 
 
+def _api_headers(request):
+    """Return common headers for API requests."""
+    jwt = ViaSecurityPolicy.encode_jwt(request)
+    return {"Authorization": f"Bearer {jwt}"}
+
+
 @view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
 @use_kwargs(
     {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
@@ -30,19 +36,65 @@ def youtube(request, url, **kwargs):
     _, client_config = Configuration.extract_from_params(kwargs)
 
     return {
+        # Common video player fields
         "client_embed_url": request.registry.settings["client_embed_url"],
         "client_config": client_config,
+        "player": "youtube",
         "title": video_title,
-        "video_id": video_id,
         "video_url": video_url,
         "api": {
             "transcript": {
                 "doc": "Get the transcript of the current video",
                 "url": request.route_url("api.youtube.transcript", video_id=video_id),
                 "method": "GET",
-                "headers": {
-                    "Authorization": f"Bearer {ViaSecurityPolicy.encode_jwt(request)}"
-                },
+                "headers": _api_headers(request),
             }
         },
+        # Fields specific to YouTube video player
+        "video_id": video_id,
+    }
+
+
+@view_config(
+    route_name="video",
+    renderer="via:templates/view_video.html.jinja2",
+)
+@use_kwargs(
+    {
+        "url": fields.Url(required=True),
+        "media_url": fields.Url(required=False),
+        "transcript": fields.Url(required=True),
+        "title": fields.Str(required=False),
+    },
+    location="query",
+    unknown=marshmallow.INCLUDE,
+)
+def video(request, **kwargs):
+    url = kwargs["url"]
+    media_url = kwargs.get("media_url")
+    transcript = kwargs["transcript"]
+
+    video_title = kwargs.get("title") or "Video"
+    media_url = media_url or url
+    _, client_config = Configuration.extract_from_params(kwargs)
+
+    return {
+        # Common video player fields
+        "client_embed_url": request.registry.settings["client_embed_url"],
+        "client_config": client_config,
+        "player": "html-video",
+        "title": video_title,
+        "video_url": url,
+        "api": {
+            "transcript": {
+                "doc": "Get the transcript of the current video",
+                "url": request.route_url(
+                    "api.video.transcript", _query={"url": transcript}
+                ),
+                "method": "GET",
+                "headers": _api_headers(request),
+            },
+        },
+        # Fields specific to HTML video player.
+        "video_src": media_url,
     }


### PR DESCRIPTION
This PR implements general video transcript annotation support based on the HTML `<video>` element and WebVTT or SRT format transcripts. WebVTT is the transcript format supported natively by browsers. SRT is a widely used and very similar text-based format, which is used by Canvas Studio.

There are several components to this:

1. A new HTML video transcript view to handles URLs of the form `/video?url={url}&media_url={media_url}&transcript={transcript}` where `url` is the canonical URL of the video, `media_url` is the URL to load the video from (currently only one is supported, but we could allow multiple to support different formats and resolutions in future) and `transcript` is the URL of a transcript in WebVTT or SRT format. The `media_url` is optional and if not provided, `url` is used as a default.
2. A new API view which takes a URL pointing to a WebVTT or SRT format transcript, fetches it, parses it using the [webvtt](https://pypi.org/project/webvtt-py/) library and then returns it to the frontend.
3. An alternate video player in the frontend which uses HTML `<video>` and `<track>` elements to render the video and subtitles, instead of the YouTube video player. The choice of player is controlled by a `player` configuration set by the backend.

**Testing:**

Check out this branch, then go to http://localhost:9083/video?url=https%3A%2F%2Finteractive-examples.mdn.mozilla.net%2Fmedia%2Fcc0-videos%2Ffriday.mp4&transcript=https%3A%2F%2Finteractive-examples.mdn.mozilla.net%2Fmedia%2Fexamples%2Ffriday.vtt

You should then the video presented with the browser's native video player, and the transcript presented in the same way as for YouTube videos. This particular example is taken from an [MDN demo](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track). Note that it is expected that this particular video is low resolution. 

Part of https://github.com/hypothesis/via/issues/1293