### PR TITLE
Enable many more Ruff linter rules

### DIFF
--- a/bin/create_pdf_template.py
+++ b/bin/create_pdf_template.py
@@ -20,7 +20,7 @@ def _insert(contents, where, pattern, new_content):
     if where == "after":
         index += len(pattern)
 
-    print(f"Inserting content {where} {pattern} at index: {index}")
+    print(f"Inserting content {where} {pattern} at index: {index}")  # noqa: T201
     before, after = contents[:index], contents[index:]
 
     return f"{before}{new_content}{after}"
@@ -39,7 +39,7 @@ def _insert_jinja2_blocks(contents):
 
 
 if __name__ == "__main__":
-    with open(SOURCE_FILE, encoding="utf8") as handle:
+    with open(SOURCE_FILE, encoding="utf8") as handle:  # noqa: PTH123
         template = _insert_jinja2_blocks(handle.read())
         template = _insert(
             template,
@@ -51,11 +51,11 @@ if __name__ == "__main__":
 
     for item in ITEMS_TO_REMOVE:
         if item not in template:
-            raise ValueError(f"Expected to find '{item}'")
-        print(f"Removing: {item}")
+            raise ValueError(f"Expected to find '{item}'")  # noqa: EM102, TRY003
+        print(f"Removing: {item}")  # noqa: T201
         template = template.replace(item, f"<!-- {item} -->")
 
-    with open(TARGET_FILE, "w", encoding="utf8") as handle:
+    with open(TARGET_FILE, "w", encoding="utf8") as handle:  # noqa: PTH123
         handle.write(template)
 
-    print(f"Created {TARGET_FILE} from {SOURCE_FILE}")
+    print(f"Created {TARGET_FILE} from {SOURCE_FILE}")  # noqa: T201

--- a/bin/minify_assets.py
+++ b/bin/minify_assets.py
@@ -17,13 +17,13 @@ PARSER.add_argument(
 
 
 def minify_js(file_name):
-    return check_output(
+    return check_output(  # noqa: S603
         ["./node_modules/.bin/terser", "--compress", "--safari10", file_name]
     ).decode("utf-8")
 
 
 def minify_css(file_name):
-    return check_output(
+    return check_output(  # noqa: S603
         ["./node_modules/.bin/sass", "--style=compressed", file_name]
     ).decode("utf-8")
 
@@ -31,7 +31,7 @@ def minify_css(file_name):
 class Minifier:
     """Minifier for CSS, Javascript and HTML."""
 
-    handlers = {"js": minify_js, "css": minify_css}
+    handlers = {"js": minify_js, "css": minify_css}  # noqa: RUF012
 
     @classmethod
     def minify(cls, instructions):
@@ -52,10 +52,10 @@ class Minifier:
 
     @classmethod
     def _ext(cls, filename):
-        if not os.path.isfile(filename):
+        if not os.path.isfile(filename):  # noqa: PTH113
             return None
 
-        base = os.path.basename(filename)
+        base = os.path.basename(filename)  # noqa: PTH119
         if "." not in base:
             return None
 
@@ -64,7 +64,7 @@ class Minifier:
     @classmethod
     def _find_files(cls, instructions):
         for pattern, settings in instructions.items():
-            for filename in glob(pattern, recursive=True):
+            for filename in glob(pattern, recursive=True):  # noqa: PTH207
                 ext = cls._ext(filename)
 
                 if filename.endswith(f".min.{ext}"):
@@ -77,12 +77,12 @@ class Minifier:
                 yield filename, handler, settings
 
     @classmethod
-    def _execute(cls, path, handler, in_place=False):
-        with open(path, encoding="utf8") as handle:
+    def _execute(cls, path, handler, in_place=False):  # noqa: FBT002
+        with open(path, encoding="utf8") as handle:  # noqa: PTH123
             content = handle.read()
 
         if not content:
-            print("NOO", path)
+            print("NOO", path)  # noqa: T201
             return
 
         minified = handler(path)
@@ -93,14 +93,14 @@ class Minifier:
             target = re.sub(f"\\.{ext}$", f".min.{ext}", target)
 
         percent = int(1000 * len(minified) / len(content)) / 10.0
-        print(path)
-        print(f"\t-> {target} {len(content)} -> {len(minified)} ({percent}%)")
+        print(path)  # noqa: T201
+        print(f"\t-> {target} {len(content)} -> {len(minified)} ({percent}%)")  # noqa: T201
 
         if len(minified) > len(content):
-            print("\tRe-using old content (it's no smaller)")
+            print("\tRe-using old content (it's no smaller)")  # noqa: T201
             minified = content
 
-        with open(target, "w", encoding="utf8") as handle:
+        with open(target, "w", encoding="utf8") as handle:  # noqa: PTH123
             handle.write(minified)
 
 
@@ -110,9 +110,9 @@ def main():
     args = PARSER.parse_args()
     config_file = args.config_file
 
-    print(f"Loading config from {config_file}...")
+    print(f"Loading config from {config_file}...")  # noqa: T201
 
-    with open(config_file, encoding="utf8") as handle:
+    with open(config_file, encoding="utf8") as handle:  # noqa: PTH123
         config = json.load(handle)
 
     Minifier.minify(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,49 +17,9 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "UP",    # pyupgrade
-    "YTT",   # flake8-2020 (checks for misuse of sys.version or sys.version_info
     "ANN",   # flake8-annotations (checks for absence of type annotations on functions)
-    "ASYNC", # flake8-async (checks for asyncio-related problems)
-    "S",     # flake8-bandit (checks for security issues)
-    "FBT",   # flake8-boolean-trap (checks for the "boolean trap" anti-pattern)
-    "B",     # flake8-bugbear (checks for bugs and design problems)
-    "A",     # flake8-builtins (checks for builtins being overridden)
     "CPY",   # flake8-copyright (checks for missing copyright notices)
-    "C4",    # flake8-comprehensions (helps write better list/set/dict comprehensions)
-    "DTZ",   # flake8-datetimez (checks for usages of unsafe naive datetime class)
-    "T10",   # flake8-debugger (checks for set traces etc)
-    "EM",    # flake8-errmsg (checks for error message formatting issues)
-    "EXE",   # flake8-executable (checks for incorrect executable permissions and shebangs)
-    "FA",    # flake8-future-annotations (checks for missing from __future__ import annotations)
-    "ISC",   # flake8-implicit-str-concat (checks for style problems with string literal concatenation)
-    "ICN",   # flake8-import-conventions (checks for unconventional imports and aliases)
-    "LOG",   # flake8-logging (checks for issues with using the logging module)
-    "G",     # flake8-logging-format (enforce usage of `extra` in logging calls)
-    "INP",   # flake8-no-pep420 (checks for missing __init__.py files)
-    "PIE",   # flake8-pie (miscellaneous)
-    "T20",   # flake8-print (checks for print and pprint statements)
-    "PT",    # flake8-pytest-style (checks for common pytest style and consistency issues)
-    "RSE",   # flake8-raise (checks for issues with raising exceptions)
-    "RET",   # flake8-return (checks for issues with return values)
-    "SLOT",  # flake8-slots (requires __slots__ in subclasses of immutable types)
-    "SIM",   # flake8-simplify (lots of code simplification checks)
-    "TID",   # flake8-tidy-imports (checks for issues with imports)
-    "TC",    # flake8-type-checking (checks for type checking imports that aren't in TYPE_CHECKING blocks)
-    "ARG",   # flake8-unused-arguments (checks for unused arguments)
-    "PTH",   # flake8-use-pathlib (checks for cases with pathlib could be used but isn't)
-    "TD",    # flake8-todos (enforces good style for "# TODO" comments)
-    "FIX",   # flake8-fixme (checks for FIXMEs, TODOs, HACKs, etc)
-    "ERA",   # eradicate (checks for commented-out code)
-    "PGH",   # pygrep-hooks (miscellaneous)
-    "PL",    # pylint (miscellaneous rules from pylint)
-    "TRY",   # tryceratops (various try/except-related checks)
-    "FLY",   # flynt (checks for old-style %-formatted strings)
-    "PERF",  # perflint (checks for performance anti-patterns)
-    "FURB",  # refurb (various "refurbishing and modernizing" checks)
-    "DOC",   # pydoclint (docstring checks)
-    "RUF",   # Ruff-specific rules
-    "COM",   # flake8-commas (we used a code formatter so we don't need a linter to check this)
+    "COM",   # flake8-commas (we use a code formatter so we don't need a linter to check this)
     "D100","D101","D102","D103","D104","D105","D106","D107", # Missing docstrings.
     "D202", # "No blank lines allowed after function docstring" conflicts with the Ruff code formatter.
     # "Multi-line docstring summary should start at the first line" (D212)
@@ -91,9 +51,16 @@ ignore = [
     "PLR0913", # Too many arguments. Tests often have lots of arguments.
     "PLR0917", # Too many positional arguments. Tests often have lots of arguments.
     "PLR0904", # Too many public methods. Test classes often have lots of test methods.
+    "S101", # Use of `assert` detected.
 ]
 "__init__.py" = [
     "F401", # Ignore unused import errors on __init__ files to avoid having to add either a noqa stament or an __all__ declaration.
+]
+"via/migrations/*" = [
+    "INP001",
+]
+"bin/*" = [
+    "INP001",
 ]
 
 [tool.coverage.run]

--- a/tests/functional/api/views/route_by_content_test.py
+++ b/tests/functional/api/views/route_by_content_test.py
@@ -8,7 +8,7 @@ from tests.conftest import assert_cache_control
 
 
 class TestRouteByContent:
-    DEFAULT_OPTIONS = {
+    DEFAULT_OPTIONS = {  # noqa: RUF012
         "via.client.ignoreOtherConfiguration": "1",
         "via.client.openSidebar": "1",
         "via.external_link_mode": "new-tab",

--- a/tests/functional/static_content_test.py
+++ b/tests/functional/static_content_test.py
@@ -10,8 +10,8 @@ from tests.conftest import assert_cache_control
 
 class TestStaticContent:
     @pytest.mark.parametrize(
-        "url,mime_type",
-        (
+        "url,mime_type",  # noqa: PT006
+        (  # noqa: PT007
             ("/favicon.ico", "image/x-icon"),
             ("/js/pdfjs-init.js", "text/javascript"),
         ),

--- a/tests/functional/via/views/index_test.py
+++ b/tests/functional/via/views/index_test.py
@@ -4,7 +4,7 @@ from tests.functional.matchers import temporary_redirect_to
 
 
 @pytest.mark.parametrize(
-    "url,expected_redirect_location",
+    "url,expected_redirect_location",  # noqa: PT006
     [
         # When you submit the form on the front page it redirects you to the
         # page that will proxy the URL that you entered.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -35,7 +35,7 @@ def pyramid_config(pyramid_settings):
 
 
 @pytest.fixture
-def pyramid_request(db_session, pyramid_config):
+def pyramid_request(db_session, pyramid_config):  # noqa: ARG001
     pyramid_request = testing.DummyRequest()
     apply_request_extensions(pyramid_request)
     pyramid_request.db = db_session

--- a/tests/unit/via/app_test.py
+++ b/tests/unit/via/app_test.py
@@ -27,7 +27,7 @@ class TestConfigureJinja2Assets:
 
 
 def test_settings_raise_value_error_if_environment_variable_is_not_set():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         load_settings({})
 
 

--- a/tests/unit/via/exceptions_test.py
+++ b/tests/unit/via/exceptions_test.py
@@ -7,8 +7,8 @@ from via.exceptions import RequestBasedException
 
 class TestRequestBasedException:
     @pytest.mark.parametrize(
-        "error_params,expected_string",
-        (
+        "error_params,expected_string",  # noqa: PT006
+        (  # noqa: PT007
             (
                 {
                     "status_code": 400,

--- a/tests/unit/via/requests_tools/headers_test.py
+++ b/tests/unit/via/requests_tools/headers_test.py
@@ -32,7 +32,7 @@ class TestCleanHeaders:
 
         assert header_name not in result
 
-    @pytest.mark.parametrize("header_name,default_value", HEADER_DEFAULTS.items())
+    @pytest.mark.parametrize("header_name,default_value", HEADER_DEFAULTS.items())  # noqa: PT006
     def test_we_assign_to_defaults_if_present(self, header_name, default_value):
         result = clean_headers({header_name: "some custom default"})
 
@@ -44,7 +44,7 @@ class TestCleanHeaders:
 
         assert header_name not in result
 
-    @pytest.mark.parametrize("header_name,mapped_name", HEADER_MAP.items())
+    @pytest.mark.parametrize("header_name,mapped_name", HEADER_MAP.items())  # noqa: PT006
     def test_we_map_mangled_header_names(self, header_name, mapped_name):
         result = clean_headers({header_name: "value"})
 

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -122,7 +122,7 @@ class TestGetOriginalURL:
 
     @pytest.mark.parametrize(
         "exc,expected",
-        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT006, PT007
+        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT007
     )
     def test_it_with_bad_paths(self, path_url_resource, exc, expected):
         path_url_resource.url_from_path.side_effect = exc
@@ -137,7 +137,7 @@ class TestGetOriginalURL:
 
     @pytest.mark.parametrize(
         "exc,expected",
-        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT006, PT007
+        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT007
     )
     def test_it_with_bad_queries(self, query_url_resource, exc, expected):
         query_url_resource.url_from_query.side_effect = exc

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -121,7 +121,7 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected",
+        "exc,expected",  # noqa: PT006
         ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT007
     )
     def test_it_with_bad_paths(self, path_url_resource, exc, expected):
@@ -136,7 +136,7 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected",
+        "exc,expected",  # noqa: PT006
         ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT007
     )
     def test_it_with_bad_queries(self, query_url_resource, exc, expected):

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -26,17 +26,17 @@ NORMALISED_URLS = [
     # requests can't.%D0%BA%D0%B0%D0%BB%D0%BE%D1%88%D0%B8
     (
         "http://%D1%81%D0%BA%D0%B0.%D1%80%D1%84/%D0%BA%D0%B0%D0%BB/%3F%D1%81%3D%D1%8F",
-        "http://ска.рф/кал/?с=я",
+        "http://ска.рф/кал/?с=я",  # noqa: RUF001
     ),
     # We can also handle completely URL encoded URLs
     (
         "http%3A%2F%2F%D1%81%D0%BA%D0%B0.%D1%80%D1%84%2F%D0%BA%D0%B0%D0%BB%2F%3F%D1%81%3D%D1%8F",
-        "http://ска.рф/кал/?с=я",
+        "http://ска.рф/кал/?с=я",  # noqa: RUF001
     ),
     # Our missing scheme defaults should still work
     (
         "%D1%81%D0%BA%D0%B0.%D1%80%D1%84/%D0%BA%D0%B0%D0%BB/%3F%D1%81%3D%D1%8F",
-        "https://ска.рф/кал/?с=я",
+        "https://ска.рф/кал/?с=я",  # noqa: RUF001
     ),
     # ... or double encoded
     (
@@ -54,13 +54,13 @@ BAD_URLS = ("https://]", "https://%5D")
 
 
 class TestQueryURLResource:
-    @pytest.mark.parametrize("url,expected", NORMALISED_URLS)
+    @pytest.mark.parametrize("url,expected", NORMALISED_URLS)  # noqa: PT006
     def test_url_from_query_returns_url(self, context, pyramid_request, url, expected):
         pyramid_request.params["url"] = url
 
         assert context.url_from_query() == expected
 
-    @pytest.mark.parametrize("params", ({}, {"urk": "foo"}, {"url": ""}))
+    @pytest.mark.parametrize("params", ({}, {"urk": "foo"}, {"url": ""}))  # noqa: PT007
     def test_url_from_query_raises_HTTPBadRequest_for_bad_urls(
         self, context, pyramid_request, params
     ):
@@ -84,13 +84,13 @@ class TestQueryURLResource:
 
 
 class TestPathURLResource:
-    @pytest.mark.parametrize("url,expected", NORMALISED_URLS)
+    @pytest.mark.parametrize("url,expected", NORMALISED_URLS)  # noqa: PT006
     def test_url_from_path_returns_url(self, context, pyramid_request, url, expected):
         pyramid_request.path_qs = f"/{url}"
 
         assert context.url_from_path() == expected
 
-    @pytest.mark.parametrize("bad_path", ("/", "/  "))
+    @pytest.mark.parametrize("bad_path", ("/", "/  "))  # noqa: PT007
     def test_url_from_path_raises_HTTPBadRequest_for_missing_urls(
         self, context, pyramid_request, bad_path
     ):
@@ -121,7 +121,7 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))
+        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))  # noqa: PT006, PT007
     )
     def test_it_with_bad_paths(self, path_url_resource, exc, expected):
         path_url_resource.url_from_path.side_effect = exc
@@ -135,7 +135,7 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))
+        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))  # noqa: PT006, PT007
     )
     def test_it_with_bad_queries(self, query_url_resource, exc, expected):
         query_url_resource.url_from_query.side_effect = exc

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -121,7 +121,8 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))  # noqa: PT006, PT007
+        "exc,expected",
+        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT006, PT007
     )
     def test_it_with_bad_paths(self, path_url_resource, exc, expected):
         path_url_resource.url_from_path.side_effect = exc
@@ -135,7 +136,8 @@ class TestGetOriginalURL:
         )
 
     @pytest.mark.parametrize(
-        "exc,expected", ((HTTPBadRequest, None), (BadURL("message", url="url"), "url"))  # noqa: PT006, PT007
+        "exc,expected",
+        ((HTTPBadRequest, None), (BadURL("message", url="url"), "url")),  # noqa: PT006, PT007
     )
     def test_it_with_bad_queries(self, query_url_resource, exc, expected):
         query_url_resource.url_from_query.side_effect = exc

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -6,7 +6,7 @@ import pytest
 from h_matchers import Any
 from marshmallow import ValidationError
 from pyramid.httpexceptions import HTTPNotFound
-from pytest import param
+from pytest import param  # noqa: PT013
 from requests import TooManyRedirects
 from requests.exceptions import HTTPError, InvalidJSONError
 
@@ -137,7 +137,7 @@ class TestGoogleDriveAPI:
         # We aren't going to go crazy here as `iter_handle_errors` is better
         # tested elsewhere
         def explode():
-            raise TooManyRedirects("Request went wrong")
+            raise TooManyRedirects("Request went wrong")  # noqa: EM101, TRY003
 
         AuthorizedSession.return_value.request.side_effect = (
             explode() for _ in range(1)
@@ -147,8 +147,8 @@ class TestGoogleDriveAPI:
             list(api.iter_file(sentinel.file_id))
 
     @pytest.mark.parametrize(
-        "kwargs,error_class,status_code",
-        (
+        "kwargs,error_class,status_code",  # noqa: PT006
+        (  # noqa: PT007
             (
                 {
                     "status_code": 404,
@@ -197,7 +197,7 @@ class TestGoogleDriveAPI:
 
     @pytest.mark.parametrize(
         "kwargs",
-        (
+        (  # noqa: PT007
             param({"error_class": InvalidJSONError}, id="unexpected class"),
             param({"status_code": 503}, id="unexpected status code"),
             param({"json_data": None}, id="no json"),
@@ -225,8 +225,8 @@ class TestGoogleDriveAPI:
             list(api.iter_file(sentinel.file_id))
 
     @pytest.mark.parametrize(
-        "url,expected",
-        (
+        "url,expected",  # noqa: PT006
+        (  # noqa: PT007
             (
                 "https://drive.google.com/uc?id=FILE_ID",
                 {"file_id": "FILE_ID", "resource_key": None},

--- a/tests/unit/via/services/http_test.py
+++ b/tests/unit/via/services/http_test.py
@@ -139,7 +139,7 @@ class TestHTTPService:
             {"status_code": status}
         )
 
-    @pytest.mark.parametrize("request_exception,expected_exception", EXCEPTION_MAP)
+    @pytest.mark.parametrize("request_exception,expected_exception", EXCEPTION_MAP)  # noqa: PT006
     def test_request_with_error_translator_defaults(
         self,
         error_translator,
@@ -155,7 +155,7 @@ class TestHTTPService:
         with pytest.raises(expected_exception):
             svc.request("GET", url)
 
-    @pytest.mark.parametrize("generator_exception,expected_exception", EXCEPTION_MAP)
+    @pytest.mark.parametrize("generator_exception,expected_exception", EXCEPTION_MAP)  # noqa: PT006
     def test_stream_with_error_translator_defaults(
         self,
         error_translator,
@@ -188,7 +188,7 @@ class TestHTTPService:
 
         session.request.side_effect = ValueError
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             svc.request("GET", url)
 
     def test_stream_with_regular_exceptions(self, error_translator, session, url):
@@ -196,12 +196,12 @@ class TestHTTPService:
 
         session.request.return_value.iter_content.side_effect = ValueError
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             list(svc.stream("GET", url))
 
     @pytest.mark.parametrize(
-        "input_bytes,output",
-        (
+        "input_bytes,output",  # noqa: PT006
+        (  # noqa: PT007
             ([b"longer_than_chunk_size"], [b"longer_than_chunk_size"]),
             ([b"chunksize"], [b"chunksize"]),
             ([b"chunk", b"size"], [b"chunksize"]),

--- a/tests/unit/via/services/pdf_url_test.py
+++ b/tests/unit/via/services/pdf_url_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import sentinel
 
 import pytest
@@ -41,7 +41,7 @@ class TestNGINXSigner:
                 hour=17,
                 minute=30,
                 second=21,
-                tzinfo=timezone.utc,
+                tzinfo=UTC,
             ),
         )
 

--- a/tests/unit/via/services/pdf_url_test.py
+++ b/tests/unit/via/services/pdf_url_test.py
@@ -48,8 +48,8 @@ class TestNGINXSigner:
 
 class TestPDFURLBuilder:
     @pytest.mark.parametrize(
-        "file_details,url",
-        (
+        "file_details,url",  # noqa: PT006
+        (  # noqa: PT007
             (
                 {"file_id": "FILE_ID"},
                 "http://example.com/google_drive/FILE_ID/proxied.pdf"
@@ -78,8 +78,8 @@ class TestPDFURLBuilder:
         assert pdf_url == secure_link_service.sign_url.return_value
 
     @pytest.mark.parametrize(
-        "url,endpoint_url",
-        (
+        "url,endpoint_url",  # noqa: PT006
+        (  # noqa: PT007
             # One Drive
             (
                 "https://my-sharepoint.sharepoint.com/FILE_ID/?download=1",

--- a/tests/unit/via/services/secure_link_test.py
+++ b/tests/unit/via/services/secure_link_test.py
@@ -66,7 +66,7 @@ class TestSecureLinkService:
 
     @pytest.fixture
     def service(self):
-        return SecureLinkService(secret="not_a_secret", signed_urls_required=True)
+        return SecureLinkService(secret="not_a_secret", signed_urls_required=True)  # noqa: S106
 
     @pytest.fixture
     def with_signed_urls_not_required(self, service):

--- a/tests/unit/via/services/transcript_test.py
+++ b/tests/unit/via/services/transcript_test.py
@@ -46,7 +46,7 @@ EXAMPLE_TRANSCRIPT = [
 
 class TestTranscriptService:
     @pytest.mark.parametrize(
-        "url,content,expected",
+        "url,content,expected",  # noqa: PT006
         [
             ("https://example.com/transcript.vtt", EXAMPLE_WEBVTT, EXAMPLE_TRANSCRIPT),
             ("https://example.com/transcript.srt", EXAMPLE_SRT, EXAMPLE_TRANSCRIPT),

--- a/tests/unit/via/services/url_details_test.py
+++ b/tests/unit/via/services/url_details_test.py
@@ -11,8 +11,8 @@ from via.services.url_details import URLDetailsService, factory
 
 class TestGetURLDetails:
     @pytest.mark.parametrize(
-        "content_type,mime_type,status_code",
-        (
+        "content_type,mime_type,status_code",  # noqa: PT006
+        (  # noqa: PT007
             ("text/html", "text/html", 501),
             ("application/pdf", "application/pdf", 200),
             ("application/pdf; qs=0.001", "application/pdf", 201),

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -8,7 +8,7 @@ from via.services.via_client import ViaClientService, factory
 
 class TestViaClientService:
     @pytest.mark.parametrize(
-        "mime_type,expected_content_type",
+        "mime_type,expected_content_type",  # noqa: PT006
         [
             ("application/x-pdf", ContentType.PDF),
             ("application/pdf", ContentType.PDF),
@@ -20,7 +20,7 @@ class TestViaClientService:
         assert svc.content_type(mime_type) == expected_content_type
 
     @pytest.mark.parametrize(
-        "mime_type,expected_content_type",
+        "mime_type,expected_content_type",  # noqa: PT006
         [
             ("application/pdf", ContentType.PDF),
             ("text/html", ContentType.HTML),

--- a/tests/unit/via/services/youtube_test.py
+++ b/tests/unit/via/services/youtube_test.py
@@ -13,7 +13,7 @@ from via.services.youtube import YouTubeDataAPIError, YouTubeService, factory
 
 class TestYouTubeService:
     @pytest.mark.parametrize(
-        "enabled,api_key,expected",
+        "enabled,api_key,expected",  # noqa: PT006
         [
             (False, None, False),
             (True, None, False),
@@ -34,7 +34,7 @@ class TestYouTubeService:
         )
 
     @pytest.mark.parametrize(
-        "url,expected_video_id",
+        "url,expected_video_id",  # noqa: PT006
         [
             ("not_an_url", None),
             ("https://notyoutube:1000000", None),
@@ -141,15 +141,15 @@ class TestYouTubeService:
         oldest_transcript, newer_transcript = transcript_factory.create_batch(
             2, video_id="video_id"
         )
-        oldest_transcript.created = datetime(2023, 8, 11)
-        newer_transcript.created = datetime(2023, 8, 12)
+        oldest_transcript.created = datetime(2023, 8, 11)  # noqa: DTZ001
+        newer_transcript.created = datetime(2023, 8, 12)  # noqa: DTZ001
 
         returned_transcript = svc.get_transcript("video_id")
 
         assert returned_transcript == oldest_transcript.transcript
 
     @pytest.mark.parametrize(
-        "video_id,expected_url",
+        "video_id,expected_url",  # noqa: PT006
         [
             ("x8TO-nrUtSI", "https://www.youtube.com/watch?v=x8TO-nrUtSI"),
             # YouTube video IDs don't actually contain any characters that

--- a/tests/unit/via/services/youtube_transcript_test.py
+++ b/tests/unit/via/services/youtube_transcript_test.py
@@ -2,7 +2,7 @@ import json
 from io import BytesIO
 from json import JSONDecodeError
 from unittest.mock import sentinel
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # noqa: ICN001
 
 import pytest
 from h_matchers import Any
@@ -19,7 +19,7 @@ from via.services.youtube_transcript import (
 
 class TestTranscriptInfo:
     @pytest.mark.parametrize(
-        "transcript_info,expected_id",
+        "transcript_info,expected_id",  # noqa: PT006
         [
             (
                 TranscriptInfoFactory(),
@@ -106,7 +106,7 @@ class TestYouTubeTranscriptService:
             svc.get_transcript_infos("test_video_id")
 
     @pytest.mark.parametrize(
-        "response_body,exception_class",
+        "response_body,exception_class",  # noqa: PT006
         [
             (b"foo", JSONDecodeError),  # Not valid JSON.
             (b"[]", TypeError),  # Not a dict.
@@ -167,7 +167,7 @@ class TestYouTubeTranscriptService:
             svc.get_transcript_infos("test_video_id")
 
     @pytest.mark.parametrize(
-        "transcript_infos,expected_default_transcript_index",
+        "transcript_infos,expected_default_transcript_index",  # noqa: PT006
         [
             (
                 [

--- a/tests/unit/via/tweens_test.py
+++ b/tests/unit/via/tweens_test.py
@@ -7,7 +7,7 @@ from via.tweens import robots_tween_factory
 
 class TestRobotsTween:
     @pytest.mark.parametrize(
-        "existing_header,expected_header",
+        "existing_header,expected_header",  # noqa: PT006
         [
             (None, "noindex, nofollow"),
             ("all", "all"),

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -194,7 +194,7 @@ class TestGoogleDriveExceptions:
 
     @pytest.mark.parametrize(
         "raw,expected_text",
-        ((123456, "... cannot retrieve ..."), (None, "")),  # noqa: PT006, PT007
+        ((123456, "... cannot retrieve ..."), (None, "")),  # noqa: PT007
     )
     def test_it_with_bad_response(self, pyramid_request, raw, expected_text):
         response = Response()

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -193,7 +193,7 @@ class TestGoogleDriveExceptions:
         assert pyramid_request.response.status_int == 419
 
     @pytest.mark.parametrize(
-        "raw,expected_text",
+        "raw,expected_text",  # noqa: PT006
         ((123456, "... cannot retrieve ..."), (None, "")),  # noqa: PT007
     )
     def test_it_with_bad_response(self, pyramid_request, raw, expected_text):

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -11,7 +11,7 @@ from pyramid.httpexceptions import (
     HTTPUnsupportedMediaType,
 )
 from pyramid.testing import DummyRequest
-from pytest import param
+from pytest import param  # noqa: PT013
 from requests import HTTPError, Request, Response
 
 from via.exceptions import (
@@ -29,8 +29,8 @@ from via.views.exceptions import (
 
 class TestOtherExceptions:
     @pytest.mark.parametrize(
-        "exception_class,status_code",
-        (
+        "exception_class,status_code",  # noqa: PT006
+        (  # noqa: PT007
             param(
                 HTTPUnsupportedMediaType,
                 HTTPUnsupportedMediaType.code,
@@ -58,8 +58,8 @@ class TestOtherExceptions:
         assert pyramid_request.response.status_int == status_code
 
     @pytest.mark.parametrize(
-        "exception_class,mapped_exception",
-        (
+        "exception_class,mapped_exception",  # noqa: PT006
+        (  # noqa: PT007
             param(BadURL, BadURL, id="Mapped directly"),
             param(HTTPUnsupportedMediaType, HTTPClientError, id="Inherited"),
             param(BlockingIOError, UnhandledUpstreamException, id="Unmapped"),
@@ -102,8 +102,8 @@ class TestOtherExceptions:
         assert values["url"]["original"] is None
 
     @pytest.mark.parametrize(
-        "exception_class,should_report",
-        (
+        "exception_class,should_report",  # noqa: PT006
+        (  # noqa: PT007
             (UpstreamServiceError, False),
             (UnhandledUpstreamException, False),
             (BadURL, False),
@@ -125,8 +125,8 @@ class TestOtherExceptions:
             h_pyramid_sentry.report_exception.assert_not_called()
 
     @pytest.mark.parametrize(
-        "exception_class,should_report",
-        (
+        "exception_class,should_report",  # noqa: PT006
+        (  # noqa: PT007
             (HTTPNotFound, False),
             (UnhandledUpstreamException, True),
             (BadURL, True),
@@ -193,7 +193,7 @@ class TestGoogleDriveExceptions:
         assert pyramid_request.response.status_int == 419
 
     @pytest.mark.parametrize(
-        "raw,expected_text", ((123456, "... cannot retrieve ..."), (None, ""))
+        "raw,expected_text", ((123456, "... cannot retrieve ..."), (None, ""))  # noqa: PT006, PT007
     )
     def test_it_with_bad_response(self, pyramid_request, raw, expected_text):
         response = Response()

--- a/tests/unit/via/views/exceptions_test.py
+++ b/tests/unit/via/views/exceptions_test.py
@@ -193,7 +193,8 @@ class TestGoogleDriveExceptions:
         assert pyramid_request.response.status_int == 419
 
     @pytest.mark.parametrize(
-        "raw,expected_text", ((123456, "... cannot retrieve ..."), (None, ""))  # noqa: PT006, PT007
+        "raw,expected_text",
+        ((123456, "... cannot retrieve ..."), (None, "")),  # noqa: PT006, PT007
     )
     def test_it_with_bad_response(self, pyramid_request, raw, expected_text):
         response = Response()

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -12,7 +12,7 @@ from via.views.route_by_content import route_by_content
 @pytest.mark.usefixtures("via_client_service")
 class TestRouteByContent:
     @pytest.mark.parametrize(
-        "content_type,status_code,expected_cache_control_header",
+        "content_type,status_code,expected_cache_control_header",  # noqa: PT006
         [
             (ContentType.PDF, 200, "public, max-age=300, stale-while-revalidate=86400"),
             (

--- a/tests/unit/via/views/status_test.py
+++ b/tests/unit/via/views/status_test.py
@@ -6,7 +6,7 @@ from via.views.status import status
 
 class TestStatusRoute:
     @pytest.mark.parametrize(
-        "include_checkmate,checkmate_fails,expected_status,expected_body",
+        "include_checkmate,checkmate_fails,expected_status,expected_body",  # noqa: PT006
         [
             (False, False, 200, {"status": "okay"}),
             (False, True, 200, {"status": "okay"}),

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -158,7 +158,7 @@ class TestVideo:
         assert response["video_src"] == "https://cdn.example.com/video.mp4?token=1234"
 
     @pytest.mark.parametrize(
-        "allow_download,expected",
+        "allow_download,expected",  # noqa: PT006
         [
             ("0", False),
             ("1", True),

--- a/via/app.py
+++ b/via/app.py
@@ -58,7 +58,7 @@ def load_settings(settings):
         )
 
         if value is None and options.get("required"):
-            raise ValueError(f"Param {param} must be provided.")
+            raise ValueError(f"Param {param} must be provided.")  # noqa: EM102, TRY003
 
     # Configure sentry
     settings["h_pyramid_sentry.filters"] = SENTRY_FILTERS
@@ -90,7 +90,7 @@ def create_app(_=None, **settings):  # pragma: no cover
     # Configure Pyramid so we can generate static URLs
     static_path = str(importlib_resources.files("via") / "static")
     cache_buster = PathCacheBuster(static_path)
-    print(f"Cache buster salt: {cache_buster.salt}")
+    print(f"Cache buster salt: {cache_buster.salt}")  # noqa: T201
 
     config.add_static_view(name="static", path="via:static")
     config.add_cache_buster("via:static", cachebust=cache_buster)

--- a/via/cache_buster.py
+++ b/via/cache_buster.py
@@ -21,7 +21,7 @@ class PathCacheBuster:
     def __init__(self, path):
         self.salt = self._generate_salt(path)
 
-    def __call__(self, request, subpath, kw):
+    def __call__(self, request, subpath, kw):  # noqa: ARG002
         """Prepend the salt to the path.
 
         Implements the ICacheBuster interface.
@@ -48,7 +48,7 @@ class PathCacheBuster:
 
         This ensures we only change salt when at least one file has changed.
         """
-        hasher = hashlib.md5()
+        hasher = hashlib.md5()  # noqa: S324
 
         for base_dir, dirs, file_names in os.walk(path, topdown=True):
             # os.walk will respect our order as long as topdown=True. This
@@ -56,7 +56,7 @@ class PathCacheBuster:
             dirs.sort()
 
             for file_name in sorted(file_names):
-                with open(os.path.join(base_dir, file_name), "rb") as handle:
+                with open(os.path.join(base_dir, file_name), "rb") as handle:  # noqa: PTH118, PTH123
                     hasher.update(handle.read())
 
         return hasher.hexdigest()

--- a/via/migrations/env.py
+++ b/via/migrations/env.py
@@ -16,10 +16,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
+# Add your model's MetaData object here for 'autogenerate' support:
+# from myapp import mymodel  # noqa: ERA001
 target_metadata = Base.metadata
 compare_type = True
 compare_server_default = True

--- a/via/pshell.py
+++ b/via/pshell.py
@@ -1,4 +1,4 @@
-from h_testkit import set_factoryboy_sqlalchemy_session  # type: ignore
+from h_testkit import set_factoryboy_sqlalchemy_session  # type: ignore  # noqa: PGH003
 
 from tests import factories
 from via import models

--- a/via/requests_tools/headers.py
+++ b/via/requests_tools/headers.py
@@ -67,10 +67,10 @@ def clean_headers(headers):
             continue
 
         # Map to standard names for things
-        header_name = HEADER_MAP.get(header_name, header_name)
+        header_name = HEADER_MAP.get(header_name, header_name)  # noqa: PLW2901
 
         # Add in defaults for certain fields
-        value = HEADER_DEFAULTS.get(header_name, value)
+        value = HEADER_DEFAULTS.get(header_name, value)  # noqa: PLW2901
 
         clean[header_name] = value
 

--- a/via/resources.py
+++ b/via/resources.py
@@ -69,7 +69,7 @@ class PathURLResource(_URLResource):
 
         url = self._request.path_qs[1:].strip()
         if not url:
-            raise HTTPBadRequest("Required path part 'url` is missing")
+            raise HTTPBadRequest("Required path part 'url` is missing")  # noqa: EM101, TRY003
 
         return self._normalise_url(url)
 
@@ -87,10 +87,10 @@ class QueryURLResource(_URLResource):
         try:
             url = self._request.params["url"].strip()
         except KeyError as err:
-            raise HTTPBadRequest("Required parameter 'url' missing") from err
+            raise HTTPBadRequest("Required parameter 'url' missing") from err  # noqa: EM101, TRY003
 
         if not url:
-            raise HTTPBadRequest("Required parameter 'url' is blank")
+            raise HTTPBadRequest("Required parameter 'url' is blank")  # noqa: EM101, TRY003
 
         return self._normalise_url(url)
 

--- a/via/security.py
+++ b/via/security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import jwt
 from pyramid.security import Allowed, Denied
@@ -29,7 +29,7 @@ class ViaSecurityPolicy:
     @classmethod
     def encode_jwt(cls, request):
         return jwt.encode(
-            {"exp": datetime.now(tz=timezone.utc) + timedelta(hours=48)},
+            {"exp": datetime.now(tz=UTC) + timedelta(hours=48)},
             cls._get_jwt_secret(request),
             algorithm="HS256",
         )

--- a/via/services/__init__.py
+++ b/via/services/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 from json import JSONDecodeError
-from pathlib import Path
+from pathlib import Path  # noqa: TC003
 
 from via.exceptions import ConfigurationError
 from via.services.checkmate import CheckmateService
@@ -80,10 +80,10 @@ def load_injected_json(settings, file_name):
     resource = data_directory / file_name
 
     if not resource.exists():
-        raise ConfigurationError(f"Expected data file '{resource}' not found")
+        raise ConfigurationError(f"Expected data file '{resource}' not found")  # noqa: EM102, TRY003
 
     with resource.open(encoding="utf-8") as handle:
         try:
             return json.load(handle)
         except JSONDecodeError as exc:
-            raise ConfigurationError(f"Invalid data file format: '{resource}'") from exc
+            raise ConfigurationError(f"Invalid data file format: '{resource}'") from exc  # noqa: EM102, TRY003

--- a/via/services/checkmate.py
+++ b/via/services/checkmate.py
@@ -1,4 +1,3 @@
-
 from checkmatelib import BadURL as CheckmateBadURL
 from checkmatelib import CheckmateClient, CheckmateException
 from checkmatelib.client import BlockResponse

--- a/via/services/checkmate.py
+++ b/via/services/checkmate.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from checkmatelib import BadURL as CheckmateBadURL
 from checkmatelib import CheckmateClient, CheckmateException
@@ -15,7 +14,7 @@ class CheckmateService:
         self._blocked_for = blocked_for
         self._ignore_reasons = ignore_reasons
 
-    def check_url(self, url) -> Optional[BlockResponse]:
+    def check_url(self, url) -> BlockResponse | None:
         """Check whether the given URL is blocked by Checkmate.
 
         Return a BlockResponse object if the URL is blocked,

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -86,7 +86,7 @@ def translate_google_error(error):
 class GoogleDriveAPI:
     """Simplified interface for interacting with Google Drive."""
 
-    SCOPES = [
+    SCOPES = [  # noqa: RUF012
         # If we want metadata
         "https://www.googleapis.com/auth/drive.metadata.readonly",
         # To actually get the file
@@ -118,8 +118,8 @@ class GoogleDriveAPI:
                 credentials_list[0], scopes=self.SCOPES
             )
         except ValueError as exc:
-            raise ConfigurationError(
-                "The Google Drive service account information is invalid"
+            raise ConfigurationError(  # noqa: TRY003
+                "The Google Drive service account information is invalid"  # noqa: EM101
             ) from exc
 
         self._http_service = HTTPService(

--- a/via/services/google_drive.py
+++ b/via/services/google_drive.py
@@ -1,7 +1,7 @@
 import re
+from collections.abc import ByteString, Iterator  # noqa: PYI057
 from json import JSONDecodeError
 from logging import getLogger
-from typing import ByteString, Iterator  # noqa: PYI057
 from urllib.parse import parse_qs, urlparse
 
 from google.auth.transport.requests import AuthorizedSession

--- a/via/services/http.py
+++ b/via/services/http.py
@@ -1,4 +1,4 @@
-import requests
+import requests  # noqa: A005
 from requests import RequestException, exceptions
 
 from via.exceptions import (
@@ -49,7 +49,7 @@ class HTTPService:
     def delete(self, *args, **kwargs):
         return self.request("DELETE", *args, **kwargs)
 
-    def request(self, method, url, timeout=(10, 10), raise_for_status=True, **kwargs):
+    def request(self, method, url, timeout=(10, 10), raise_for_status=True, **kwargs):  # noqa: FBT002
         r"""Send a request with `requests`.
 
         :param method: The HTTP method to use, one of "GET", "PUT", "POST",

--- a/via/services/pdf_url.py
+++ b/via/services/pdf_url.py
@@ -1,9 +1,9 @@
 import hashlib
 import re
 from base64 import b64encode
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable
 
 from h_vialib.secure import quantized_expiry
 from requests import Request

--- a/via/services/pdf_url.py
+++ b/via/services/pdf_url.py
@@ -36,7 +36,7 @@ class _NGINXSigner:
         # This implements the NGINX secure link module's hashing algorithm:
         #
         # http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link_md5
-        hash_ = hashlib.md5()
+        hash_ = hashlib.md5()  # noqa: S324
         hash_.update(hash_expression.encode("utf-8"))
         sec = hash_.digest()
         sec = b64encode(sec)

--- a/via/services/transcript.py
+++ b/via/services/transcript.py
@@ -32,7 +32,7 @@ class TranscriptService:
         content_buf = StringIO(content)
 
         # See https://www.w3.org/TR/webvtt1/#file-structure
-        if content.startswith("WEBVTT"):
+        if content.startswith("WEBVTT"):  # noqa: SIM108
             content_format = "vtt"
         else:
             content_format = "srt"

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -6,7 +6,7 @@ from h_vialib import ContentType, ViaClient
 class ViaClientService:
     """A wrapper service for h_vialib.ViaClient."""
 
-    _mime_types_content_type = {
+    _mime_types_content_type = {  # noqa: RUF012
         "application/x-pdf": ContentType.PDF,
         "application/pdf": ContentType.PDF,
         "video/x-youtube": ContentType.YOUTUBE,

--- a/via/services/youtube.py
+++ b/via/services/youtube.py
@@ -15,7 +15,7 @@ class YouTubeService:
     def __init__(
         self,
         db_session,
-        enabled: bool,
+        enabled: bool,  # noqa: FBT001
         api_key: str,
         http_service: HTTPService,
         youtube_transcript_service: YouTubeTranscriptService,
@@ -87,7 +87,7 @@ class YouTubeService:
                 },
             ).json()["items"][0]["snippet"]["title"]
         except Exception as exc:
-            raise YouTubeDataAPIError("getting the video title failed") from exc
+            raise YouTubeDataAPIError("getting the video title failed") from exc  # noqa: EM101, TRY003
 
         self._db.add(Video(video_id=video_id, title=title))
 

--- a/via/services/youtube_transcript.py
+++ b/via/services/youtube_transcript.py
@@ -1,7 +1,6 @@
 import re
 from base64 import b64encode
 from dataclasses import dataclass
-from typing import Dict, List
 from xml.etree import ElementTree
 
 import requests
@@ -78,7 +77,7 @@ class YouTubeTranscriptService:
     def __init__(self, http_service: HTTPService):
         self._http_service = http_service
 
-    def get_transcript_infos(self, video_id: str) -> List[TranscriptInfo]:
+    def get_transcript_infos(self, video_id: str) -> list[TranscriptInfo]:
         """Return the list of available transcripts for `video_id`."""
         response = self._http_service.post(
             "https://youtubei.googleapis.com/youtubei/v1/player",
@@ -107,7 +106,7 @@ class YouTubeTranscriptService:
         ]
 
     def pick_default_transcript(
-        self, transcript_infos: List[TranscriptInfo]
+        self, transcript_infos: list[TranscriptInfo]
     ) -> TranscriptInfo:
         """Return a choice of default transcript from `transcript_infos`."""
 
@@ -125,7 +124,7 @@ class YouTubeTranscriptService:
 
         return transcript_infos[0]
 
-    def get_transcript(self, transcript_info: TranscriptInfo) -> List[Dict]:
+    def get_transcript(self, transcript_info: TranscriptInfo) -> list[dict]:
         """Download and return the actual transcript text for `transcript_info`."""
         response = self._http_service.get(transcript_info.url)
         xml_elements = ElementTree.fromstring(response.text)

--- a/via/services/youtube_transcript.py
+++ b/via/services/youtube_transcript.py
@@ -1,7 +1,7 @@
 import re
 from base64 import b64encode
 from dataclasses import dataclass
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # noqa: ICN001
 
 import requests
 
@@ -127,11 +127,11 @@ class YouTubeTranscriptService:
     def get_transcript(self, transcript_info: TranscriptInfo) -> list[dict]:
         """Download and return the actual transcript text for `transcript_info`."""
         response = self._http_service.get(transcript_info.url)
-        xml_elements = ElementTree.fromstring(response.text)
+        xml_elements = ElementTree.fromstring(response.text)  # noqa: S314
 
         def strip_html(xml_string):
             return "".join(
-                ElementTree.fromstring(f"<span>{xml_string}</span>").itertext()
+                ElementTree.fromstring(f"<span>{xml_string}</span>").itertext()  # noqa: S314
             ).strip()
 
         return [

--- a/via/views/exceptions.py
+++ b/via/views/exceptions.py
@@ -115,7 +115,7 @@ def _serialise_requests_info(request, response):
     if request:
         data["url"] = request.url
 
-    try:
+    try:  # noqa: SIM105
         data["json"] = response.json()
     except (AttributeError, ValueError):
         pass
@@ -137,7 +137,7 @@ def other_exceptions(exc, request):
 
     # We don't want to log errors from upstream services or things which are
     # the user goofing about making bad queries.
-    if not isinstance(exc, (UpstreamServiceError, BadURL, HTTPClientError)):
+    if not isinstance(exc, (UpstreamServiceError, BadURL, HTTPClientError)):  # noqa: UP038
         h_pyramid_sentry.report_exception(exc)
 
     return _get_error_body(exc, request)

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -8,7 +8,7 @@ from via.services import URLDetailsService, ViaClientService, has_secure_url_tok
 def static_fallback(_context, _request):
     """Make sure we don't try to proxy out of date static content."""
 
-    raise HTTPGone("It appears you have requested out of date content")
+    raise HTTPGone("It appears you have requested out of date content")  # noqa: EM101, TRY003
 
 
 @view_config(

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -24,14 +24,14 @@ def youtube(request, url, **kwargs):
     youtube_service = request.find_service(YouTubeService)
 
     if not youtube_service.enabled:
-        raise HTTPUnauthorized()
+        raise HTTPUnauthorized()  # noqa: RSE102
 
     video_id = youtube_service.get_video_id(url)
     video_url = youtube_service.canonical_video_url(video_id)
     video_title = youtube_service.get_video_title(video_id)
 
     if not video_id:
-        raise BadURL(f"Unsupported video URL: {url}", url=url)
+        raise BadURL(f"Unsupported video URL: {url}", url=url)  # noqa: EM102, TRY003
 
     _, client_config = Configuration.extract_from_params(kwargs)
 

--- a/via/views/webargs.py
+++ b/via/views/webargs.py
@@ -22,7 +22,7 @@ def handle_error(error: MarshmallowValidationError, *_args, **_kwargs):
 
     """
     # Make the HTTP status for Marshmallow validation error responses be 400.
-    error.status_int = 400  # type: ignore
+    error.status_int = 400  # type: ignore  # noqa: PGH003
 
     # Re-raise the original Marshmallow validation error so that our exception
     # views have direct access to it.


### PR DESCRIPTION
... and fix all the resulting linter violations by running `make fix` (asks Ruff to automatically fix violations when it can safely do so) and `make noqa` (asks Ruff to add `# noqa` comments for the remaining violations).