### PR TITLE
Add typescript-eslint to eslint dependabot package

### DIFF
--- a/.cookiecutter/includes/.github/dependabot/npm/tail.yml
+++ b/.cookiecutter/includes/.github/dependabot/npm/tail.yml
@@ -5,7 +5,7 @@ groups:
   eslint:
     patterns:
       - 'eslint*'
-      - '@typescript-eslint/*'
+      - 'typescript-eslint'
   rollup:
     patterns:
       - 'rollup'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     eslint:
       patterns:
         - 'eslint*'
-        - '@typescript-eslint/*'
+        - 'typescript-eslint'
     rollup:
       patterns:
         - 'rollup'


### PR DESCRIPTION
Bring back changes from https://github.com/hypothesis/via/pull/1439, that were automatically rolled back by the cookiecutter bot in https://github.com/hypothesis/via/pull/1452

This PR ensures the change is not rolled back again, by adding the change to cookiecutters includes template.