### PR TITLE
Update nginx proxy in dev to current stable version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
   nginx-proxy:
-    image: nginx:1.17.6-alpine
+    image: nginx:1.26.3-alpine
     ports:
       - '9083:9083'
     environment:


### PR DESCRIPTION
This resolves an issue I encountered where loading PDFs in Via failed, with the logs showing:

```
nginx (stderr)       | 2025/03/14 09:57:07 [alert] 1#1: worker process 13 exited on signal 4
```

Signal 4 is SIGILL. I do not know exactly what the problem is, but updating nginx to the current stable version has resolved the issue for me.