### PR TITLE
Use `via.secret.query` as query parameters for PDF requests

### DIFF
--- a/tests/unit/via/services/pdf_url_test.py
+++ b/tests/unit/via/services/pdf_url_test.py
@@ -117,6 +117,16 @@ class TestPDFURLBuilder:
             "http://example.com/d2l/proxied.pdf?url=http%2F%2Fd2l.com%2Fcontent%2Ftopics%2FFILEID%2Ffile%3Fstream%3D1&via.secret.headers=SECRET-HEADERS"
         )
 
+    def test_python_pdf_with_query(self, svc, pyramid_request, secure_link_service):
+        pyramid_request.params["via.secret.query"] = "SECRET-QUERY"
+
+        svc.get_pdf_url("http//d2l.com/content/topics/FILEID/file?stream=1")
+
+        secure_link_service.sign_url.assert_called_once_with(
+            # pylint:disable=line-too-long
+            "http://example.com/d2l/proxied.pdf?url=http%2F%2Fd2l.com%2Fcontent%2Ftopics%2FFILEID%2Ffile%3Fstream%3D1&via.secret.query=SECRET-QUERY"
+        )
+
     def test_nginx_file_url(self, svc):
         pdf_url = svc.get_pdf_url("http://nginx/document.pdf")
 

--- a/via/services/pdf_url.py
+++ b/via/services/pdf_url.py
@@ -102,6 +102,10 @@ class PDFURLBuilder:
             # Pass headers of the original request back to the PDF endpoint
             query_params["via.secret.headers"] = headers
 
+        if query := self.request.params.get("via.secret.query"):
+            # Pass extra query params to the PDF endpoint
+            query_params["via.secret.query"] = query
+
         url = self.secure_link_service.sign_url(
             self.route_url(route, _query=query_params)
         )


### PR DESCRIPTION
Via library change over: https://github.com/hypothesis/h-vialib/pull/66

Follow the same patter we use for headers, take a encrypted dictionary of query parameters and use them to make the HTTP requests to the upstream server.


The headers parameter was introduced here https://github.com/hypothesis/via/pull/845