### PR TITLE
Support configuring a proxy for fetching YouTube transcripts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ passenv =
     dev: CLIENT_EMBED_URL
     dev: SIGNED_URLS_REQUIRED
     dev: YOUTUBE_API_KEY
+    dev: YOUTUBE_PROXY
 deps =
     pip-tools
     pip-sync-faster

--- a/via/app.py
+++ b/via/app.py
@@ -30,6 +30,7 @@ PARAMETERS = {
     "youtube_transcripts": {"formatter": asbool},
     "api_jwt_secret": {"required": True},
     "youtube_api_key": {},
+    "youtube_proxy": {},
 }
 
 

--- a/via/services/youtube_transcript.py
+++ b/via/services/youtube_transcript.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from typing import Dict, List
 from xml.etree import ElementTree
 
+import requests
+
 from via.services.http import HTTPService
 
 
@@ -145,4 +147,8 @@ class YouTubeTranscriptService:
 
 
 def factory(_context, request):
-    return YouTubeTranscriptService(http_service=request.find_service(HTTPService))
+    session = requests.Session()
+    if youtube_proxy := request.registry.settings.get("youtube_proxy"):
+        session.proxies["https"] = youtube_proxy
+    http_svc = HTTPService(session=session)
+    return YouTubeTranscriptService(http_service=http_svc)


### PR DESCRIPTION
Add a `YOUTUBE_PROXY` environment variable which specifies a proxy service to use when fetching caption tracks/transcripts from YouTube.

The format of this variable should be an argument that can be used with the `proxies` argument to `requests.post`, eg.
"http://proxy_user:proxy_pass@proxy_host:port".

Part of https://github.com/hypothesis/support/issues/143.
Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1723188976861449

Testing: Set the `YOUTUBE_PROXY` environment variable before starting the service. See Slack thread for details.