### PR TITLE
Support disabling video download controls via `allow_download` query param

### DIFF
--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -112,6 +112,7 @@ class TestVideo:
         response = video(pyramid_request)
 
         assert response == {
+            "allow_download": True,
             "client_embed_url": "http://hypothes.is/embed.js",
             "client_config": Configuration.extract_from_params.return_value[1],
             "player": "html-video",
@@ -159,6 +160,28 @@ class TestVideo:
 
         assert response["video_url"] == video_url
         assert response["video_src"] == "https://cdn.example.com/video.mp4?token=1234"
+
+    @pytest.mark.parametrize(
+        "allow_download,expected",
+        [
+            ("0", False),
+            ("1", True),
+        ],
+    )
+    def test_it_sets_allow_download(self, pyramid_request, allow_download, expected):
+        video_url = "https://example.com/video.mp4"
+        transcript_url = "https://example.com/transcript.vtt"
+        pyramid_request.params.update(
+            {
+                "url": video_url,
+                "transcript": transcript_url,
+                "allow_download": allow_download,
+            }
+        )
+
+        response = video(pyramid_request)
+
+        assert response["allow_download"] is expected
 
 
 @pytest.fixture(autouse=True)

--- a/via/static/scripts/video_player/components/HTMLVideoPlayer.tsx
+++ b/via/static/scripts/video_player/components/HTMLVideoPlayer.tsx
@@ -48,12 +48,20 @@ export type HTMLVideoPlayerProps = VideoPlayerProps & {
    * This is used to generate a caption `<track>` for the video.
    */
   transcript?: TranscriptData;
+
+  /**
+   * Whether to enable download controls for the video.
+   *
+   * Defaults to true.
+   */
+  allowDownload?: boolean;
 };
 
 /**
  * Video player built on the browser's native `<video>` element.
  */
 export default function HTMLVideoPlayer({
+  allowDownload,
   videoURL,
   transcript,
   play = false,
@@ -108,11 +116,22 @@ export default function HTMLVideoPlayer({
     };
   }, [transcript]);
 
+  const controlsList = !allowDownload ? 'nodownload' : '';
+
   return (
     <AspectRatio>
       <video
         ref={videoRef}
         controls
+        // Disable UI controls to download videos if requested. This is only
+        // a "soft" block since the video URL can easily be obtained via
+        // developer tools.
+        controlsList={controlsList}
+        onContextMenu={e => {
+          if (!allowDownload) {
+            e.preventDefault();
+          }
+        }}
         src={videoURL}
         onTimeUpdate={event => {
           const video = event.target as HTMLVideoElement;

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -35,6 +35,11 @@ import YouTubeVideoPlayer from './YouTubeVideoPlayer';
 import { DownIcon, PauseIcon, PlayIcon, SyncIcon, UpIcon } from './icons';
 
 export type VideoPlayerAppProps = {
+  /**
+   * Whether to allow download of the video, if supported by the player.
+   */
+  allowDownload?: boolean;
+
   /** ID of the YouTube video to load. */
   videoId?: string;
 
@@ -99,6 +104,7 @@ function isTranscript(value: any): value is TranscriptData {
  * client so the user can annotate the transcript.
  */
 export default function VideoPlayerApp({
+  allowDownload,
   videoId,
   videoURL,
   clientSrc,
@@ -382,6 +388,7 @@ export default function VideoPlayerApp({
             )}
             {player === 'html-video' && (
               <HTMLVideoPlayer
+                allowDownload={allowDownload}
                 videoURL={videoURL!}
                 transcript={isTranscript(transcript) ? transcript : undefined}
                 play={playing}

--- a/via/static/scripts/video_player/components/test/HTMLVideoPlayer-test.js
+++ b/via/static/scripts/video_player/components/test/HTMLVideoPlayer-test.js
@@ -105,4 +105,26 @@ describe('HTMLVideoPlayer', () => {
 
     assert.equal(track.cues.length, 3);
   });
+
+  [true, false].forEach(allowDownload => {
+    it('should disable download controls if `allowDownload` is false', () => {
+      const wrapper = createPlayer({
+        videoURL: 'test-video.mp4',
+        transcript: { segments: [] },
+        allowDownload,
+      });
+      const video = wrapper.find('video').getDOMNode();
+
+      if ('controlsList' in video) {
+        assert.deepEqual(
+          Array.from(video.controlsList.values()),
+          allowDownload ? [] : ['nodownload']
+        );
+      }
+
+      const contextEvent = new Event('contextmenu', { cancelable: true });
+      video.dispatchEvent(contextEvent);
+      assert.equal(contextEvent.defaultPrevented, !allowDownload);
+    });
+  });
 });

--- a/via/static/scripts/video_player/config.ts
+++ b/via/static/scripts/video_player/config.ts
@@ -23,6 +23,9 @@ export type ConfigObject = {
 
   /** API index. */
   api: APIIndex;
+
+  /** Whether to enable download controls for the video. */
+  allow_download?: boolean;
 };
 
 /**

--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -13,6 +13,7 @@ export function init() {
   }
 
   const {
+    allow_download: allowDownload = true,
     api,
     client_config: clientConfig,
     client_src: clientSrc,
@@ -43,6 +44,7 @@ export function init() {
 
   render(
     <VideoPlayerApp
+      allowDownload={allowDownload}
       videoId={videoId}
       videoURL={videoURL}
       clientConfig={clientConfig}

--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -14,6 +14,7 @@
     <div id="app"></div>
     <script type="application/json" class="js-config">
       {
+        "allow_download": {{ allow_download | tojson }},
         "client_config": {{ client_config | tojson }},
         "client_src": "{{ client_embed_url }}",
         "player": {{ player | tojson }},

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -65,11 +65,13 @@ def youtube(request, url, **kwargs):
         "media_url": fields.Url(required=False),
         "transcript": fields.Url(required=True),
         "title": fields.Str(required=False),
+        "allow_download": fields.Boolean(required=False),
     },
     location="query",
     unknown=marshmallow.INCLUDE,
 )
 def video(request, **kwargs):
+    allow_download = kwargs.get("allow_download", True)
     url = kwargs["url"]
     media_url = kwargs.get("media_url")
     transcript = kwargs["transcript"]
@@ -96,5 +98,6 @@ def video(request, **kwargs):
             },
         },
         # Fields specific to HTML video player.
+        "allow_download": allow_download,
         "video_src": media_url,
     }


### PR DESCRIPTION
Support disabling obvious video download controls via an `allow_download` query param. The default behavior if not specified is to show the browser's default controls, which includes a download option in all major browsers.

Note this is only a "soft" mechanism for preventing downloads, which won't stop anyone who is able to fetch the video URL via developer tools etc. It nevertheless matches the level of protection for content that eg. Canvas Studio's own video player provides.

**Testing:**

1. Load the test video URL from https://github.com/hypothesis/via/pull/1294 in Chrome. The video should have a download button in its "..." menu and context menu.
2. Add `allow_download=0` to the URL and reload. The download option in the "..." menu should disappear and right-clicking on the video should not show the context menu.