### PR TITLE
Add a more verbose accessible label for timestamps

### DIFF
--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -125,8 +125,11 @@ function TranscriptSegment({
   }, [highlighter, matches]);
 
   const hadSelectionOnPointerDown = useRef(false);
-  const timestamp = useMemo(
-    () => formatTimestamp(segment.start),
+  const [timestamp, timestampDescription] = useMemo(
+    () => [
+      formatTimestamp(segment.start, 'digits'),
+      formatTimestamp(segment.start, 'description'),
+    ],
     [segment.start]
   );
 
@@ -153,7 +156,7 @@ function TranscriptSegment({
         data-testid="segment"
       >
         <button
-          aria-label={timestamp}
+          aria-label={timestampDescription}
           onClick={stableOnSelect}
           className={classnames(
             // TODO: Use shared Button to get these styles for free
@@ -246,6 +249,7 @@ function TranscriptSegment({
       stableOnSelect,
       text,
       timestamp,
+      timestampDescription,
     ]
   );
 }

--- a/via/static/scripts/video_player/components/test/Transcript-test.js
+++ b/via/static/scripts/video_player/components/test/Transcript-test.js
@@ -70,11 +70,14 @@ describe('Transcript', () => {
       const segment = segments.at(i);
       const start = segment.find('p').prop('data-time-start');
       const end = segment.find('p').prop('data-time-end');
+      const timestamp = segment.find('button[data-timestamp]');
       renderedSegments.push({
         text: segment.text(),
         isCurrent: segment.prop('data-is-current'),
         startTime: start ? parseFloat(start) : undefined,
         endTime: end ? parseFloat(end) : undefined,
+        timestamp: timestamp.prop('data-timestamp'),
+        timestampDescription: timestamp.prop('aria-label'),
       });
     }
 
@@ -84,18 +87,24 @@ describe('Transcript', () => {
         isCurrent: true,
         startTime: 5,
         endTime: 10,
+        timestamp: '0:05',
+        timestampDescription: '5 seconds',
       },
       {
         text: 'To this video about ',
         isCurrent: false,
         startTime: 10,
         endTime: 20,
+        timestamp: '0:10',
+        timestampDescription: '10 seconds',
       },
       {
         text: 'how to use Hypothesis ',
         isCurrent: false,
         startTime: 20,
         endTime: 24,
+        timestamp: '0:20',
+        timestampDescription: '20 seconds',
       },
     ]);
   });

--- a/via/static/scripts/video_player/utils/test/time-test.js
+++ b/via/static/scripts/video_player/utils/test/time-test.js
@@ -1,24 +1,52 @@
 import { formatTimestamp } from '../time';
 
 describe('formatTimestamp', () => {
-  it('formats durations under one hour as m:ss', () => {
-    assert.equal(formatTimestamp(30), '0:30');
-    assert.equal(formatTimestamp(96), '1:36');
-    assert.equal(formatTimestamp(96.35), '1:36');
-    assert.equal(formatTimestamp(620), '10:20');
-    assert.equal(formatTimestamp(59 * 60 + 59), '59:59');
+  [
+    // Times under one hour
+    [30, '0:30'],
+    [96, '1:36'],
+    [96.35, '1:36'],
+    [620, '10:20'],
+    [59 * 60 + 59, '59:59'],
+
+    // Times >= one hour
+    [60 * 60, '1:00:00'],
+    [60 * 60 + 123, '1:02:03'],
+    [10 * 60 * 60, '10:00:00'],
+    [100 * 60 * 60, '100:00:00'],
+  ].forEach(([value, expected]) => {
+    it('formats durations as digits', () => {
+      assert.equal(formatTimestamp(value), expected);
+    });
   });
 
-  it('formats durations over one hour as h:mm:ss', () => {
-    assert.equal(formatTimestamp(60 * 60), '1:00:00');
-    assert.equal(formatTimestamp(60 * 60 + 123), '1:02:03');
-    assert.equal(formatTimestamp(10 * 60 * 60), '10:00:00');
-    assert.equal(formatTimestamp(100 * 60 * 60), '100:00:00');
+  [
+    // Times under one minute.
+    [0, '0 seconds'],
+    [1, '1 second'],
+    [30, '30 seconds'],
+    [59, '59 seconds'],
+    // Times >= one minute. These only have a seconds component if non-zero.
+    [60, '1 minute'],
+    [96, '1 minute, 36 seconds'],
+    [620, '10 minutes, 20 seconds'],
+    [59 * 60 + 59, '59 minutes, 59 seconds'],
+    // Times >= one hour. These only have minutes and seconds components if
+    // non-zero.
+    [60 * 60, '1 hour'],
+    [60 * 60 + 123, '1 hour, 2 minutes, 3 seconds'],
+    [10 * 60 * 60, '10 hours'],
+    [100 * 60 * 60, '100 hours'],
+  ].forEach(([value, expected]) => {
+    it('formats durations as descriptions', () => {
+      assert.equal(formatTimestamp(value, 'description'), expected);
+    });
   });
 
-  it('formats invalid timestamps', () => {
-    assert.equal(formatTimestamp(NaN), '');
-    assert.equal(formatTimestamp(-1), '');
-    assert.equal(formatTimestamp(Infinity), '');
+  [NaN, -1, Infinity].forEach(value => {
+    it('formats invalid timestamps', () => {
+      assert.equal(formatTimestamp(value, 'digits'), '');
+      assert.equal(formatTimestamp(value, 'description'), '');
+    });
   });
 });

--- a/via/static/scripts/video_player/utils/time.ts
+++ b/via/static/scripts/video_player/utils/time.ts
@@ -2,6 +2,18 @@ function pad(value: number): string {
   return value.toString().padStart(2, '0');
 }
 
+function formatTimePiece(
+  value: number,
+  singular: string,
+  plural: string
+): string {
+  if (value === 1) {
+    return `${value} ${singular}`;
+  } else {
+    return `${value} ${plural}`;
+  }
+}
+
 /**
  * Format a video timestamp.
  *
@@ -10,8 +22,16 @@ function pad(value: number): string {
  * youtube.com.
  *
  * @param time - Time in seconds since the start of the video
+ * @param format - Format to use
+ *   "digits" - A short "mm:ss" or "hh:mm:ss" timestamp, suitable for display
+ *   "description" - A verbose "H hours, M minutes, S seconds" format, useful
+ *     for screen readers or contexts where the meaning of the text would not
+ *     be obvious in the "digits" format
  */
-export function formatTimestamp(time: number): string {
+export function formatTimestamp(
+  time: number,
+  format: 'digits' | 'description' = 'digits'
+): string {
   if (!isFinite(time) || time < 0) {
     return '';
   }
@@ -19,9 +39,29 @@ export function formatTimestamp(time: number): string {
   const hours = Math.floor(totalSeconds / (60 * 60));
   const mins = Math.floor(totalSeconds / 60) % 60;
   const secs = totalSeconds % 60;
-  if (hours > 0) {
-    return `${hours}:${pad(mins)}:${pad(secs)}`;
-  } else {
-    return `${mins}:${pad(secs)}`;
+
+  switch (format) {
+    case 'digits':
+      if (hours > 0) {
+        return `${hours}:${pad(mins)}:${pad(secs)}`;
+      } else {
+        return `${mins}:${pad(secs)}`;
+      }
+    case 'description': {
+      const formatted = [];
+      if (hours > 0) {
+        formatted.push(formatTimePiece(hours, 'hour', 'hours'));
+      }
+      if (mins > 0) {
+        formatted.push(formatTimePiece(mins, 'minute', 'minutes'));
+      }
+      if (secs > 0 || (hours === 0 && mins === 0)) {
+        formatted.push(formatTimePiece(secs, 'second', 'seconds'));
+      }
+      return formatted.join(', ');
+    }
+    /* istanbul ignore next */
+    default:
+      return '';
   }
 }


### PR DESCRIPTION
Set the accessible label of timestamps to a more verbose format that requires less contextual awareness to understand. This also matches how timestamps are rendered in YouTube's transcript viewer.

See test cases in `time-test.ts` for examples.

<img width="723" alt="Verbose timestamp" src="https://github.com/hypothesis/via/assets/2458/e47b8c79-929d-4607-93cb-bf8d341ddb81">
