### PR TITLE
Check URL signature in proxy view

### DIFF
--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,7 +1,7 @@
 from pyramid.httpexceptions import HTTPGone
 from pyramid.view import view_config
 
-from via.services import URLDetailsService, ViaClientService
+from via.services import URLDetailsService, ViaClientService, has_secure_url_token
 
 
 @view_config(route_name="static_fallback")
@@ -11,7 +11,11 @@ def static_fallback(_context, _request):
     raise HTTPGone("It appears you have requested out of date content")
 
 
-@view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")
+@view_config(
+    route_name="proxy",
+    renderer="via:templates/proxy.html.jinja2",
+    decorator=(has_secure_url_token,),
+)
 def proxy(context, request):
     url = context.url_from_path()
 


### PR DESCRIPTION
There are two entry points to Via for proxying a URL:

```
/{url}
/route?url={url}
```

The `/route` entry point has a decorator which checks for a signature parameter in the URL if `SIGNED_URLS_REQUIRED` is set, but the first entry point did not use this decorator, so it would serve the content without checking the signature. Add the decorator so that it does check.