### PR TITLE
Fix error in YouTube video viewer

### DIFF
--- a/via/templates/view_video.html.jinja2
+++ b/via/templates/view_video.html.jinja2
@@ -14,7 +14,10 @@
     <div id="app"></div>
     <script type="application/json" class="js-config">
       {
+        {% if allow_download %}
         "allow_download": {{ allow_download | tojson }},
+        {% endif %}
+
         "client_config": {{ client_config | tojson }},
         "client_src": "{{ client_embed_url }}",
         "player": {{ player | tojson }},


### PR DESCRIPTION
The `allow_download` attribute is not set when viewing YouTube videos. Fixes:

```
TypeError: Object of type Undefined is not JSON serializable
```

See https://hypothes-is.slack.com/archives/C2BLQDKHA/p1712670950892439