### PR TITLE
Add decomission banner

### DIFF
--- a/via/templates/index.html.jinja2
+++ b/via/templates/index.html.jinja2
@@ -67,9 +67,21 @@
     .annotate-btn:hover {
       background-color: #d00032;
     }
+
+    .decommission-banner {
+        padding: 10px 15px;
+        background: #fceedb;
+        position: relative;
+        z-index: 1000;
+        font-weight: bold;
+        border: 1px solid #fbc168;
+    }
   </style>
 </head>
 <body>
+  <div class="decommission-banner">
+      Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+  </div>
   <div class="content">
     <a href="https://hypothes.is">
       <svg xmlns="http://www.w3.org/2000/svg"

--- a/via/templates/index.html.jinja2
+++ b/via/templates/index.html.jinja2
@@ -80,7 +80,7 @@
 </head>
 <body>
   <div class="decommission-banner">
-      Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+      Access to Via is being restricted as of Monday, February 2nd, 2026. You can find information <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
   </div>
   <div class="content">
     <a href="https://hypothes.is">

--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -17,7 +17,7 @@
 
     .proxied-content-iframe {
       position: fixed;
-      top: 0;
+      top: 40px;
       left: 0;
       bottom: 0;
       right: 0;
@@ -98,6 +98,14 @@
         opacity: 0.0;
       }
     }
+
+    .decommission-banner {
+        padding: 10px 15px;
+        background: #fceedb;
+        position: relative;
+        font-weight: bold;
+        border: 1px solid #fbc168;
+    }
   </style>
 
   <script>
@@ -154,10 +162,23 @@
       history.replaceState(null, document.title, viaURL);
     }
   });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const frame = /** @type {HTMLElement} */  document.getElementById('proxied-content-iframe');
+    const banner = document.getElementById('decommission-banner');
+    const observer = new ResizeObserver(() => {
+      const { height } = banner.getBoundingClientRect();
+      frame.style.top = `${height}px`;
+    });
+    observer.observe(frame);
+  });
   </script>
 </head>
   <body>
-    <iframe class="js-content-frame proxied-content-iframe" allow="clipboard-write" src={{ src }}></iframe>
+    <div class="decommission-banner" id="decommission-banner">
+        Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+    </div>
+    <iframe id="proxied-content-iframe" class="js-content-frame proxied-content-iframe" allow="clipboard-write" src={{ src }}></iframe>
 
     {# Loading indicator.
 

--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -176,7 +176,7 @@
 </head>
   <body>
     <div class="decommission-banner" id="decommission-banner">
-        Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+        Access to Via is being restricted as of Monday, February 2nd, 2026. You can find information <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
     </div>
     <iframe id="proxied-content-iframe" class="js-content-frame proxied-content-iframe" allow="clipboard-write" src={{ src }}></iframe>
 


### PR DESCRIPTION
Add a banner in home page and proxied pages indicating the service is going to be decommissioned in January 26.

<img width="1116" height="653" alt="Captura desde 2025-11-27 10-53-31" src="https://github.com/user-attachments/assets/c1945dd6-daad-4bae-b81d-a49d48a49b70" />
<img width="1116" height="653" alt="Captura desde 2025-11-27 10-53-43" src="https://github.com/user-attachments/assets/726afeb7-2736-495a-8a4d-86f6da9543dd" />
<img width="1116" height="653" alt="Captura desde 2025-11-27 10-53-38" src="https://github.com/user-attachments/assets/599f68e7-c800-4f2e-ae65-2bb41f5de1c7" />

### Todo

- [x] Add definitive blog post link
- [x] In proxy page, make the space to top of the iframe be dynamically based on the size of the banner
- [x] Make sure the banner is shown only for public via